### PR TITLE
CDK-363: Fix hadoop-1 build with multiple artifacts.

### DIFF
--- a/kite-data/kite-data-core/pom.xml
+++ b/kite-data/kite-data-core/pom.xml
@@ -116,13 +116,13 @@
   <dependencies>
     <dependency>
       <groupId>org.kitesdk</groupId>
-      <artifactId>kite-hadoop-dependencies</artifactId>
+      <artifactId>${artifact.hadoop-deps}</artifactId>
       <type>pom</type>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.kitesdk</groupId>
-      <artifactId>kite-hadoop-test-dependencies</artifactId>
+      <artifactId>${artifact.hadoop-test-deps}</artifactId>
       <type>pom</type>
       <scope>test</scope>
     </dependency>

--- a/kite-data/kite-data-crunch/pom.xml
+++ b/kite-data/kite-data-crunch/pom.xml
@@ -93,13 +93,13 @@
     </dependency>
     <dependency>
       <groupId>org.kitesdk</groupId>
-      <artifactId>kite-hadoop-dependencies</artifactId>
+      <artifactId>${artifact.hadoop-deps}</artifactId>
       <type>pom</type>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.kitesdk</groupId>
-      <artifactId>kite-hadoop-test-dependencies</artifactId>
+      <artifactId>${artifact.hadoop-test-deps}</artifactId>
       <type>pom</type>
       <scope>test</scope>
     </dependency>

--- a/kite-data/kite-data-hbase/pom.xml
+++ b/kite-data/kite-data-hbase/pom.xml
@@ -165,13 +165,13 @@
     </dependency>
     <dependency>
       <groupId>org.kitesdk</groupId>
-      <artifactId>kite-hadoop-dependencies</artifactId>
+      <artifactId>${artifact.hadoop-deps}</artifactId>
       <type>pom</type>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.kitesdk</groupId>
-      <artifactId>kite-hadoop-test-dependencies</artifactId>
+      <artifactId>${artifact.hadoop-test-deps}</artifactId>
       <type>pom</type>
       <scope>test</scope>
     </dependency>

--- a/kite-data/kite-data-hcatalog/pom.xml
+++ b/kite-data/kite-data-hcatalog/pom.xml
@@ -97,13 +97,13 @@
     </dependency>
     <dependency>
       <groupId>org.kitesdk</groupId>
-      <artifactId>kite-hadoop-dependencies</artifactId>
+      <artifactId>${artifact.hadoop-deps}</artifactId>
       <type>pom</type>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.kitesdk</groupId>
-      <artifactId>kite-hadoop-test-dependencies</artifactId>
+      <artifactId>${artifact.hadoop-test-deps}</artifactId>
       <type>pom</type>
       <scope>test</scope>
     </dependency>

--- a/kite-data/kite-data-mapreduce/pom.xml
+++ b/kite-data/kite-data-mapreduce/pom.xml
@@ -116,14 +116,14 @@
 
     <dependency>
       <groupId>org.kitesdk</groupId>
-      <artifactId>kite-hadoop-dependencies</artifactId>
+      <artifactId>${artifact.hadoop-deps}</artifactId>
       <type>pom</type>
       <scope>provided</scope>
     </dependency>
     
     <dependency>
       <groupId>org.kitesdk</groupId>
-      <artifactId>kite-hadoop-test-dependencies</artifactId>
+      <artifactId>${artifact.hadoop-test-deps}</artifactId>
       <type>pom</type>
       <scope>test</scope>
     </dependency>

--- a/kite-hadoop-dependencies/hadoop1-test/pom.xml
+++ b/kite-hadoop-dependencies/hadoop1-test/pom.xml
@@ -17,9 +17,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>kite-hadoop-test-dependencies</artifactId>
+  <artifactId>kite-hadoop1-test-dependencies</artifactId>
   <packaging>pom</packaging>
-  <version>0.12.2-SNAPSHOT-hadoop1</version>
+  <version>0.12.2-SNAPSHOT</version>
 
   <parent>
     <groupId>org.kitesdk</groupId>

--- a/kite-hadoop-dependencies/hadoop1/pom.xml
+++ b/kite-hadoop-dependencies/hadoop1/pom.xml
@@ -17,9 +17,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>kite-hadoop-dependencies</artifactId>
+  <artifactId>kite-hadoop1-dependencies</artifactId>
   <packaging>pom</packaging>
-  <version>0.12.2-SNAPSHOT-hadoop1</version>
+  <version>0.12.2-SNAPSHOT</version>
 
   <parent>
     <groupId>org.kitesdk</groupId>

--- a/kite-maven-plugin/pom.xml
+++ b/kite-maven-plugin/pom.xml
@@ -128,7 +128,7 @@
     </dependency>
     <dependency>
       <groupId>org.kitesdk</groupId>
-      <artifactId>kite-hadoop-dependencies</artifactId>
+      <artifactId>${artifact.hadoop-deps}</artifactId>
       <type>pom</type>
       <scope>compile</scope> <!-- plugin acts as a Hadoop container -->
     </dependency>

