### PR TITLE
Correct format strings for Guava preconditions

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetDescriptor.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetDescriptor.java
@@ -587,11 +587,11 @@ public class DatasetDescriptor {
         // the record.
         Schema.Field field = schema.getField(fp.getSourceName());
         Preconditions.checkState(field != null,
-            "Cannot partition on {} (missing from schema)", fp.getSourceName());
+            "Cannot partition on %s (missing from schema)", fp.getSourceName());
         Preconditions.checkState(
             SchemaUtil.isConsistentWithExpectedType(
                 field.schema().getType(), fp.getSourceType()),
-            "Field type {} does not match partitioner {}",
+            "Field type %s does not match partitioner %s",
             field.schema().getType(), fp);
       }
     }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/PartitionedDatasetWriter.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/filesystem/PartitionedDatasetWriter.java
@@ -87,7 +87,7 @@ class PartitionedDatasetWriter<E> implements DatasetWriter<E> {
       // avoid checking in every whether the entity belongs in the view by only
       // checking when a new writer is created
       Preconditions.checkArgument(view.includes(entity),
-          "View {} does not include entity {}", view, entity);
+          "View %s does not include entity %s", view, entity);
       // get a new key because it is stored in the cache
       StorageKey key = StorageKey.copy(reusedKey);
       try {

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/Compatibility.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/Compatibility.java
@@ -89,7 +89,7 @@ public abstract class Compatibility {
   public static void checkDatasetName(String name) {
     Preconditions.checkNotNull(name, "Dataset name cannot be null");
     Preconditions.checkArgument(Compatibility.isCompatibleName(name),
-        "Hive incompatible: Dataset name {} is not alphanumeric (plus '_')",
+        "Hive incompatible: Dataset name %s is not alphanumeric (plus '_')",
         name);
   }
 
@@ -102,7 +102,7 @@ public abstract class Compatibility {
     Preconditions.checkNotNull(schema, "Schema cannot be null");
     List<String> incompatible = getIncompatibleNames(schema);
     Preconditions.checkState(incompatible.isEmpty(),
-        "Hive incompatible: field names are not alphanumeric (plus '_'): {}",
+        "Hive incompatible: field names are not alphanumeric (plus '_'): %s",
         Joiner.on(", ").join(incompatible));
   }
 
@@ -141,10 +141,10 @@ public abstract class Compatibility {
         }
       }
       Preconditions.checkState(incompatible.isEmpty(),
-          "Hive incompatible: partition names are not alphanumeric (plus '_'): {}",
+          "Hive incompatible: partition names are not alphanumeric (plus '_'): %s",
           Joiner.on(", ").join(incompatible));
       Preconditions.checkState(duplicates.isEmpty(),
-          "Hive incompatible: partition names duplicate data fields: {}",
+          "Hive incompatible: partition names duplicate data fields: %s",
           Joiner.on(", ").join(duplicates));
     }
   }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/SchemaUtil.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/SchemaUtil.java
@@ -129,7 +129,7 @@ public class SchemaUtil {
         // check to make sure this hasn't been visited before
         String name = schema.getFullName();
         Preconditions.checkState(!visitor.recordLevels.contains(name),
-            "Cannot process recursive Avro record {}", name);
+            "Cannot process recursive Avro record %s", name);
 
         visitor.recordLevels.push(name);
 


### PR DESCRIPTION
There are a number of places where Kite uses the slf4j formatting symbol "{}" for Guava Preconditions calls. This patch replaces the "{}" symbols with "%s" so that the Precondition messages are formatted correctly.
