### PR TITLE
Fix "LIFE_CYLCLE" typo in Notifications class, add Javadoc

### DIFF
--- a/kite-morphlines/kite-morphlines-core/src/main/java/org/kitesdk/morphline/base/Notifications.java
+++ b/kite-morphlines/kite-morphlines-core/src/main/java/org/kitesdk/morphline/base/Notifications.java
@@ -24,39 +24,83 @@ import org.kitesdk.morphline.api.Record;
  * Tools for notifications on the control plane.
  */
 public final class Notifications {
+  /**
+   * The field in which the notification of the lifecycle is stored.
+   * @since 0.10.1
+   */
+  public static final String LIFE_CYCLE = "lifecycle";
 
-  public static final String LIFE_CYLCLE = "lifecycle";
+  /**
+   * The field in which the notification of the lifecycle is stored.
+   * @deprecated (since 0.10.1) Use {@link #LIFE_CYCLE} instead.
+   */
+  @Deprecated
+  public static final String LIFE_CYLCLE = LIFE_CYCLE;
   
+  /**
+   * Get all lifecycle events from the given record.
+   * @return A {@link List} of {@link LifecycleEvent} enumerations representing all lifecycles stored in the given notification.
+   */
   public static List getLifecycleEvents(Record notification) {
     return notification.get(LIFE_CYLCLE);
   }
   
+  /**
+   * Notify the given command that a transaction has begun.
+   * @param command The {@link Command} to be notified.
+   */
   public static void notifyBeginTransaction(Command command) {
     notify(command, LifecycleEvent.BEGIN_TRANSACTION);
   }
   
+  /**
+   * Notify the given command that a transaction has been committed.
+   * @param command The {@link Command} to be notified.
+   */
   public static void notifyCommitTransaction(Command command) {
     notify(command, LifecycleEvent.COMMIT_TRANSACTION);
   }
   
+  /**
+   * Notify the given command that a transaction has been rolled back.
+   * @param command The {@link Command} to be notified.
+   */
   public static void notifyRollbackTransaction(Command command) {
     notify(command, LifecycleEvent.ROLLBACK_TRANSACTION);
   }
   
+  /**
+   * Notify the given command that a shutdown command has been issued.
+   * @param command The {@link Command} to be notified.
+   */
   public static void notifyShutdown(Command command) {
     notify(command, LifecycleEvent.SHUTDOWN);
   }
   
+  /**
+   * Notify the given command that a session has started.
+   * @param command The {@link Command} to be notified.
+   */
   public static void notifyStartSession(Command command) {
     notify(command, LifecycleEvent.START_SESSION);
   }
   
+  /**
+   * Notify a command that a lifecycle event has occurred.
+   * @param command The {@link Command} to be notified.
+   * @param event The {@link LifecycleEvent} to be passed down to the given command.
+   */
   private static void notify(Command command, LifecycleEvent event) {
     Record notification = new Record();
-    notification.put(LIFE_CYLCLE, event);
+    notification.put(LIFE_CYCLE, event);
     command.notify(notification);
   }
   
+  /**
+   * Determine whether or not the given notification contains the given lifecycle event.
+   * @param notification A {@link Record} that represents a notification.
+   * @param event A {@link LifecycleEvent} enumeration that is to be searched for in the given notification.
+   */
   public static boolean containsLifecycleEvent(Record notification, LifecycleEvent event) {
     return getLifecycleEvents(notification).contains(event);
   }
@@ -64,11 +108,29 @@ public final class Notifications {
   ///////////////////////////////////////////////////////////////////////////////
   // Nested classes:
   ///////////////////////////////////////////////////////////////////////////////
+  /**
+   * Enumerations of the standard lifecycle events.
+   */
   public static enum LifecycleEvent {
+    /**
+     * A transaction has been started.
+     */
     BEGIN_TRANSACTION,
+    /**
+     * A transaction has been commited.
+     */
     COMMIT_TRANSACTION,
+    /**
+     * A transaction has been rolled back.
+     */
     ROLLBACK_TRANSACTION,
+    /**
+     * A shutdown has been initiated.
+     */
     SHUTDOWN,
+    /**
+     * A session has been started.
+     */
     START_SESSION;
   }     
 


### PR DESCRIPTION
Noticed a typo in the static field for Notifications - thought I'd fix it (and add some Javadoc in the process).
