### PR TITLE
Add type parameter to pathIterator method

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/AccessorImpl.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/AccessorImpl.java
@@ -15,7 +15,8 @@
  */
 package org.kitesdk.data.filesystem;
 
-import java.io.IOException;
+import java.util.Iterator;
+
 import org.kitesdk.data.Dataset;
 import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.DatasetException;
@@ -36,11 +37,11 @@ final class AccessorImpl extends Accessor {
   }
 
   @Override
-  public Iterable<Path> getPathIterator(View view) {
+  public Iterator<Path> getDirectoryIterator(View view) {
     if (view instanceof FileSystemView) {
-      return ((FileSystemView) view).pathIterator();
+      return ((FileSystemView<?>) view).dirIterator();
     } else if (view instanceof FileSystemDataset) {
-      return ((FileSystemDataset) view).pathIterator();
+      return ((FileSystemDataset<?>) view).dirIterator();
     } else {
       throw new DatasetException(
           "Underlying Dataset must be a FileSystemDataset");

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/FileSystemDataset.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/FileSystemDataset.java
@@ -16,6 +16,8 @@
 package org.kitesdk.data.filesystem;
 
 import com.google.common.collect.Sets;
+
+import java.util.Iterator;
 import java.util.Set;
 import org.apache.hadoop.mapreduce.InputFormat;
 import org.kitesdk.data.Dataset;
@@ -131,6 +133,15 @@ class FileSystemDataset<E> extends AbstractDataset<E> implements Mergeable<FileS
 
   PathIterator pathIterator() {
     return unbounded.pathIterator();
+  }
+
+  /**
+   * Returns an iterator that provides all leaf-level directories in this view.
+   *
+   * @return leaf-directory iterator
+   */
+  Iterator<Path> dirIterator() {
+    return unbounded.dirIterator();
   }
 
   @Override

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/FileSystemDatasetKeyInputFormat.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/FileSystemDatasetKeyInputFormat.java
@@ -67,7 +67,7 @@ class FileSystemDatasetKeyInputFormat<E> extends InputFormat<E, Void> {
   }
 
   private void setInputPaths(JobContext jobContext, Job job) throws IOException {
-    List<Path> paths = Lists.newArrayList(Accessor.getDefault().getPathIterator(dataset));
+    List<Path> paths = Lists.newArrayList(Accessor.getDefault().getDirectoryIterator(dataset));
     FileInputFormat.setInputPaths(job, paths.toArray(new Path[paths.size()]));
     // the following line is needed for Hadoop 1, otherwise the paths are not set
     jobContext.getConfiguration().set("mapred.input.dir", job.getConfiguration().get("mapred.input.dir"));

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/FileSystemView.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/FileSystemView.java
@@ -16,6 +16,7 @@
 
 package org.kitesdk.data.filesystem;
 
+import com.google.common.base.Function;
 import com.google.common.collect.Iterators;
 import java.util.Iterator;
 import org.kitesdk.data.DatasetDescriptor;
@@ -31,6 +32,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import java.io.IOException;
 
@@ -102,6 +104,27 @@ class FileSystemView<E> extends AbstractRefinableView<E> {
           Pair.of((StorageKey) null, root));
     }
     return new PathIterator(fs, root, directories);
+  }
+
+  /**
+   * Returns an iterator that provides all leaf-level directories in this view.
+   *
+   * @return leaf-directory iterator
+   */
+  Iterator<Path> dirIterator() {
+    if (dataset.getDescriptor().isPartitioned()) {
+      return Iterators.transform(partitionIterator(), new Function<Pair<StorageKey, Path>, Path>() {
+        @Override
+        @edu.umd.cs.findbugs.annotations.SuppressWarnings(
+            value="NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+            justification="False positive, initialized above as non-null.")
+        public Path apply(@Nullable Pair<StorageKey, Path> input) {
+          return new Path(root, input.second());
+        }
+      });
+    } else {
+      return Iterators.singletonIterator(root);
+    }
   }
 
   private FileSystemPartitionIterator partitionIterator() {

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/impl/Accessor.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/impl/Accessor.java
@@ -21,6 +21,7 @@ import org.kitesdk.data.filesystem.FileSystemDatasetRepository;
 import org.kitesdk.data.Dataset;
 import org.kitesdk.data.View;
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -65,14 +66,14 @@ public abstract class Accessor {
   public abstract Path getDirectory(Dataset<?> dataset);
 
   /**
-   * Returns an {@code Iterable} that will list all of the data files in the
+   * Returns an {@code Iterator} that will list all of the leaf-level directories in the
    * given {@link View}.
    * @param view a {@code View}
-   * @return An Iterable of all data file paths in the given {@code View}
+   * @return An {@code Iterator} of all leaf-level directory paths in the given {@code View}
    *
-   * @since 0.9.0
+   * @since 0.12.1
    */
-  public abstract Iterable<Path> getPathIterator(View view);
+  public abstract Iterator<Path> getDirectoryIterator(View view);
 
   public abstract void ensureExists(DatasetDescriptor descriptor, Configuration conf);
 

--- a/kite-data/kite-data-crunch/src/main/java/org/kitesdk/data/crunch/CrunchDatasets.java
+++ b/kite-data/kite-data-crunch/src/main/java/org/kitesdk/data/crunch/CrunchDatasets.java
@@ -60,7 +60,7 @@ public class CrunchDatasets {
     Path directory = Accessor.getDefault().getDirectory(dataset);
     if (directory != null) {
       List<Path> paths = Lists.newArrayList(
-          Accessor.getDefault().getPathIterator(dataset));
+          Accessor.getDefault().getDirectoryIterator(dataset));
 
       AvroType<E> avroType;
       if (type.isAssignableFrom(GenericData.Record.class)) {


### PR DESCRIPTION
When reading a dataset (or a view) through Crunch, Kite currently builds up an iterator of all individual file paths to be read within the view. In the case where there are there are a large number of files (consider partitioning based on date, with 20 files per day over a year, resulting in 7300 files), the resulting job configuration for the Crunch job becomes huge.

Building up the job configuration in Crunch for so many individual input files can be extremely slow (mostly due to the resulting performance of Configuration#substituteVars), and in some cases even causes an IOException because the serialized Configuration's size goes over the limit of 5MB.

This issue is largely mitigated by [CRUNCH-335](https://issues.apache.org/jira/browse/CRUNCH-335), which isn't currently available in a released version of Crunch. Even so, it seems useful to reduce the size of the job configuration when dealing with a large number of input files.

FileInputFormat can work with directories instead of individual file paths, so this patch makes the pathIterator method parameterized so that it's possible to create an iterator of individual files, or an iterator of leaf-level directories. The directory iterator is used by CrunchDatasets, avoiding the issue of creating an oversized job configuration.
