### PR TITLE
Avoid concurrent access on thrift client.

### DIFF
--- a/kite-data/kite-data-hcatalog/src/main/java/org/kitesdk/data/hcatalog/HCatalog.java
+++ b/kite-data/kite-data-hcatalog/src/main/java/org/kitesdk/data/hcatalog/HCatalog.java
@@ -54,7 +54,7 @@ final class HCatalog {
         table = HCatUtil.getTable(client, dbName, tableName);
       }
     } catch (RuntimeException e) {
-        throw new RuntimeException("Hive metastore exception", e);
+        throw e;
     } catch (Exception e) {
       throw new DatasetNotFoundException("Hive table lookup exception", e);
     }
@@ -91,7 +91,7 @@ final class HCatalog {
         client.alter_table(tbl.getDbName(), tbl.getTableName(), tbl.getTTable());
       }
     } catch (RuntimeException e) {
-        throw new RuntimeException("Hive metastore exception", e);
+        throw e;
     } catch (Exception e) {
       throw new RuntimeException("Hive alter table exception", e);
     }
@@ -104,7 +104,7 @@ final class HCatalog {
           true /* ignoreUnknownTable */);
       }
     } catch (RuntimeException e) {
-        throw new RuntimeException("Hive metastore exception", e);
+        throw e;
     } catch (Exception e) {
       throw new RuntimeException("Hive metastore exception", e);
     }
@@ -121,7 +121,7 @@ final class HCatalog {
     } catch (AlreadyExistsException e) {
       // this is okay
     } catch (RuntimeException e) {
-      throw new RuntimeException("Hive metastore exception", e);
+      throw e;
     } catch (Exception e) {
       throw new RuntimeException("Hive metastore exception", e);
     }


### PR DESCRIPTION
See CDK-328. Until we can get a non-cached HMS client (hive 0.12) we should deal with the fact that HMS client isn't thread safe.
This shouldn't hurt performance in most cases, while definitely fixing the use-case of using multiple writers concurrently (on partitioned datasets backed by hive).
