### PR TITLE
CDK-249. Hive partitions are not created in the metastore.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/AccessorImpl.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/AccessorImpl.java
@@ -19,7 +19,6 @@ import org.kitesdk.data.Dataset;
 import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.DatasetException;
 import org.kitesdk.data.View;
-import org.kitesdk.data.FieldPartitioner;
 import org.kitesdk.data.filesystem.impl.Accessor;
 import java.io.IOException;
 import java.util.List;
@@ -61,10 +60,5 @@ final class AccessorImpl extends Accessor {
   public void ensureExists(
       DatasetDescriptor descriptor, Configuration conf) {
     FileSystemDatasetRepository.ensureExists(descriptor, conf);
-  }
-
-  @Override
-  public <T> String dirnameForValue(FieldPartitioner<?, T> field, T value) {
-    return PathConversion.dirnameForValue(field, value);
   }
 }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/FileSystemDataset.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/FileSystemDataset.java
@@ -197,8 +197,8 @@ class FileSystemDataset<E> extends AbstractDataset<E> {
         if (allowCreate) {
           fileSystem.mkdirs(partitionDirectory);
           if (partitionListener != null) {
-            partitionListener.partitionAdded(name, new StorageKey(partitionStrategy,
-                key.getValues()));
+            partitionListener.partitionAdded(name,
+                toRelativeDirectory(key).toString());
           }
         } else {
           return null;
@@ -313,9 +313,18 @@ class FileSystemDataset<E> extends AbstractDataset<E> {
     Path result = dir;
     for (int i = 0; i < key.getLength(); i++) {
       final FieldPartitioner fp = partitionStrategy.getFieldPartitioners().get(i);
-      result = new Path(result, convert.dirnameForValue(fp, key.get(i)));
+      if (result != null) {
+        result = new Path(result, convert.dirnameForValue(fp, key.get(i)));
+      } else {
+        result = new Path(convert.dirnameForValue(fp, key.get(i)));
+      }
     }
     return result;
+  }
+
+  @SuppressWarnings("unchecked")
+  private Path toRelativeDirectory(PartitionKey key) {
+    return toDirectoryName(null, key);
   }
 
   @SuppressWarnings("unchecked")

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/FileSystemView.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/FileSystemView.java
@@ -73,7 +73,7 @@ class FileSystemView<E> extends AbstractRangeView<E> {
     if (dataset.getDescriptor().isPartitioned()) {
       return new PartitionedDatasetWriter<E>(this);
     } else {
-      return FileSystemWriters.newFileWriter(fs, root, dataset.getDescriptor(), null, null, null);
+      return FileSystemWriters.newFileWriter(fs, root, dataset.getDescriptor());
     }
   }
 

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/FileSystemWriters.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/FileSystemWriters.java
@@ -23,9 +23,6 @@ import org.kitesdk.data.DatasetWriterException;
 import org.kitesdk.data.Format;
 import org.kitesdk.data.Formats;
 import org.kitesdk.data.UnknownFormatException;
-import org.kitesdk.data.spi.PartitionListener;
-import org.kitesdk.data.spi.StorageKey;
-import javax.annotation.Nullable;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
@@ -35,15 +32,10 @@ abstract class FileSystemWriters {
 
   @SuppressWarnings("unchecked") // See https://github.com/Parquet/parquet-mr/issues/106
   public static <E> DatasetWriter<E> newFileWriter(
-      FileSystem fs, Path path, DatasetDescriptor descriptor,
-      @Nullable PartitionListener partitionListener, @Nullable String name,
-      @Nullable StorageKey key) {
+      FileSystem fs, Path path, DatasetDescriptor descriptor) {
     // ensure the path exists
     try {
       fs.mkdirs(path);
-      if (partitionListener != null) {
-        partitionListener.partitionAdded(name, key);
-      }
     } catch (IOException ex) {
       throw new DatasetWriterException("Could not create path:" + path, ex);
     }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/impl/Accessor.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/impl/Accessor.java
@@ -16,7 +16,6 @@
 package org.kitesdk.data.filesystem.impl;
 
 import org.kitesdk.data.DatasetDescriptor;
-import org.kitesdk.data.FieldPartitioner;
 import org.kitesdk.data.filesystem.FileSystemDatasetRepository;
 import org.kitesdk.data.Dataset;
 import org.kitesdk.data.View;
@@ -83,6 +82,4 @@ public abstract class Accessor {
   public abstract Iterable<Path> getPathIterator(View view);
 
   public abstract void ensureExists(DatasetDescriptor descriptor, Configuration conf);
-
-  public abstract <T> String dirnameForValue(FieldPartitioner<?, T> field, T value);
 }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/PartitionListener.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/PartitionListener.java
@@ -20,5 +20,5 @@ package org.kitesdk.data.spi;
  * so they can act on it (e.g. by registering the new partition in their metadata store).
  */
 public interface PartitionListener {
-  void partitionAdded(String name, StorageKey key);
+  void partitionAdded(String name, String partition);
 }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/StorageKey.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/StorageKey.java
@@ -70,7 +70,7 @@ public class StorageKey extends Marker implements Comparable<StorageKey> {
         new Object[strategy.getFieldPartitioners().size()]));
   }
 
-  public StorageKey(PartitionStrategy strategy, List<Object> values) {
+  private StorageKey(PartitionStrategy strategy, List<Object> values) {
     try {
       this.fields = FIELD_CACHE.get(strategy);
     } catch (ExecutionException ex) {

--- a/kite-data/kite-data-hcatalog/src/main/java/org/kitesdk/data/hcatalog/HCatalogMetadataProvider.java
+++ b/kite-data/kite-data-hcatalog/src/main/java/org/kitesdk/data/hcatalog/HCatalogMetadataProvider.java
@@ -16,6 +16,8 @@
 
 package org.kitesdk.data.hcatalog;
 
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
 import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.FieldPartitioner;
 import org.kitesdk.data.filesystem.impl.Accessor;
@@ -36,6 +38,8 @@ abstract class HCatalogMetadataProvider extends AbstractMetadataProvider impleme
 
   private static final Logger logger = LoggerFactory
       .getLogger(HCatalogMetadataProvider.class);
+  private static final Splitter PATH_SPLITTER = Splitter.on('/');
+
   protected final Configuration conf;
   final HCatalog hcat;
 
@@ -88,12 +92,8 @@ abstract class HCatalogMetadataProvider extends AbstractMetadataProvider impleme
 
   @Override
   @SuppressWarnings("unchecked")
-  public void partitionAdded(String name, StorageKey key) {
-    List<String> partitionValues = Lists.newArrayList();
-    for (FieldPartitioner fp : key.getPartitionStrategy().getFieldPartitioners()) {
-      partitionValues.add(Accessor.getDefault().dirnameForValue(fp,
-          key.get(fp.getName())));
-    }
-    hcat.addPartition(HiveUtils.DEFAULT_DB, name, partitionValues);
+  public void partitionAdded(String name, String key) {
+    hcat.addPartition(HiveUtils.DEFAULT_DB, name,
+        Lists.newArrayList(PATH_SPLITTER.split(key)));
   }
 }


### PR DESCRIPTION
This is an updated version of https://github.com/cloudera/cdk/pull/28, with the necessary changes for Kite.

Regarding https://github.com/cloudera/cdk/pull/28/files#r8067500, I chose not to expose the Path since the code would need to know how much of the path to interpret as partition directories (also it would be filesystem-specific, which the current patch isn't).
