### PR TITLE
CDK-349: Add Schema to Constraints.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetDescriptor.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetDescriptor.java
@@ -589,7 +589,8 @@ public class DatasetDescriptor {
         Preconditions.checkState(field != null,
             "Cannot partition on {} (missing from schema)", fp.getSourceName());
         Preconditions.checkState(
-            SchemaUtil.checkType(field.schema().getType(), fp.getSourceType()),
+            SchemaUtil.isConsistentWithExpectedType(
+                field.schema().getType(), fp.getSourceType()),
             "Field type {} does not match partitioner {}",
             field.schema().getType(), fp);
       }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractDataset.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractDataset.java
@@ -64,31 +64,26 @@ public abstract class AbstractDataset<E> implements Dataset<E>, RefinableView<E>
 
   @Override
   public RefinableView<E> with(String name, Object... values) {
-    Conversions.checkTypeConsistency(getDescriptor(), name, values);
     return asRefinableView().with(name, values);
   }
 
   @Override
   public RefinableView<E> from(String name, Comparable value) {
-    Conversions.checkTypeConsistency(getDescriptor(), name, value);
     return asRefinableView().from(name, value);
   }
 
   @Override
   public RefinableView<E> fromAfter(String name, Comparable value) {
-    Conversions.checkTypeConsistency(getDescriptor(), name, value);
     return asRefinableView().fromAfter(name, value);
   }
 
   @Override
   public RefinableView<E> to(String name, Comparable value) {
-    Conversions.checkTypeConsistency(getDescriptor(), name, value);
     return asRefinableView().to(name, value);
   }
 
   @Override
   public RefinableView<E> toBefore(String name, Comparable value) {
-    Conversions.checkTypeConsistency(getDescriptor(), name, value);
     return asRefinableView().toBefore(name, value);
   }
 

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractRefinableView.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractRefinableView.java
@@ -60,7 +60,7 @@ public abstract class AbstractRefinableView<E> implements RefinableView<E> {
       this.comparator = null;
       this.keys = null;
     }
-    this.constraints = new Constraints();
+    this.constraints = new Constraints(dataset.getDescriptor().getSchema());
     this.entityTest = constraints.toEntityPredicate();
   }
 
@@ -120,31 +120,26 @@ public abstract class AbstractRefinableView<E> implements RefinableView<E> {
 
   @Override
   public AbstractRefinableView<E> with(String name, Object... values) {
-    Conversions.checkTypeConsistency(dataset.getDescriptor(), name, values);
     return filter(constraints.with(name, values));
   }
 
   @Override
   public AbstractRefinableView<E> from(String name, Comparable value) {
-    Conversions.checkTypeConsistency(dataset.getDescriptor(), name, value);
     return filter(constraints.from(name, value));
   }
 
   @Override
   public AbstractRefinableView<E> fromAfter(String name, Comparable value) {
-    Conversions.checkTypeConsistency(dataset.getDescriptor(), name, value);
     return filter(constraints.fromAfter(name, value));
   }
 
   @Override
   public AbstractRefinableView<E> to(String name, Comparable value) {
-    Conversions.checkTypeConsistency(dataset.getDescriptor(), name, value);
     return filter(constraints.to(name, value));
   }
 
   @Override
   public AbstractRefinableView<E> toBefore(String name, Comparable value) {
-    Conversions.checkTypeConsistency(dataset.getDescriptor(), name, value);
     return filter(constraints.toBefore(name, value));
   }
 

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/Conversions.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/Conversions.java
@@ -110,41 +110,4 @@ public class Conversions {
     }
   }
 
