### PR TITLE
CDK-486 add embedded solr server

### DIFF
--- a/kite-morphlines/kite-morphlines-solr-core/src/main/java/org/kitesdk/morphline/solr/SolrLocator.java
+++ b/kite-morphlines/kite-morphlines-solr-core/src/main/java/org/kitesdk/morphline/solr/SolrLocator.java
@@ -30,7 +30,6 @@ import org.apache.solr.core.SolrConfig;
 import org.apache.solr.core.SolrResourceLoader;
 import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.schema.IndexSchemaFactory;
-import org.apache.solr.util.SystemIdResolver;
 import org.apache.zookeeper.KeeperException;
 import org.kitesdk.morphline.api.MorphlineCompilationException;
 import org.kitesdk.morphline.api.MorphlineContext;
@@ -38,7 +37,6 @@ import org.kitesdk.morphline.api.MorphlineRuntimeException;
 import org.kitesdk.morphline.base.Configs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import com.google.common.base.Preconditions;
@@ -90,7 +88,7 @@ public class SolrLocator {
         return loader;
       }
     }
-    
+
     if (zkHost != null && zkHost.length() > 0) {
       if (collectionName == null || collectionName.length() == 0) {
         throw new MorphlineCompilationException("Parameter 'zkHost' requires that you also pass parameter 'collection'", config);
@@ -104,14 +102,12 @@ public class SolrLocator {
         throw new MorphlineRuntimeException(e);
       }
     } else {
-
-      if ( solrUrl == null && solrHomeDir !=null ) {
-          CoreContainer coreContainer = new CoreContainer(solrHomeDir);
-          coreContainer.load();
-          EmbeddedSolrServer embeddedSolrServer = new EmbeddedSolrServer(coreContainer,collectionName);
-          return new SolrServerDocumentLoader(embeddedSolrServer, batchSize);
+      if (solrUrl == null && solrHomeDir != null) {
+        CoreContainer coreContainer = new CoreContainer(solrHomeDir);
+        coreContainer.load();
+        EmbeddedSolrServer embeddedSolrServer = new EmbeddedSolrServer(coreContainer, collectionName);
+        return new SolrServerDocumentLoader(embeddedSolrServer, batchSize);
       }
-
       if (solrUrl == null || solrUrl.length() == 0) {
         throw new MorphlineCompilationException("Missing parameter 'solrUrl'", config);
       }

--- a/kite-morphlines/kite-morphlines-solr-core/src/test/java/org/kitesdk/morphline/solr/SolrLocatorTest.java
+++ b/kite-morphlines/kite-morphlines-solr-core/src/test/java/org/kitesdk/morphline/solr/SolrLocatorTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kitesdk.morphline.solr;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.solr.client.solrj.SolrServer;
+import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
+import org.junit.Test;
+import org.kitesdk.morphline.api.MorphlineContext;
+
+/** Verify that the correct Solr Server is selected based on parameters given the locator */
+public class SolrLocatorTest {
+
+  @Test
+  public void testSelectsEmbeddedSolrServer() {
+    //Solr locator should select EmbeddedSolrServer only solrHome is specified
+    SolrLocator solrLocator = new SolrLocator(new MorphlineContext.Builder().build());
+    solrLocator.setSolrHomeDir("ignored");
+    SolrServerDocumentLoader documentLoader = (SolrServerDocumentLoader)solrLocator.getLoader();
+    SolrServer solrServer = documentLoader.getSolrServer();
+    assertTrue(solrServer instanceof EmbeddedSolrServer);
+  }
+
+}
+


### PR DESCRIPTION
Small patch to enable use of EmbeddedSolrServer to build the index. Testing this on my MBP running everything locally revealed a 5x speedup. Useful in ETL flows building the index on shared storage or building and pushing later.
