### PR TITLE
CDK-379. Tests generating derby db in git tracked location.

### DIFF
--- a/kite-data/kite-data-crunch/pom.xml
+++ b/kite-data/kite-data-crunch/pom.xml
@@ -48,6 +48,20 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemProperties>
+            <property>
+              <!-- Make sure derby.log goes to target/ subdir
+                   when running tests involving Hive -->
+              <name>derby.stream.error.file</name>
+              <value>target/derby.log</value>
+            </property>
+          </systemProperties>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
       </plugin>

--- a/kite-data/kite-data-crunch/src/test/resources/hive-site.xml
+++ b/kite-data/kite-data-crunch/src/test/resources/hive-site.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+Copyright 2013 Cloudera Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configuration>
+    <property>
+        <name>javax.jdo.option.ConnectionURL</name>
+        <value>jdbc:derby:;databaseName=target/hive-metastore-derby-db;create=true</value>
+        <description>JDBC connect string for a JDBC metastore</description>
+    </property>
+    <property>
+        <name>hive.stats.dbconnectionstring</name>
+        <value>jdbc:derby:;databaseName=target/hive-stats-derby-db;create=true</value>
+        <description>The default connection string for the database that stores temporary Hive statistics.</description>
+    </property>
+</configuration>


### PR DESCRIPTION
Fix for issue at https://issues.cloudera.org/browse/CDK-379
- Adds a test-only hive-site.xml that changes all default derby configs to be target-subdir based.
- Adds a surefire configuration to change the derby.log location when running tests, to also be target-subdir based.
