### PR TITLE
CDK-266: Use random UUIDs for unique file names.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/FileSystemWriters.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/FileSystemWriters.java
@@ -16,13 +16,13 @@
 
 package org.kitesdk.data.filesystem;
 
+import java.util.UUID;
 import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.DatasetWriter;
 import org.kitesdk.data.DatasetWriterException;
 import org.kitesdk.data.Format;
 import org.kitesdk.data.Formats;
 import org.kitesdk.data.UnknownFormatException;
-import com.google.common.base.Joiner;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
@@ -56,13 +56,8 @@ abstract class FileSystemWriters {
     }
   }
 
-  private static Joiner DASH = Joiner.on('-');
-
   private static String uniqueFilename(Format format) {
-    // FIXME: This file name is not guaranteed to be truly unique.
-    return DASH.join(
-        System.currentTimeMillis(),
-        Thread.currentThread().getId() + "." + format.getExtension());
+    return UUID.randomUUID() + "." + format.getExtension();
   }
 
 }


### PR DESCRIPTION
This fixes the unique filename problem by using a randomly-generated UUID. Chances of collision are extremely low and this doesn't require any hacks to get information unavailable in the JVM, like PID. It does make file names longer, but not too much longer than the existing implementation plus more unique information. We can always truncate the UUID if it is too long.