--- a/kite-morphlines/kite-morphlines-hadoop-core/pom.xml
+++ b/kite-morphlines/kite-morphlines-hadoop-core/pom.xml
@@ -39,7 +39,7 @@
 
     <dependency>
       <groupId>org.kitesdk</groupId>
-      <artifactId>kite-hadoop-dependencies</artifactId>
+      <artifactId>${artifact.hadoop-deps}</artifactId>
       <type>pom</type>
       <scope>provided</scope>
     </dependency>
@@ -47,7 +47,7 @@
     <!-- for MiniDFSCluster -->
     <dependency>
       <groupId>org.kitesdk</groupId>
-      <artifactId>kite-hadoop-test-dependencies</artifactId>
+      <artifactId>${artifact.hadoop-test-deps}</artifactId>
       <type>pom</type>
       <scope>test</scope>
     </dependency>

--- a/kite-morphlines/kite-morphlines-hadoop-parquet-avro/pom.xml
+++ b/kite-morphlines/kite-morphlines-hadoop-parquet-avro/pom.xml
@@ -33,7 +33,7 @@
     <!-- needed for parquet-avro -->
     <dependency>
       <groupId>org.kitesdk</groupId>
-      <artifactId>kite-hadoop-dependencies</artifactId>
+      <artifactId>${artifact.hadoop-deps}</artifactId>
       <type>pom</type>
       <scope>provided</scope>
     </dependency>

--- a/kite-morphlines/kite-morphlines-hadoop-rcfile/pom.xml
+++ b/kite-morphlines/kite-morphlines-hadoop-rcfile/pom.xml
@@ -39,7 +39,7 @@
 
     <dependency>
       <groupId>org.kitesdk</groupId>
-      <artifactId>kite-hadoop-dependencies</artifactId>
+      <artifactId>${artifact.hadoop-deps}</artifactId>
       <type>pom</type>
       <scope>provided</scope>
     </dependency>
@@ -53,7 +53,7 @@
     <!-- for MiniDFSCluster -->
     <dependency>
       <groupId>org.kitesdk</groupId>
-      <artifactId>kite-hadoop-test-dependencies</artifactId>
+      <artifactId>${artifact.hadoop-test-deps}</artifactId>
       <type>pom</type>
       <scope>test</scope>
     </dependency>

--- a/kite-morphlines/kite-morphlines-hadoop-sequencefile/pom.xml
+++ b/kite-morphlines/kite-morphlines-hadoop-sequencefile/pom.xml
@@ -39,7 +39,7 @@
 
     <dependency>
       <groupId>org.kitesdk</groupId>
-      <artifactId>kite-hadoop-dependencies</artifactId>
+      <artifactId>${artifact.hadoop-deps}</artifactId>
       <type>pom</type>
       <scope>provided</scope>
     </dependency>

--- a/kite-tools/pom.xml
+++ b/kite-tools/pom.xml
@@ -145,7 +145,7 @@
     </dependency>
     <dependency>
       <groupId>org.kitesdk</groupId>
-      <artifactId>kite-hadoop-dependencies</artifactId>
+      <artifactId>${artifact.hadoop-deps}</artifactId>
       <type>pom</type>
       <scope>compile</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,10 @@
 
     <cdh.version>4.4.0</cdh.version>
 
+    <!-- artifacts that depend on profiles -->
+    <artifact.hadoop-deps>kite-hadoop-dependencies</artifact.hadoop-deps>
+    <artifact.hadoop-test-deps>kite-hadoop-test-dependencies</artifact.hadoop-test-deps>
+
     <!-- Library versions -->
     <vers.avro>1.7.5</vers.avro>
     <vers.commons-codec>1.4</vers.commons-codec>
@@ -643,14 +647,14 @@
       <!-- Hadoop dependencies -->
       <dependency>
         <groupId>org.kitesdk</groupId>
-        <artifactId>kite-hadoop-dependencies</artifactId>
-        <version>${vers.hadoop-deps}</version>
+        <artifactId>${artifact.hadoop-deps}</artifactId>
+        <version>${project.version}</version>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.kitesdk</groupId>
-        <artifactId>kite-hadoop-test-dependencies</artifactId>
-        <version>${vers.hadoop-deps}</version>
+        <artifactId>${artifact.hadoop-test-deps}</artifactId>
+        <version>${project.version}</version>
         <type>pom</type>
         <scope>test</scope>
       </dependency>
@@ -1019,7 +1023,8 @@
         </property>
       </activation>
       <properties>
-        <vers.hadoop-deps>${project.version}-hadoop1</vers.hadoop-deps>
+        <artifact.hadoop-deps>kite-hadoop1-dependencies</artifact.hadoop-deps>
+        <artifact.hadoop-test-deps>kite-hadoop1-test-dependencies</artifact.hadoop-test-deps>
         <vers.crunch>${vers.crunch-base}</vers.crunch>
         <vers.hcatalog>0.5.0-incubating</vers.hcatalog>
         <vers.hive>0.10.0</vers.hive>


### PR DESCRIPTION
This changes the kite-hadoop dependencies to use different artifacts
instead of different versions because versions can't be used with the
maven-release-plugin.