-  /**
-   * Checks that the type of each of {@code values} is consistent with the type of
-   * field {@code fieldName} declared in the Avro schema (from {@code descriptor}).
-   */
-  public static void checkTypeConsistency(DatasetDescriptor descriptor, String fieldName,
-      Object... values) {
-
-    Preconditions.checkArgument(hasField(descriptor, fieldName),
-        "No field '%s' in descriptor %s", fieldName, descriptor);
-
-    Schema schema = descriptor.getSchema();
-    Schema.Field field = schema.getField(fieldName);
-
-    for (Object value : values) {
-      // SpecificData#validate checks consistency for generic, reflect,
-      // and specific models.
-      Preconditions.checkArgument(SpecificData.get().validate(field.schema(), value),
-          "Value '%s' of type '%s' inconsistent with field %s.", value, value.getClass(),
-          field);
-    }
-  }
-
-
-  private static boolean hasField(DatasetDescriptor descriptor, String fieldName) {
-    Schema schema = descriptor.getSchema();
-    Schema.Field field = schema.getField(fieldName);
-    if (field != null) {
-      return true;
-    }
-    PartitionStrategy partitionStrategy = descriptor.getPartitionStrategy();
-    for (FieldPartitioner<?, ?> fp : partitionStrategy.getFieldPartitioners()) {
-      if (fp.getName().equals(fieldName)) {
-        return true;
-      }
-    }
-    return false;
-  }
 }

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/filesystem/TestFileSystemPartitionIterator.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/filesystem/TestFileSystemPartitionIterator.java
@@ -19,6 +19,7 @@ package org.kitesdk.data.filesystem;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import javax.annotation.Nullable;
+import org.apache.avro.SchemaBuilder;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.kitesdk.data.spi.Constraints;
@@ -54,6 +55,11 @@ public class TestFileSystemPartitionIterator extends MiniDFSTest {
   public static PartitionStrategy strategy;
   public static MarkerComparator comparator;
   public static List<StorageKey> keys;
+
+  public static final Constraints emptyConstraints = new Constraints(
+      SchemaBuilder.record("Event").fields()
+          .requiredLong("timestamp")
+          .endRecord());
 
   @BeforeClass
   public static void createExpectedKeys() {
@@ -115,7 +121,7 @@ public class TestFileSystemPartitionIterator extends MiniDFSTest {
   @Test
   public void testUnbounded() throws Exception {
     Iterable<StorageKey> partitions = firsts(new FileSystemPartitionIterator(
-        fileSystem, testDirectory, strategy, new Constraints()));
+        fileSystem, testDirectory, strategy, emptyConstraints));
 
     assertIterableEquals(keys, partitions);
   }
@@ -129,7 +135,7 @@ public class TestFileSystemPartitionIterator extends MiniDFSTest {
   public void testFrom() throws Exception {
     Iterable<StorageKey> partitions = firsts(new FileSystemPartitionIterator(
         fileSystem, testDirectory, strategy,
-        new Constraints().from("timestamp", oct_24_2013)));
+        emptyConstraints.from("timestamp", oct_24_2013)));
     assertIterableEquals(keys.subList(16, 24), partitions);
   }
 
@@ -137,7 +143,7 @@ public class TestFileSystemPartitionIterator extends MiniDFSTest {
   public void testAfter() throws Exception {
     Iterable<StorageKey> partitions = firsts(new FileSystemPartitionIterator(
         fileSystem, testDirectory, strategy,
-        new Constraints().fromAfter("timestamp", oct_24_2013_end)));
+        emptyConstraints.fromAfter("timestamp", oct_24_2013_end)));
     assertIterableEquals(keys.subList(17, 24), partitions);
   }
 
@@ -145,7 +151,7 @@ public class TestFileSystemPartitionIterator extends MiniDFSTest {
   public void testTo() throws Exception {
     Iterable<StorageKey> partitions = firsts(new FileSystemPartitionIterator(
         fileSystem, testDirectory, strategy,
-        new Constraints().to("timestamp", oct_25_2012)));
+        emptyConstraints.to("timestamp", oct_25_2012)));
     assertIterableEquals(keys.subList(0, 6), partitions);
   }
 
