### PR TITLE
CDK-348. RefineableView should be spelled without the "e" in the middle ...

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/Dataset.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/Dataset.java
@@ -46,7 +46,7 @@ import javax.annotation.concurrent.Immutable;
  * @see Schema
  */
 @Immutable
-public interface Dataset<E> extends RefineableView<E> {
+public interface Dataset<E> extends RefinableView<E> {
 
   /**
    * Get the name of a {@code Dataset}. No guarantees about the format of this

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/RefinableView.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/RefinableView.java
@@ -18,16 +18,16 @@ package org.kitesdk.data;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * A {@code RefineableView} specifies a subset of a {@link Dataset} by one or more
+ * A {@code RefinableView} specifies a subset of a {@link Dataset} by one or more
  * logical constraints.
  *
  * @param <E>
  *      The type of entities stored in the {@code Dataset} underlying this
- *      {@code RefineableView}.
+ *      {@code RefinableView}.
  * @since 0.11.0
  */
 @Immutable
-public interface RefineableView<E> extends View<E> {
+public interface RefinableView<E> extends View<E> {
 
   /**
    * Creates a sub-{@code View}, restricted to entities whose <code>name</code> field is
@@ -38,7 +38,7 @@ public interface RefineableView<E> extends View<E> {
    * @param name the field name of the entity
    * @return the restricted view
    */
-  RefineableView<E> with(String name, Object... values);
+  RefinableView<E> with(String name, Object... values);
 
   /**
    * Creates a sub-{@code View}, restricted to entities whose <code>name</code> field
@@ -47,7 +47,7 @@ public interface RefineableView<E> extends View<E> {
    * @param name the field name of the entity
    * @return the restricted view
    */
-  RefineableView<E> from(String name, Comparable value);
+  RefinableView<E> from(String name, Comparable value);
 
   /**
    * Creates a sub-{@code View}, restricted to entities whose <code>name</code> field
@@ -56,7 +56,7 @@ public interface RefineableView<E> extends View<E> {
    * @param name the field name of the entity
    * @return the restricted view
    */
-  RefineableView<E> fromAfter(String name, Comparable value);
+  RefinableView<E> fromAfter(String name, Comparable value);
 
   /**
    * Creates a sub-{@code View}, restricted to entities whose <code>name</code> field
@@ -65,7 +65,7 @@ public interface RefineableView<E> extends View<E> {
    * @param name the field name of the entity
    * @return the restricted view
    */
-  RefineableView<E> to(String name, Comparable value);
+  RefinableView<E> to(String name, Comparable value);
 
   /**
    * Creates a sub-{@code View}, restricted to entities whose <code>name</code> field
@@ -74,6 +74,6 @@ public interface RefineableView<E> extends View<E> {
    * @param name the field name of the entity
    * @return the restricted view
    */
-  RefineableView<E> toBefore(String name, Comparable value);
+  RefinableView<E> toBefore(String name, Comparable value);
 
 }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/FileSystemDataset.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/FileSystemDataset.java
@@ -25,7 +25,7 @@ import org.kitesdk.data.DatasetIOException;
 import org.kitesdk.data.DatasetRepositoryException;
 import org.kitesdk.data.PartitionKey;
 import org.kitesdk.data.PartitionStrategy;
-import org.kitesdk.data.RefineableView;
+import org.kitesdk.data.RefinableView;
 import org.kitesdk.data.impl.Accessor;
 import org.kitesdk.data.spi.AbstractDataset;
 import org.kitesdk.data.spi.FieldPartitioner;
@@ -133,7 +133,7 @@ class FileSystemDataset<E> extends AbstractDataset<E> implements Mergeable<FileS
   }
 
   @Override
-  protected RefineableView<E> asRefineableView() {
+  protected RefinableView<E> asRefinableView() {
     return unbounded;
   }
 

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/FileSystemView.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/FileSystemView.java
@@ -22,7 +22,7 @@ import org.kitesdk.data.DatasetException;
 import org.kitesdk.data.DatasetIOException;
 import org.kitesdk.data.DatasetReader;
 import org.kitesdk.data.DatasetWriter;
-import org.kitesdk.data.spi.AbstractRefineableView;
+import org.kitesdk.data.spi.AbstractRefinableView;
 import org.kitesdk.data.spi.Constraints;
 import org.kitesdk.data.spi.Pair;
 import org.kitesdk.data.spi.StorageKey;
@@ -35,12 +35,12 @@ import java.io.IOException;
 
 /**
  * FileSystem implementation of a {@link org.kitesdk.data.spi.Constraints}-based
- * {@link org.kitesdk.data.RefineableView}.
+ * {@link org.kitesdk.data.RefinableView}.
  *
  * @param <E> The type of records read and written by this view.
  */
 @Immutable
-class FileSystemView<E> extends AbstractRefineableView<E> {
+class FileSystemView<E> extends AbstractRefinableView<E> {
 
   private final FileSystem fs;
   private final Path root;

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractDataset.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractDataset.java
@@ -20,7 +20,7 @@ import org.apache.hadoop.mapreduce.InputFormat;
 import org.kitesdk.data.Dataset;
 import org.kitesdk.data.DatasetReader;
 import org.kitesdk.data.DatasetWriter;
-import org.kitesdk.data.RefineableView;
+import org.kitesdk.data.RefinableView;
 import javax.annotation.concurrent.Immutable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,11 +32,11 @@ import org.slf4j.LoggerFactory;
  * @since 0.9.0
  */
 @Immutable
-public abstract class AbstractDataset<E> implements Dataset<E>, RefineableView<E> {
+public abstract class AbstractDataset<E> implements Dataset<E>, RefinableView<E> {
 
   private static final Logger logger = LoggerFactory.getLogger(AbstractDataset.class);
 
-  protected abstract RefineableView<E> asRefineableView();
+  protected abstract RefinableView<E> asRefinableView();
 
   @Override
   public Dataset<E> getDataset() {
@@ -47,14 +47,14 @@ public abstract class AbstractDataset<E> implements Dataset<E>, RefineableView<E
   public DatasetWriter<E> newWriter() {
     logger.debug("Getting writer to dataset:{}", this);
 
-    return asRefineableView().newWriter();
+    return asRefinableView().newWriter();
   }
 
   @Override
   public DatasetReader<E> newReader() {
     logger.debug("Getting reader for dataset:{}", this);
 
-    return asRefineableView().newReader();
+    return asRefinableView().newReader();
   }
 
   @Override
@@ -63,33 +63,33 @@ public abstract class AbstractDataset<E> implements Dataset<E>, RefineableView<E
   }
 
   @Override
-  public RefineableView<E> with(String name, Object... values) {
+  public RefinableView<E> with(String name, Object... values) {
     Conversions.checkTypeConsistency(getDescriptor(), name, values);
-    return asRefineableView().with(name, values);
+    return asRefinableView().with(name, values);
   }
 
   @Override
-  public RefineableView<E> from(String name, Comparable value) {
+  public RefinableView<E> from(String name, Comparable value) {
     Conversions.checkTypeConsistency(getDescriptor(), name, value);
-    return asRefineableView().from(name, value);
+    return asRefinableView().from(name, value);
   }
 
   @Override
-  public RefineableView<E> fromAfter(String name, Comparable value) {
+  public RefinableView<E> fromAfter(String name, Comparable value) {
     Conversions.checkTypeConsistency(getDescriptor(), name, value);
-    return asRefineableView().fromAfter(name, value);
+    return asRefinableView().fromAfter(name, value);
   }
 
   @Override
-  public RefineableView<E> to(String name, Comparable value) {
+  public RefinableView<E> to(String name, Comparable value) {
     Conversions.checkTypeConsistency(getDescriptor(), name, value);
-    return asRefineableView().to(name, value);
+    return asRefinableView().to(name, value);
   }
 
   @Override
-  public RefineableView<E> toBefore(String name, Comparable value) {
+  public RefinableView<E> toBefore(String name, Comparable value) {
     Conversions.checkTypeConsistency(getDescriptor(), name, value);
-    return asRefineableView().toBefore(name, value);
+    return asRefinableView().toBefore(name, value);
   }
 
   public InputFormat<E, Void> getDelegateInputFormat() {

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractRefinableView.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractRefinableView.java
@@ -23,7 +23,7 @@ import com.google.common.base.Objects;
 
 import javax.annotation.concurrent.Immutable;
 
-import org.kitesdk.data.RefineableView;
+import org.kitesdk.data.RefinableView;
 import org.kitesdk.data.View;
 
 /**
@@ -35,7 +35,7 @@ import org.kitesdk.data.View;
  * @since 0.9.0
  */
 @Immutable
-public abstract class AbstractRefineableView<E> implements RefineableView<E> {
+public abstract class AbstractRefinableView<E> implements RefinableView<E> {
 
   protected final Dataset<E> dataset;
   protected final MarkerComparator comparator;
@@ -45,7 +45,7 @@ public abstract class AbstractRefineableView<E> implements RefineableView<E> {
   // This class is Immutable and must be thread-safe
   protected final ThreadLocal<StorageKey> keys;
 
-  protected AbstractRefineableView(Dataset<E> dataset) {
+  protected AbstractRefinableView(Dataset<E> dataset) {
     this.dataset = dataset;
     final DatasetDescriptor descriptor = dataset.getDescriptor();
     if (descriptor.isPartitioned()) {
@@ -64,7 +64,7 @@ public abstract class AbstractRefineableView<E> implements RefineableView<E> {
     this.entityTest = constraints.toEntityPredicate();
   }
 
-  protected AbstractRefineableView(AbstractRefineableView<E> view, Constraints constraints) {
+  protected AbstractRefinableView(AbstractRefinableView<E> view, Constraints constraints) {
     this.dataset = view.dataset;
     this.comparator = view.comparator;
     this.constraints = constraints;
@@ -73,7 +73,7 @@ public abstract class AbstractRefineableView<E> implements RefineableView<E> {
     this.keys = view.keys;
   }
 
-  protected abstract AbstractRefineableView<E> filter(Constraints c);
+  protected abstract AbstractRefinableView<E> filter(Constraints c);
 
   @Override
   public Dataset<E> getDataset() {
@@ -134,31 +134,31 @@ public abstract class AbstractRefineableView<E> implements RefineableView<E> {
   }
 
   @Override
-  public AbstractRefineableView<E> with(String name, Object... values) {
+  public AbstractRefinableView<E> with(String name, Object... values) {
     Conversions.checkTypeConsistency(dataset.getDescriptor(), name, values);
     return filter(constraints.with(name, values));
   }
 
   @Override
-  public AbstractRefineableView<E> from(String name, Comparable value) {
+  public AbstractRefinableView<E> from(String name, Comparable value) {
     Conversions.checkTypeConsistency(dataset.getDescriptor(), name, value);
     return filter(constraints.from(name, value));
   }
 
   @Override
-  public AbstractRefineableView<E> fromAfter(String name, Comparable value) {
+  public AbstractRefinableView<E> fromAfter(String name, Comparable value) {
     Conversions.checkTypeConsistency(dataset.getDescriptor(), name, value);
     return filter(constraints.fromAfter(name, value));
   }
 
   @Override
-  public AbstractRefineableView<E> to(String name, Comparable value) {
+  public AbstractRefinableView<E> to(String name, Comparable value) {
     Conversions.checkTypeConsistency(dataset.getDescriptor(), name, value);
     return filter(constraints.to(name, value));
   }
 
   @Override
-  public AbstractRefineableView<E> toBefore(String name, Comparable value) {
+  public AbstractRefinableView<E> toBefore(String name, Comparable value) {
     Conversions.checkTypeConsistency(dataset.getDescriptor(), name, value);
     return filter(constraints.toBefore(name, value));
   }
@@ -173,7 +173,7 @@ public abstract class AbstractRefineableView<E> implements RefineableView<E> {
       return false;
     }
 
-    AbstractRefineableView that = (AbstractRefineableView) o;
+    AbstractRefinableView that = (AbstractRefinableView) o;
     return (Objects.equal(this.dataset, that.dataset) &&
         Objects.equal(this.constraints, that.constraints));
   }

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/TestRefinableViews.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/TestRefinableViews.java
@@ -82,7 +82,7 @@ public abstract class TestRefinableViews extends MiniDFSTest {
   protected FileSystem fs;
   protected PartitionStrategy strategy = null;
   protected DatasetDescriptor testDescriptor = null;
-  protected RefineableView<StandardEvent> unbounded = null;
+  protected RefinableView<StandardEvent> unbounded = null;
 
   @Before
   public void setup() throws Exception {
@@ -175,7 +175,7 @@ public abstract class TestRefinableViews extends MiniDFSTest {
   public void testLimitedWriter() {
     long start = new DateTime(2013, 10, 1, 0, 0, DateTimeZone.UTC).getMillis();
     long end = new DateTime(2013, 11, 14, 0, 0, DateTimeZone.UTC).getMillis();
-    final RefineableView<StandardEvent> range = unbounded
+    final RefinableView<StandardEvent> range = unbounded
         .from("timestamp", start).toBefore("timestamp", end);
 
     DatasetWriter<StandardEvent> writer = range.newWriter();
@@ -218,7 +218,7 @@ public abstract class TestRefinableViews extends MiniDFSTest {
 
   @Test
   public void testLimitedWriterForNonPartitionedField() {
-    final RefineableView<StandardEvent> view = unbounded.with("user_id", 0L);
+    final RefinableView<StandardEvent> view = unbounded.with("user_id", 0L);
 
     DatasetWriter<StandardEvent> writer = view.newWriter();
     try {
@@ -250,7 +250,7 @@ public abstract class TestRefinableViews extends MiniDFSTest {
     long instant = new DateTime(2013, 10, 1, 0, 0, DateTimeZone.UTC).getMillis();
     long later = instant + 1;
     final long earlier = instant - 1;
-    final RefineableView<StandardEvent> fromOctober =
+    final RefinableView<StandardEvent> fromOctober =
         unbounded.from("timestamp", instant);
 
     // test events
@@ -326,7 +326,7 @@ public abstract class TestRefinableViews extends MiniDFSTest {
     final long instant = new DateTime(2013, 9, 30, 12, 59, 59, 999, DateTimeZone.UTC).getMillis();
     long later = instant + 1;
     final long earlier = instant - 1;
-    final RefineableView<StandardEvent> afterSep =
+    final RefinableView<StandardEvent> afterSep =
         unbounded.fromAfter("timestamp", instant);
 
     // test events
@@ -407,7 +407,7 @@ public abstract class TestRefinableViews extends MiniDFSTest {
     final long instant = new DateTime(2013, 9, 30, 12, 59, 59, 999, DateTimeZone.UTC).getMillis();
     final long later = instant + 1;
     long earlier = instant - 1;
-    final RefineableView<StandardEvent> toOct =
+    final RefinableView<StandardEvent> toOct =
         unbounded.to("timestamp", instant);
 
     // test events
@@ -483,7 +483,7 @@ public abstract class TestRefinableViews extends MiniDFSTest {
     final long instant = new DateTime(2013, 10, 1, 0, 0, DateTimeZone.UTC).getMillis();
     final long later = instant + 1;
     long earlier = instant - 1;
-    final RefineableView<StandardEvent> beforeOct =
+    final RefinableView<StandardEvent> beforeOct =
         unbounded.toBefore("timestamp", instant);
 
     // test events
@@ -564,7 +564,7 @@ public abstract class TestRefinableViews extends MiniDFSTest {
     final long instant = new DateTime(2013, 10, 1, 0, 0, DateTimeZone.UTC).getMillis();
     final long later = instant + 1;
     final long earlier = instant - 1;
-    final RefineableView<StandardEvent> withSpecificTimestamp =
+    final RefinableView<StandardEvent> withSpecificTimestamp =
         unbounded.with("timestamp", instant);
 
     Assert.assertNotNull("from(same instant) should succeed",
@@ -618,7 +618,7 @@ public abstract class TestRefinableViews extends MiniDFSTest {
     final long later = end + 1;
     final long earlier = start - 1;
     long included = octEvent.getTimestamp();
-    final RefineableView<StandardEvent> oct = unbounded
+    final RefinableView<StandardEvent> oct = unbounded
         .from("timestamp", start).to("timestamp", end);
 
     // test events

--- a/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/DaoDataset.java
+++ b/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/DaoDataset.java
@@ -22,7 +22,7 @@ import org.kitesdk.data.Key;
 import org.kitesdk.data.PartitionKey;
 import org.kitesdk.data.PartitionStrategy;
 import org.kitesdk.data.RandomAccessDataset;
-import org.kitesdk.data.RefineableView;
+import org.kitesdk.data.RefinableView;
 import org.kitesdk.data.hbase.impl.Dao;
 import org.kitesdk.data.spi.AbstractDataset;
 
@@ -70,7 +70,7 @@ class DaoDataset<E> extends AbstractDataset<E> implements RandomAccessDataset<E>
   }
 
   @Override
-  protected RefineableView<E> asRefineableView() {
+  protected RefinableView<E> asRefinableView() {
     return unbounded;
   }
 

--- a/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/DaoView.java
+++ b/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/DaoView.java
@@ -25,14 +25,14 @@ import org.kitesdk.data.DatasetWriter;
 import org.kitesdk.data.spi.FieldPartitioner;
 import org.kitesdk.data.PartitionKey;
 import org.kitesdk.data.PartitionStrategy;
-import org.kitesdk.data.spi.AbstractRefineableView;
+import org.kitesdk.data.spi.AbstractRefinableView;
 import org.kitesdk.data.spi.Constraints;
 import org.kitesdk.data.spi.StorageKey;
 import org.kitesdk.data.spi.Marker;
 import org.kitesdk.data.spi.MarkerRange;
 import java.util.List;
 
-class DaoView<E> extends AbstractRefineableView<E> {
+class DaoView<E> extends AbstractRefinableView<E> {
 
   private final DaoDataset<E> dataset;
 

--- a/kite-data/kite-data-hbase/src/test/java/org/kitesdk/data/hbase/DaoViewTest.java
+++ b/kite-data/kite-data-hbase/src/test/java/org/kitesdk/data/hbase/DaoViewTest.java
@@ -26,7 +26,7 @@ import org.kitesdk.data.hbase.avro.entities.TestEntity;
 import org.kitesdk.data.hbase.avro.entities.TestEnum;
 import org.kitesdk.data.hbase.testing.HBaseTestUtils;
 
-import org.kitesdk.data.spi.AbstractRefineableView;
+import org.kitesdk.data.spi.AbstractRefinableView;
 import java.util.ArrayList;
 import java.util.HashMap;
 
@@ -90,7 +90,7 @@ public class DaoViewTest {
   public void testRange() {
     populateTestEntities(10);
 
-    final AbstractRefineableView<TestEntity> range = new DaoView<TestEntity>(ds)
+    final AbstractRefinableView<TestEntity> range = new DaoView<TestEntity>(ds)
             .fromAfter(NAMES[0], "1").to(NAMES[0], "9")
             .fromAfter(NAMES[1], "1").to(NAMES[1], "9");
 
@@ -125,7 +125,7 @@ public class DaoViewTest {
   public void testLimitedReader() {
     populateTestEntities(10);
 
-    AbstractRefineableView<TestEntity> range = new DaoView<TestEntity>(ds)
+    AbstractRefinableView<TestEntity> range = new DaoView<TestEntity>(ds)
         .from(NAMES[0], "0").to(NAMES[0], "9")
         .from(NAMES[1], "0").to(NAMES[1], "9");
     validRange(range, 0, 10);

--- a/src/site/markdown/release_notes.md
+++ b/src/site/markdown/release_notes.md
@@ -9,6 +9,9 @@ Release date: TBD
 
 Version 0.12.0 has the following notable changes:
 
+* Views API. There is an incompatible change in this release: RefineableView in the
+  org.kitesdk.data package has been renamed to RefinableView (no 'e'). Clients should
+  update and recompile.
 * Morphlines Library
     * Added a sampling command that forwards each input record with a given probability to its child command: [sample](kite-morphlines/morphlinesReferenceGuide.html#sample)
     * Added a command that ignores all input records beyond the N-th record, akin to the Unix head command: [head](kite-morphlines/morphlinesReferenceGuide.html#head)


### PR DESCRIPTION
...(i.e., RefinableView)
