### PR TITLE
CDK-354: Add View#deleteAll and FS impl.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/View.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/View.java
@@ -77,4 +77,23 @@ public interface View<E> {
    */
   boolean includes(E entity);
 
+  /**
+   * Deletes the entities included in this {@link View} or throws an
+   * {@link UnsupportedOperationException}.
+   *
+   * Implementations are allowed to throw {@code UnsupportedOperationException}
+   * if the {@code View} could require additional work to delete. For example,
+   * if some but not all of the data in an underlying data file must be removed,
+   * then the implementation is allowed to reject the deletion rather than
+   * copy the remaining records to a new file. Implementations must  document
+   * what deletes are supported and under what conditions deletes will be
+   * rejected.
+   *
+   * @return true if any data was deleted, false if the View was already empty
+   * @throws UnsupportedOperationException
+   *          If the requested delete cannot be completed by the implementation
+   * @throws DatasetIOException
+   *          If the requested delete failed because of an IOException
+   */
+  public boolean deleteAll();
 }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/FileSystemDataset.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/FileSystemDataset.java
@@ -125,7 +125,8 @@ class FileSystemDataset<E> extends AbstractDataset<E> implements Mergeable<FileS
   }
 
   public boolean deleteAll() {
-    return unbounded.deleteAll();
+    // no constraints, so delete is always aligned to partition boundaries
+    return unbounded.deleteAllUnsafe();
   }
 
   PathIterator pathIterator() {

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractDataset.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractDataset.java
@@ -96,4 +96,10 @@ public abstract class AbstractDataset<E> implements Dataset<E>, RefineableView<E
     throw new UnsupportedOperationException("No delegate input format defined.");
   }
 
+  @Override
+  public boolean deleteAll() {
+    throw new UnsupportedOperationException(
+        "This Dataset does not support bulk deletion");
+  }
+
 }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractRefineableView.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractRefineableView.java
@@ -80,25 +80,10 @@ public abstract class AbstractRefineableView<E> implements RefineableView<E> {
     return dataset;
   }
 
