### PR TITLE
CDK-483: Fix Hive MetaStore URI handling.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/Registration.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/Registration.java
@@ -103,7 +103,11 @@ public class Registration {
     for (Loadable loader : impls) {
       // the ServiceLoader is lazy, so this iteration forces service loading
       LOG.debug("Loading: " + loader.getClass().getName());
-      loader.load();
+      try {
+        loader.load();
+      } catch (Exception e) {
+        LOG.warn("Cannot load " + loader.getClass(), e);
+      }
     }
     LOG.debug("Registered repository URIs:\n\t" +
         Joiner.on("\n\t").join(REPO_PATTERNS.keySet()));

--- a/kite-data/kite-data-hcatalog/src/main/java/org/kitesdk/data/hcatalog/impl/HCatalog.java
+++ b/kite-data/kite-data-hcatalog/src/main/java/org/kitesdk/data/hcatalog/impl/HCatalog.java
@@ -67,11 +67,11 @@ public final class HCatalog {
   }
 
   public HCatalog(Configuration conf) {
+    this.hiveConf = new HiveConf(conf, HiveConf.class);
     if (conf.get(Loader.HIVE_METASTORE_URI_PROP) == null) {
       LOG.warn("Using a local Hive MetaStore (for testing only)");
     }
     try {
-      hiveConf = new HiveConf(conf, HiveConf.class);
       client = new HiveMetaStoreClient(hiveConf);
     } catch (TException e) {
       throw new DatasetRepositoryException("Hive metastore exception", e);

--- a/kite-hadoop-compatibility/src/main/java/org/kitesdk/compat/DynConstructors.java
+++ b/kite-hadoop-compatibility/src/main/java/org/kitesdk/compat/DynConstructors.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2013 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.compat;
+
+import com.google.common.base.Throwables;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+public class DynConstructors {
+  public static class Ctor<C> {
+    private final Constructor<C> ctor;
+    private final Class<? extends C> constructed;
+
+    private Ctor(Constructor<C> constructor, Class<? extends C> constructed) {
+      this.ctor = constructor;
+      this.constructed = constructed;
+    }
+
+    public Class<? extends C> getConstructedClass() {
+      return constructed;
+    }
+
+    public C newInstanceChecked(Object... args) throws Exception {
+      try {
+        return ctor.newInstance(args);
+      } catch (InstantiationException e) {
+        throw e;
+      } catch (IllegalAccessException e) {
+        throw e;
+      } catch (InvocationTargetException e) {
+        // rethrow the cause is an exception
+        Throwables.propagateIfPossible(e.getCause(), Exception.class);
+        // otherwise, propagate the throwable
+        throw Throwables.propagate(e.getCause());
+      }
+    }
+
+    public C newInstance(Object... args) {
+      try {
+        return newInstanceChecked(args);
+      } catch (Exception e) {
+        throw Throwables.propagate(e);
+      }
+    }
+  }
+
+  public static class Builder {
+    private final Class<?> baseClass;
+    private Ctor ctor = null;
+
+    public Builder(Class<?> baseClass) {
+      this.baseClass = baseClass;
+    }
+
+    public Builder() {
+      this.baseClass = null;
+    }
+
+    public Builder impl(Class<?>... types) {
+      impl(baseClass, types);
+      return this;
+    }
+
+    public Builder impl(String className, Class<?>... types) {
+      // don't do any work if an implementation has been found
+      if (ctor != null) {
+        return this;
+      }
+
+      try {
+        Class<?> targetClass = Class.forName(className);
+        impl(targetClass, types);
+      } catch (NoClassDefFoundError e) {
+        // cannot load this implementation
+      } catch (ClassNotFoundException e) {
+        // not the right implementation
+      }
+      return this;
+    }
+
+    public <T> Builder impl(Class<T> targetClass, Class<?>... types) {
+      // don't do any work if an implementation has been found
+      if (ctor != null) {
+        return this;
+      }
+
+      try {
+        ctor = new Ctor<T>(targetClass.getConstructor(types), targetClass);
+      } catch (NoSuchMethodException e) {
+        // not the right implementation
+      }
+      return this;
+    }
+
+    public Builder hiddenImpl(Class<?>... types) {
+      hiddenImpl(baseClass, types);
+      return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public Builder hiddenImpl(String className, Class<?>... types) {
+      // don't do any work if an implementation has been found
+      if (ctor != null) {
+        return this;
+      }
+
+      try {
+        Class targetClass = Class.forName(className);
+        hiddenImpl(targetClass, types);
+      } catch (NoClassDefFoundError e) {
+        // cannot load this implementation
+      } catch (ClassNotFoundException e) {
+        // not the right implementation
+      }
+      return this;
+    }
+
+    public <T> Builder hiddenImpl(Class<T> targetClass, Class<?>... types) {
+      // don't do any work if an implementation has been found
+      if (ctor != null) {
+        return this;
+      }
+
+      try {
+        Constructor<T> hidden = targetClass.getDeclaredConstructor(types);
+        AccessController.doPrivileged(new MakeAccessible(hidden));
+        ctor = new Ctor<T>(hidden, targetClass);
+      } catch (SecurityException e) {
+        // unusable
+      } catch (NoSuchMethodException e) {
+        // not the right implementation
+      }
+      return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <C> Ctor<C> buildChecked() throws NoSuchMethodException {
+      if (ctor != null) {
+        return ctor;
+      }
+      throw new NoSuchMethodException(
+          "Cannot find constructor for " + baseClass);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <C> Ctor<C> build() {
+      if (ctor != null) {
+        return ctor;
+      }
+      throw new RuntimeException("Cannot find constructor for " + baseClass);
+    }
+  }
+
+  private static class MakeAccessible implements PrivilegedAction<Void> {
+    private Constructor<?> hidden;
+
+    public MakeAccessible(Constructor<?> hidden) {
+      this.hidden = hidden;
+    }
+
+    @Override
+    public Void run() {
+      hidden.setAccessible(true);
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
The hive.metastore.uris property is set in hive-site.xml, but the Loader
and HCatalog class were checking the property before creating a HiveConf
that reads the hive-site.xml file. This prevented the environment's
MetaStore URI from being loaded.

HiveConf is now required in the Loader to initialize URIs correctly, but
this caused test failures kite-data-mapreduce because the MR tasks did
not have Hive jars in the classpath. This commit adds dynamic resolution
of HiveConf so that the hive URIs will not be registered if it can't be
loaded without failing registration for all implementations.

-This also updates the logic to fail rather than warn if a local
MetaStore is being used because the local MS is only for testing. To
avoid this failure, this commit introduces the property,
kite.allow.test-metastore to override the new behavior and adds a
hadoop-site.xml file to the test resources that adds it to the test
environment. (Use hadoop-site.xml because hive-site.xml breaks Hive.)-