@@ -153,7 +159,7 @@ public class TestFileSystemPartitionIterator extends MiniDFSTest {
   public void testBefore() throws Exception {
     Iterable <StorageKey> partitions = firsts(new FileSystemPartitionIterator(
         fileSystem, testDirectory, strategy,
-        new Constraints().toBefore("timestamp", oct_25_2012)));
+        emptyConstraints.toBefore("timestamp", oct_25_2012)));
     assertIterableEquals(keys.subList(0, 5), partitions);
   }
 
@@ -161,7 +167,7 @@ public class TestFileSystemPartitionIterator extends MiniDFSTest {
   public void testWith() throws Exception {
     Iterable<StorageKey> partitions = firsts(new FileSystemPartitionIterator(
         fileSystem, testDirectory, strategy,
-        new Constraints().with("timestamp", oct_24_2013)));
+        emptyConstraints.with("timestamp", oct_24_2013)));
     assertIterableEquals(keys.subList(16, 17), partitions);
   }
 
@@ -169,7 +175,7 @@ public class TestFileSystemPartitionIterator extends MiniDFSTest {
   public void testDayRange() throws Exception {
     Iterable<StorageKey> partitions = firsts(new FileSystemPartitionIterator(
         fileSystem, testDirectory, strategy,
-        new Constraints().from("timestamp", oct_24_2013).to("timestamp", oct_24_2013_end)));
+        emptyConstraints.from("timestamp", oct_24_2013).to("timestamp", oct_24_2013_end)));
     assertIterableEquals(keys.subList(16, 17), partitions);
   }
 
@@ -177,7 +183,7 @@ public class TestFileSystemPartitionIterator extends MiniDFSTest {
   public void testLargerRange() throws Exception {
     Iterable<StorageKey> partitions = firsts(new FileSystemPartitionIterator(
         fileSystem, testDirectory, strategy,
-        new Constraints().from("timestamp", oct_25_2012).to("timestamp", oct_24_2013)));
+        emptyConstraints.from("timestamp", oct_25_2012).to("timestamp", oct_24_2013)));
     assertIterableEquals(keys.subList(5, 17), partitions);
   }
 

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/filesystem/TestFileSystemPartitionIteratorTolerance.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/filesystem/TestFileSystemPartitionIteratorTolerance.java
@@ -19,6 +19,7 @@ package org.kitesdk.data.filesystem;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import javax.annotation.Nullable;
+import org.apache.avro.SchemaBuilder;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.kitesdk.data.spi.Constraints;
@@ -53,6 +54,11 @@ public class TestFileSystemPartitionIteratorTolerance extends MiniDFSTest {
   public static PartitionStrategy strategy;
   public static MarkerComparator comparator;
   public static List<StorageKey> keys;
+
+  public static final Constraints emptyConstraints = new Constraints(
+      SchemaBuilder.record("Event").fields()
+          .requiredLong("timestamp")
+          .endRecord());
 
   @BeforeClass
   public static void createExpectedKeys() {
@@ -147,7 +153,7 @@ public class TestFileSystemPartitionIteratorTolerance extends MiniDFSTest {
   @Test
   public void testUnbounded() throws Exception {
     Iterable<StorageKey> partitions = firsts(new FileSystemPartitionIterator(
-        fileSystem, testDirectory, strategy, new Constraints()));
+        fileSystem, testDirectory, strategy, emptyConstraints));
 
     assertIterableEquals(keys, partitions);
   }
@@ -161,7 +167,7 @@ public class TestFileSystemPartitionIteratorTolerance extends MiniDFSTest {
   public void testFrom() throws Exception {
     Iterable<StorageKey> partitions = firsts(new FileSystemPartitionIterator(
         fileSystem, testDirectory, strategy,
-        new Constraints().from("timestamp", oct_24_2013)));
+        emptyConstraints.from("timestamp", oct_24_2013)));
     assertIterableEquals(keys.subList(16, 24), partitions);
   }
 