-  /**
-   * Deletes the data in this {@link View} or throws an {@code Exception}.
-   *
-   * Implementations may choose to throw {@link UnsupportedOperationException}
-   * for deletes that cannot be easily satisfied by the implementation. For
-   * example, in a partitioned {@link Dataset}, the implementation may reject
-   * deletes that do not align with partition boundaries. Implementations must
-   * document what deletes are supported and under what conditions deletes will
-   * be rejected.
-   *
-   * @return true if any data was deleted; false if the view was already empty
-   * @throws UnsupportedOperationException
-   *          If the requested delete cannot be completed by the implementation
-   * @throws org.kitesdk.data.DatasetIOException
-   *          If the requested delete failed because of an IOException
-   */
+  @Override
   public boolean deleteAll() {
     throw new UnsupportedOperationException(
-        "This Dataset does not support deletion");
+        "This Dataset does not support bulk deletion");
   }
 
   /**

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/filesystem/TestFileSystemView.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/filesystem/TestFileSystemView.java
@@ -18,9 +18,11 @@ package org.kitesdk.data.filesystem;
 
 import java.util.Iterator;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.junit.Ignore;
 import org.kitesdk.data.DatasetRepository;
 import org.kitesdk.data.DatasetWriter;
+import org.kitesdk.data.TestHelpers;
 import org.kitesdk.data.View;
 import org.kitesdk.data.spi.TestRefinableViews;
 import org.kitesdk.data.event.StandardEvent;
@@ -122,49 +124,151 @@ public class TestFileSystemView extends TestRefinableViews {
     final Path nov11 = new Path("target/data/test/year=2013/month=11/day=11");
     assertDirectoriesExist(fs, root, y2013, sep, sep12, oct, oct12, nov, nov11);
 
-    long julStart = new DateTime(2013, 6, 1, 0, 0).getMillis();
-    long sepStart = new DateTime(2013, 9, 1, 0, 0).getMillis();
-    long nov11Start = new DateTime(2013, 11, 11, 0, 0).getMillis();
-    long nov12Start = new DateTime(2013, 11, 12, 0, 0).getMillis();
-    long decStart = new DateTime(2013, 12, 1, 0, 0).getMillis();
-    long sepInstant = sepEvent.getTimestamp();
-    long octInstant = octEvent.getTimestamp();
+    long julStart = new DateTime(2013, 6, 1, 0, 0, DateTimeZone.UTC).getMillis();
+    long sepStart = new DateTime(2013, 9, 1, 0, 0, DateTimeZone.UTC).getMillis();
+    final long nov11Start = new DateTime(2013, 11, 11, 0, 0, DateTimeZone.UTC).getMillis();
+    final long nov12Start = new DateTime(2013, 11, 12, 0, 0, DateTimeZone.UTC).getMillis();
+    long decStart = new DateTime(2013, 12, 1, 0, 0, DateTimeZone.UTC).getMillis();
+    final long sepInstant = sepEvent.getTimestamp();
+    final long sep12End = new DateTime(2013, 9, 13, 0, 0, DateTimeZone.UTC).getMillis() - 1;
+    final long octInstant = octEvent.getTimestamp();
+    // aligned with second boundaries, but not partition boundaries
+    final long oct12Start = new DateTime(2013, 10, 12, 0, 0, 0, DateTimeZone.UTC).getMillis();
+    final long oct12BadStart = new DateTime(2013, 10, 12, 0, 1, 0, DateTimeZone.UTC).getMillis();
+    final long oct12End = new DateTime(2013, 10, 12, 23, 59, 59, 999, DateTimeZone.UTC).getMillis();
+    final long oct12BadEnd = new DateTime(2013, 10, 12, 23, 59, 57, 999, DateTimeZone.UTC).getMillis();
 
     Assert.assertFalse("Delete should return false to indicate no changes",
-        deleteAll(unbounded.from("timestamp", julStart).toBefore("timestamp", sepStart)));
+        unbounded.from("timestamp", decStart).deleteAll());
     Assert.assertFalse("Delete should return false to indicate no changes",
-        deleteAll(unbounded.from("timestamp", decStart)));
+        unbounded.from("timestamp", julStart).toBefore("timestamp", sepStart).deleteAll());
 
-    // delete everything up to September
+    // cannot delete mid-partition
+    TestHelpers.assertThrows(
+        "Delete should fail if not aligned with partition boundary",
+        UnsupportedOperationException.class, new Runnable() {
+      @Override
+      public void run() {
+        unbounded.to("timestamp", sepInstant).deleteAll();
+      }
+    });
+    TestHelpers.assertThrows(
+        "Delete should fail if not aligned with partition boundary",
+        UnsupportedOperationException.class, new Runnable() {
+      @Override
+      public void run() {
+        unbounded.toBefore("timestamp", sep12End).deleteAll();
+      }
+    });
+
+    // delete everything up through September
     assertTrue("Delete should return true to indicate FS changed",
-        deleteAll(unbounded.to("timestamp", sepInstant)));
+        unbounded.to("timestamp", sep12End).deleteAll());
     assertDirectoriesDoNotExist(fs, sep12, sep);
     assertDirectoriesExist(fs, root, y2013, oct, oct12, nov, nov11);
     Assert.assertFalse("Delete should return false to indicate no changes",
-        deleteAll(unbounded.to("timestamp", sepInstant)));
+        unbounded.to("timestamp", sep12End).deleteAll());
+    assertDirectoriesDoNotExist(fs, sep12, sep);
+    assertDirectoriesExist(fs, root, y2013, oct, oct12, nov, nov11);
+
+    // cannot delete mid-partition
+    TestHelpers.assertThrows(
+        "Delete should fail if not aligned with partition boundary",
+        UnsupportedOperationException.class, new Runnable() {
+      @Override
+      public void run() {
+        unbounded.from("timestamp", nov11Start).to("timestamp", nov12Start).deleteAll();
+      }
+    });
+    TestHelpers.assertThrows(
+        "Delete should fail if not aligned with partition boundary",
+        UnsupportedOperationException.class, new Runnable() {
+      @Override
+      public void run() {
+        unbounded.fromAfter("timestamp", nov11Start).toBefore("timestamp", nov12Start).deleteAll();
+      }
+    });
 
     // delete November 11 and later
     assertTrue("Delete should return true to indicate FS changed",
-        deleteAll(unbounded.from("timestamp", nov11Start).to("timestamp", nov12Start)));
+        unbounded.from("timestamp", nov11Start).toBefore("timestamp", nov12Start).deleteAll());
     assertDirectoriesDoNotExist(fs, sep12, sep, nov11, nov);
     assertDirectoriesExist(fs, root, y2013, oct, oct12);
     Assert.assertFalse("Delete should return false to indicate no changes",
-        deleteAll(unbounded.from("timestamp", nov11Start).to("timestamp", nov12Start)));
+        unbounded.from("timestamp", nov11Start).toBefore("timestamp", nov12Start).deleteAll());
+    assertDirectoriesDoNotExist(fs, sep12, sep, nov11, nov);
+    assertDirectoriesExist(fs, root, y2013, oct, oct12);
+
+    // cannot delete mid-partition
+    TestHelpers.assertThrows(
+        "Delete should fail if not aligned with partition boundary",
+        UnsupportedOperationException.class, new Runnable() {
+      @Override
+      public void run() {
+        unbounded.from("timestamp", octInstant).to("timestamp", octInstant).deleteAll();
+      }
+    });
+    TestHelpers.assertThrows(
+        "Delete should fail if not aligned with partition boundary",
+        UnsupportedOperationException.class, new Runnable() {
+      @Override
+      public void run() {
+        unbounded.from("timestamp", oct12BadStart).to("timestamp", oct12End).deleteAll();
+      }
+    });
+    TestHelpers.assertThrows(
+        "Delete should fail if not aligned with partition boundary",
+        UnsupportedOperationException.class, new Runnable() {
+      @Override
+      public void run() {
+        unbounded.from("timestamp", oct12Start).to("timestamp", oct12BadEnd).deleteAll();
+      }
+    });
 
     // delete October and the 2013 directory
     assertTrue("Delete should return true to indicate FS changed",
-        deleteAll(unbounded.from("timestamp", octInstant).to("timestamp", octInstant)));
+        unbounded.from("timestamp", oct12Start).to("timestamp", oct12End).deleteAll());
     assertDirectoriesDoNotExist(fs, y2013, sep12, sep, oct12, oct, nov11, nov);
     assertDirectoriesExist(fs, root);
     Assert.assertFalse("Delete should return false to indicate no changes",
-        deleteAll(unbounded.from("timestamp", octInstant).to("timestamp", octInstant)));
+        unbounded.from("timestamp", oct12Start).to("timestamp", oct12End).deleteAll());
+    assertDirectoriesDoNotExist(fs, y2013, sep12, sep, oct12, oct, nov11, nov);
+    assertDirectoriesExist(fs, root);
 
     Assert.assertFalse("Delete should return false to indicate no changes",
-        ((FileSystemDataset) unbounded).deleteAll());
+        unbounded.deleteAll());
+    assertDirectoriesDoNotExist(fs, y2013, sep12, sep, oct12, oct, nov11, nov);
+    assertDirectoriesExist(fs, root);
   }
 
-  private boolean deleteAll(View v) {
-    return ((FileSystemView) v).deleteAll(); // until deleteAll is exposed on View
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testUnboundedDelete() throws Exception {
+    // NOTE: this is an un-restricted write so all should succeed
+    final DatasetWriter<StandardEvent> writer = unbounded.newWriter();
+    try {
+      writer.open();
+      writer.write(sepEvent);
+      writer.write(octEvent);
+      writer.write(novEvent);
+    } finally {
+      writer.close();
+    }
+
+    final Path root = new Path("target/data/test");
+    final Path y2013 = new Path("target/data/test/year=2013");
+    final Path sep = new Path("target/data/test/year=2013/month=09");
+    final Path sep12 = new Path("target/data/test/year=2013/month=09/day=12");
+    final Path oct = new Path("target/data/test/year=2013/month=10");
+    final Path oct12 = new Path("target/data/test/year=2013/month=10/day=12");
+    final Path nov = new Path("target/data/test/year=2013/month=11");
+    final Path nov11 = new Path("target/data/test/year=2013/month=11/day=11");
+    assertDirectoriesExist(fs, root, y2013, sep, sep12, oct, oct12, nov, nov11);
+
+    Assert.assertTrue("Delete should return false to indicate no changes",
+        unbounded.deleteAll());
+    assertDirectoriesDoNotExist(fs, y2013, sep12, sep, oct12, oct, nov11, nov);
+    assertDirectoriesExist(fs, root);
   }
 
   @SuppressWarnings("deprecation")


### PR DESCRIPTION
This adds View#deleteAll to the public API. AbstractRefinableView
defaults the behavior to reject all deletes. The FS implementation
checks that a view's constraints are aligned with boundaries in the
partition strategy. This guarantees that there are no entities in the
view's covering partitions that do not match the view's constraints.
