### PR TITLE
CDK-415: Add reconnect and retry support for Hive.

### DIFF
--- a/kite-data/kite-data-hcatalog/src/main/java/org/kitesdk/data/hcatalog/impl/HCatalog.java
+++ b/kite-data/kite-data-hcatalog/src/main/java/org/kitesdk/data/hcatalog/impl/HCatalog.java
@@ -15,16 +15,25 @@
  */
 package org.kitesdk.data.hcatalog.impl;
 
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
+import org.apache.hadoop.hive.metastore.api.InvalidObjectException;
+import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.UnknownDBException;
 import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hcatalog.common.HCatUtil;
-import org.kitesdk.data.DatasetException;
+import org.apache.thrift.TException;
+import org.kitesdk.data.DatasetExistsException;
+import org.kitesdk.data.DatasetIOException;
 import org.kitesdk.data.DatasetNotFoundException;
-import org.kitesdk.data.impl.Accessor;
+import org.kitesdk.data.DatasetRepositoryException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,8 +41,33 @@ public final class HCatalog {
 
   private static final Logger LOG = LoggerFactory.getLogger(HCatalog.class);
 
-  private HiveMetaStoreClient client;
-  private HiveConf hiveConf;
+  private final HiveMetaStoreClient client;
+  private final HiveConf hiveConf;
+
+  private static interface ClientAction<R> {
+    R call() throws TException;
+  }
+
+  private <R> R doWithRetry(ClientAction<R> action) throws TException {
+    try {
+      synchronized (client) {
+        return action.call();
+      }
+    } catch (TException e) {
+      try {
+        synchronized (client) {
+          client.reconnect();
+        }
+      } catch (MetaException swallowedException) {
+        // reconnect failed, throw the original exception
+        throw e;
+      }
+      synchronized (client) {
+        // retry the action. if this fails, its exception is propagated
+        return action.call();
+      }
+    }
+  }
 
   public HCatalog(Configuration conf) {
     if (conf.get(Loader.HIVE_METASTORE_URI_PROP) == null) {
@@ -42,114 +76,187 @@ public final class HCatalog {
     try {
       hiveConf = new HiveConf(conf, HiveConf.class);
       client = HCatUtil.getHiveClient(hiveConf);
-    } catch (Exception e) {
-      throw new RuntimeException("Hive metastore exception", e);
+    } catch (TException e) {
+      throw new DatasetRepositoryException("Hive metastore exception", e);
+    } catch (IOException e) {
+      throw new DatasetIOException("Hive metastore exception", e);
     }
   }
 
-  public Table getTable(String dbName, String tableName) {
+  public Table getTable(final String dbName, final String tableName) {
+    ClientAction<Table> getTable =
+        new ClientAction<Table>() {
+          @Override
+          public Table call() throws TException {
+            return HCatUtil.getTable(client, dbName, tableName);
+          }
+        };
+
     Table table;
     try {
-      synchronized(client) {
-        table = HCatUtil.getTable(client, dbName, tableName);
-      }
-    } catch (RuntimeException e) {
-        throw e;
-    } catch (Exception e) {
+      table = doWithRetry(getTable);
+    } catch (NoSuchObjectException e) {
       throw new DatasetNotFoundException("Hive table lookup exception", e);
+    } catch (MetaException e) {
+      throw new DatasetNotFoundException("Hive table lookup exception", e);
+    } catch (TException e) {
+      throw new DatasetRepositoryException(
+          "Exception communicating with the Hive MetaStore", e);
     }
-    
+
     if (table == null) {
       throw new DatasetNotFoundException("Could not find info for table: " + tableName);
     }
     return table;
   }
   
-  public boolean tableExists(String dbName, String tableName) {
+  public boolean tableExists(final String dbName, final String tableName) {
+    ClientAction<Boolean> exists =
+        new ClientAction<Boolean>() {
+          @Override
+          public Boolean call() throws TException {
+            return client.tableExists(dbName, tableName);
+          }
+        };
+
     try {
-      synchronized(client) {
-        return client.tableExists(dbName, tableName);
-      }
-    } catch (Exception e) {
-      throw new RuntimeException("Hive metastore exception", e);
+      return doWithRetry(exists);
+    } catch (UnknownDBException e) {
+      return false;
+    } catch (MetaException e) {
+      throw new DatasetRepositoryException("Hive MetaStore exception", e);
+    } catch (TException e) {
+      throw new DatasetRepositoryException(
+          "Exception communicating with the Hive MetaStore", e);
     }
   }
   
-  public void createTable(Table tbl) {
+  public void createTable(final Table tbl) {
+    ClientAction<Void> create =
+        new ClientAction<Void>() {
+          @Override
+          public Void call() throws TException {
+            client.createTable(tbl.getTTable());
+            return null;
+          }
+        };
+
     try {
-      synchronized(client) {
-        client.createTable(tbl.getTTable());
-      }
-    } catch (Exception e) {
-      throw new RuntimeException("Hive table creation exception", e);
+      doWithRetry(create);
+    } catch (NoSuchObjectException e) {
+      throw new DatasetNotFoundException("Hive table lookup exception", e);
+    } catch (AlreadyExistsException e) {
+      throw new DatasetExistsException("Hive table exists", e);
+    } catch (InvalidObjectException e) {
+      throw new DatasetRepositoryException("Invalid table", e);
+    } catch (MetaException e) {
+      throw new DatasetRepositoryException("Hive MetaStore exception", e);
+    } catch (TException e) {
+      throw new DatasetRepositoryException(
+          "Exception communicating with the Hive MetaStore", e);
     }
   }
 
-  public void alterTable(Table tbl) {
+  public void alterTable(final Table tbl) {
+    ClientAction<Void> alter =
+        new ClientAction<Void>() {
+          @Override
+          public Void call() throws TException {
+            client.alter_table(
+                tbl.getDbName(), tbl.getTableName(), tbl.getTTable());
+            return null;
+          }
+        };
+
     try {
-      synchronized(client) {
-        client.alter_table(tbl.getDbName(), tbl.getTableName(), tbl.getTTable());
-      }
-    } catch (RuntimeException e) {
-        throw e;
-    } catch (Exception e) {
-      throw new RuntimeException("Hive alter table exception", e);
+      doWithRetry(alter);
+    } catch (NoSuchObjectException e) {
+      throw new DatasetNotFoundException("Hive table lookup exception", e);
+    } catch (InvalidObjectException e) {
+      throw new DatasetRepositoryException("Invalid table", e);
+    } catch (InvalidOperationException e) {
+      throw new DatasetRepositoryException("Invalid table change", e);
+    } catch (MetaException e) {
+      throw new DatasetRepositoryException("Hive MetaStore exception", e);
+    } catch (TException e) {
+      throw new DatasetRepositoryException(
+          "Exception communicating with the Hive MetaStore", e);
     }
   }
   
-  public void dropTable(String dbName, String tableName) {
+  public void dropTable(final String dbName, final String tableName) {
+    ClientAction<Void> drop =
+        new ClientAction<Void>() {
+          @Override
+          public Void call() throws TException {
+            client.dropTable(dbName, tableName, true /* deleteData */,
+                true /* ignoreUnknownTable */);
+            return null;
+          }
+        };
+
     try {
-      synchronized(client) {
-        client.dropTable(dbName, tableName, true /* deleteData */,
-          true /* ignoreUnknownTable */);
-      }
-    } catch (RuntimeException e) {
-        throw e;
-    } catch (Exception e) {
-      throw new RuntimeException("Hive metastore exception", e);
+      doWithRetry(drop);
+    } catch (NoSuchObjectException e) {
+      // this is okay
+    } catch (MetaException e) {
+      throw new DatasetRepositoryException("Hive MetaStore exception", e);
+    } catch (TException e) {
+      throw new DatasetRepositoryException(
+          "Exception communicating with the Hive MetaStore", e);
     }
   }
 
-  public void addPartition(String dbName, String tableName, String path) {
+  public void addPartition(final String dbName, final String tableName,
+                           final String path) {
+    ClientAction<Void> addPartition =
+        new ClientAction<Void>() {
+          @Override
+          public Void call() throws TException {
+            // purposely don't check if the partition already exists because
+            // getPartition(db, table, path) will throw an exception to indicate the
+            // partition doesn't exist also. this way, it's only one call.
+              client.appendPartition(dbName, tableName, path);
+            return null;
+          }
+        };
+
     try {
-      // purposely don't check if the partition already exists because
-      // getPartition(db, table, path) will throw an exception to indicate the
-      // partition doesn't exist also. this way, it's only one call.
-      synchronized(client) {
-        client.appendPartition(dbName, tableName, path);
-      }
+      doWithRetry(addPartition);
     } catch (AlreadyExistsException e) {
       // this is okay
-    } catch (RuntimeException e) {
-      throw e;
-    } catch (Exception e) {
-      throw new RuntimeException("Hive metastore exception", e);
+    } catch (InvalidObjectException e) {
+      throw new DatasetRepositoryException("Invalid partition", e);
+    } catch (MetaException e) {
+      throw new DatasetRepositoryException("Hive MetaStore exception", e);
+    } catch (TException e) {
+      throw new DatasetRepositoryException(
+          "Exception communicating with the Hive MetaStore", e);
     }
   }
 
   public boolean exists(String dbName, String tableName) {
-    try {
-      synchronized(client) {
-        return client.tableExists(dbName, tableName);
-      }
-    } catch (Exception e) {
-      throw Accessor.getDefault().providerExceptionFor(
-          new DatasetException("Hive metastore exception", e));
-    }
+    return tableExists(dbName, tableName);
   }
 
-  public List<String> getAllTables(String dbName) {
-    try {
-      synchronized(client) {
-        return client.getAllTables(dbName);
-      }
-    } catch (Exception e) {
-      throw Accessor.getDefault().providerExceptionFor(
-          new DatasetException("Hive metastore exception", e));
-    }
-  }
+  public List<String> getAllTables(final String dbName) {
+    ClientAction<List<String>> create =
+        new ClientAction<List<String>>() {
+          @Override
+          public List<String> call() throws TException {
+            return client.getAllTables(dbName);
+          }
+        };
 
-  public String getConf(String name, String def) throws Exception {
-    return hiveConf.get(name, def);
+    try {
+      return doWithRetry(create);
+    } catch (NoSuchObjectException e) {
+      return ImmutableList.of();
+    } catch (MetaException e) {
+      throw new DatasetRepositoryException("Hive MetaStore exception", e);
+    } catch (TException e) {
+      throw new DatasetRepositoryException(
+          "Exception communicating with the Hive MetaStore", e);
+    }
   }
 }


### PR DESCRIPTION
This adds a `doWithRetry()` method to the internal HCatalog class that
will run an action and catch TExceptions. If a TException is thrown, it
will reconnect to Hive and then retry the action. Because all actions go
through this method, the synchronization on the Hive client is there as
well.

Most of the HCatalog methods caught Exception and RuntimeException. This
commit updates the error handling to catch the correct Hive exceptions
and handle them more correctly in some cases. The fallback is the same
behavior as before when a TException is unknown.