@@ -169,7 +175,7 @@ public class TestFileSystemPartitionIteratorTolerance extends MiniDFSTest {
   public void testAfter() throws Exception {
     Iterable<StorageKey> partitions = firsts(new FileSystemPartitionIterator(
         fileSystem, testDirectory, strategy,
-        new Constraints().fromAfter("timestamp", oct_24_2013_end)));
+        emptyConstraints.fromAfter("timestamp", oct_24_2013_end)));
     assertIterableEquals(keys.subList(17, 24), partitions);
   }
 
@@ -177,7 +183,7 @@ public class TestFileSystemPartitionIteratorTolerance extends MiniDFSTest {
   public void testTo() throws Exception {
     Iterable<StorageKey> partitions = firsts(new FileSystemPartitionIterator(
         fileSystem, testDirectory, strategy,
-        new Constraints().to("timestamp", oct_25_2012)));
+        emptyConstraints.to("timestamp", oct_25_2012)));
     assertIterableEquals(keys.subList(0, 6), partitions);
   }
 
@@ -185,7 +191,7 @@ public class TestFileSystemPartitionIteratorTolerance extends MiniDFSTest {
   public void testBefore() throws Exception {
     Iterable <StorageKey> partitions = firsts(new FileSystemPartitionIterator(
         fileSystem, testDirectory, strategy,
-        new Constraints().toBefore("timestamp", oct_25_2012)));
+        emptyConstraints.toBefore("timestamp", oct_25_2012)));
     assertIterableEquals(keys.subList(0, 5), partitions);
   }
 
@@ -193,7 +199,7 @@ public class TestFileSystemPartitionIteratorTolerance extends MiniDFSTest {
   public void testWith() throws Exception {
     Iterable<StorageKey> partitions = firsts(new FileSystemPartitionIterator(
         fileSystem, testDirectory, strategy,
-        new Constraints().with("timestamp", oct_24_2013)));
+        emptyConstraints.with("timestamp", oct_24_2013)));
     assertIterableEquals(keys.subList(16, 17), partitions);
   }
 
@@ -201,7 +207,7 @@ public class TestFileSystemPartitionIteratorTolerance extends MiniDFSTest {
   public void testDayRange() throws Exception {
     Iterable<StorageKey> partitions = firsts(new FileSystemPartitionIterator(
         fileSystem, testDirectory, strategy,
-        new Constraints().from("timestamp", oct_24_2013).to("timestamp", oct_24_2013_end)));
+        emptyConstraints.from("timestamp", oct_24_2013).to("timestamp", oct_24_2013_end)));
     assertIterableEquals(keys.subList(16, 17), partitions);
   }
 
@@ -209,7 +215,7 @@ public class TestFileSystemPartitionIteratorTolerance extends MiniDFSTest {
   public void testLargerRange() throws Exception {
     Iterable <StorageKey> partitions = firsts(new FileSystemPartitionIterator(
         fileSystem, testDirectory, strategy,
-        new Constraints().from("timestamp", oct_25_2012).to("timestamp", oct_24_2013)));
+        emptyConstraints.from("timestamp", oct_25_2012).to("timestamp", oct_24_2013)));
     assertIterableEquals(keys.subList(5, 17), partitions);
   }
 

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/filesystem/TestMultiFileDatasetReader.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/filesystem/TestMultiFileDatasetReader.java
@@ -38,9 +38,9 @@ import org.kitesdk.data.spi.Constraints;
 
 public class TestMultiFileDatasetReader extends TestDatasetReaders {
 
-  public static final Constraints CONSTRAINTS = new Constraints();
   public static final Path TEST_FILE = new Path(
       Resources.getResource("data/strings-100.avro").getFile());
+  public static final Constraints CONSTRAINTS = new Constraints(STRING_SCHEMA);
   public static final RecordValidator<Record> VALIDATOR =
       new RecordValidator<Record>() {
       @Override


### PR DESCRIPTION
This adds a Schema to Constraints so that Constraints can serialize
values in its Predicate set. The type and field checks now belong to
Constraints because this makes it more self-contained.
