### PR TITLE
CDK-317: Fix HCatalog URIs.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/URIPattern.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/URIPattern.java
@@ -124,6 +124,10 @@ public class URIPattern {
     } else if (!uri.isOpaque()) {
       addAuthority(uri, result);
 
+      if (pattern.getPath().isEmpty() && !uri.getPath().isEmpty()) {
+        return null;
+      }
+
       Iterator<String> parts = PATH_SPLITTER.split(uri.getPath()).iterator();
       for (String patternPart : PATH_SPLITTER.split(pattern.getPath())) {
         if (!addMatch(patternPart, parts, result)) {

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/TestURIPattern.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/TestURIPattern.java
@@ -88,6 +88,25 @@ public class TestURIPattern {
   }
 
   @Test
+  public void testEmptyPath() throws URISyntaxException {
+    URIPattern pattern = new URIPattern("scheme://authority");
+    String uri = "scheme://real-authority";
+
+    Assert.assertTrue(pattern.matches(uri));
+
+    Map<String, String> actual = pattern.getMatch(uri);
+    expected.put("scheme", "scheme");
+    expected.put("host", "real-authority");
+    Assert.assertEquals(expected, actual);
+
+    // should not match any path element or fragment
+    Assert.assertFalse(pattern.matches(uri + "/"));
+    Assert.assertFalse(pattern.matches("scheme:/"));
+    Assert.assertFalse(pattern.matches(uri + "/abc"));
+    Assert.assertFalse(pattern.matches(uri + "#fragment"));
+  }
+
+  @Test
   public void testStaticPathStart() throws URISyntaxException {
     URIPattern pattern = new URIPattern("mysql:/required/:db/:table");
     String uri = "mysql:/required/myDB/myTable";

--- a/kite-data/kite-data-hcatalog/src/main/java/org/kitesdk/data/hcatalog/HCatalogDatasetRepository.java
+++ b/kite-data/kite-data-hcatalog/src/main/java/org/kitesdk/data/hcatalog/HCatalogDatasetRepository.java
@@ -201,10 +201,6 @@ public class HCatalogDatasetRepository extends AbstractDatasetRepository {
         Preconditions.checkArgument(hiveMetaStoreUri.getScheme().equals("thrift"),
             "Metastore URI scheme must be 'thrift'.");
         uri.append("://").append(hiveMetaStoreUri.getAuthority());
-        // workaround for bug where repo:hive://host:port (no trailing /) is not recognized
-        if (rootDirectory == null) {
-          uri.append("/");
-        }
       }
       if (rootDirectory != null) {
         if (hiveMetaStoreUriProperty == null) {

--- a/kite-data/kite-data-hcatalog/src/main/java/org/kitesdk/data/hcatalog/HCatalogExternalDatasetRepository.java
+++ b/kite-data/kite-data-hcatalog/src/main/java/org/kitesdk/data/hcatalog/HCatalogExternalDatasetRepository.java
@@ -15,6 +15,7 @@
  */
 package org.kitesdk.data.hcatalog;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.net.URI;
 import java.util.Collection;
 import org.apache.hadoop.conf.Configuration;
@@ -26,6 +27,7 @@ import org.kitesdk.data.spi.AbstractDatasetRepository;
 
 class HCatalogExternalDatasetRepository extends AbstractDatasetRepository {
 
+  private final MetadataProvider provider;
   private final FileSystemDatasetRepository fsRepository;
   private final URI repositoryUri;
 
@@ -34,6 +36,7 @@ class HCatalogExternalDatasetRepository extends AbstractDatasetRepository {
    */
   @SuppressWarnings("deprecation")
   HCatalogExternalDatasetRepository(Configuration conf, MetadataProvider provider, URI repositoryUri) {
+    this.provider = provider;
     this.fsRepository = new FileSystemDatasetRepository.Builder().configuration(conf)
         .metadataProvider(provider).build();
     this.repositoryUri = repositoryUri;
@@ -74,4 +77,8 @@ class HCatalogExternalDatasetRepository extends AbstractDatasetRepository {
     return repositoryUri;
   }
 
+  @VisibleForTesting
+  MetadataProvider getMetadataProvider() {
+    return provider;
+  }
 }

--- a/kite-data/kite-data-hcatalog/src/main/java/org/kitesdk/data/hcatalog/impl/Loader.java
+++ b/kite-data/kite-data-hcatalog/src/main/java/org/kitesdk/data/hcatalog/impl/Loader.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import parquet.Preconditions;
 
 /**
  * A Loader implementation to register URIs for FileSystemDatasetRepositories.
@@ -42,6 +43,7 @@ public class Loader implements Loadable {
 
   public static final String HIVE_METASTORE_URI_PROP = "hive.metastore.uris";
   private static final int UNSPECIFIED_PORT = -1;
+  private static final String ALWAYS_REPLACED = "ALWAYS-REPLACED";
 
   /**
    * This class builds configured instances of
@@ -61,13 +63,11 @@ public class Loader implements Loadable {
       logger.debug("External URI options: {}", match);
       final Path root;
       String path = match.get("path");
-      if (path == null || path.isEmpty()) {
-        root = new Path(".");
-      } else if (match.containsKey("absolute")
+      if (match.containsKey("absolute")
           && Boolean.valueOf(match.get("absolute"))) {
-        root = new Path("/", path);
+        root = path == null ? new Path("/") : new Path("/", path);
       } else {
-        root = new Path(path);
+        root = path == null ? new Path(".") : new Path(path);
       }
       final FileSystem fs;
       try {
@@ -100,6 +100,9 @@ public class Loader implements Loadable {
       logger.debug("Managed URI options: {}", match);
       // make a modifiable copy and setup the MetaStore URI
       Configuration conf = new Configuration(envConf);
+      // sanity check the URI
+      Preconditions.checkArgument(!ALWAYS_REPLACED.equals(match.get("host")),
+          "[BUG] URI matched but authority was not replaced.");
       setMetaStoreURI(conf, match);
       return new HCatalogDatasetRepository.Builder()
           .configuration(conf)
@@ -129,8 +132,11 @@ public class Loader implements Loadable {
         new ManagedBuilder(conf);
     Accessor.getDefault().registerDatasetRepository(
         new URIPattern(URI.create("hive")), managedBuilder);
+    // add a URI with no path to allow overriding the metastore authority
+    // the authority section is *always* a URI without it cannot match and one
+    // with a path (so missing authority) also cannot match
     Accessor.getDefault().registerDatasetRepository(
-        new URIPattern(URI.create("hive://" + hiveAuthority + "/")),
+        new URIPattern(URI.create("hive://" + ALWAYS_REPLACED)),
         managedBuilder);
 
     // external data sets


### PR DESCRIPTION
This updates URIPattern to catch the case where a URI pattern does not
have a path but the tested URI does, and fail the URI. This allows the
HCatalog URIs to separately handle URIs without a path (Managed) and
URIs with a path (External) while still allowing the user to override
the authority information, host/port.

Previously, the HCatalog URIs used the root path, /, to signal that
the URI was for a managed HCatalog repository rather than an external
one. This is no longer necessary because the update to URIPattern and
any non-null path now returns an external repo.
