### PR TITLE
CDK-496: Added the type parameter to the Datasets API

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/Dataset.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/Dataset.java
@@ -50,7 +50,7 @@ import javax.annotation.concurrent.Immutable;
 public interface Dataset<E> extends RefinableView<E> {
 
   /**
-   * Get the name of a {@code Dataset}. No guarantees are made about the format 
+   * Get the name of a {@code Dataset}. No guarantees are made about the format
    * of this name.
    */
   String getName();
@@ -111,7 +111,7 @@ public interface Dataset<E> extends RefinableView<E> {
    * Return a {@code URI} for this {@code Dataset}.
    *
    * The returned URI should load a copy of this dataset when passed to
-   * {@link Datasets#load(java.net.URI)}.
+   * {@link Datasets#load(java.net.URI, java.lang.Class)}.
    *
    * @return a URI that identifies this dataset
    */

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetRepository.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetRepository.java
@@ -61,6 +61,19 @@ public interface DatasetRepository {
   <E> Dataset<E> load(String name);
 
   /**
+   * Get the latest version of a named {@link Dataset}. If no dataset with the
+   * provided {@code name} exists, a {@link DatasetNotFoundException} is thrown.
+   *
+   * @param name The name of the dataset.
+   * @param type the Java type of entities in the dataset
+   * @throws DatasetNotFoundException if there is no data set named {@code name}
+   * @throws DatasetRepositoryException
+   *
+   * @since 0.15.0
+   */
+  <E> Dataset<E> load(String name, Class<E> type);
+
+  /**
    * Create a {@link Dataset} with the supplied {@code descriptor}. Depending on
    * the underlying dataset storage, some schema types or configurations might
    * not be supported. If you supply an illegal schema, the implementing class
@@ -89,6 +102,39 @@ public interface DatasetRepository {
    * @throws DatasetRepositoryException
    */
   <E> Dataset<E> create(String name, DatasetDescriptor descriptor);
+
+  /**
+   * Create a {@link Dataset} with the supplied {@code descriptor}. Depending on
+   * the underlying dataset storage, some schema types or configurations might
+   * not be supported. If you supply an illegal schema, the implementing class
+   * throws an exception. It is illegal to create more than one dataset with the
+   * same name. If you provide a duplicate name, the implementing class throws
+   * an exception.
+   *
+   * @param name        The fully qualified dataset name
+   * @param descriptor  A descriptor that describes the schema and other
+   *                    properties of the dataset
+   * @param type        the Java type of entities in the dataset
+   * @return The newly created dataset
+   * @throws IllegalArgumentException   if {@code name} or {@code descriptor}
+   *                                    is {@code null}
+   * @throws DatasetExistsException     if a {@code Dataset} named {@code name}
+   *                                    already exists.
+   * @throws ConcurrentSchemaModificationException
+   *                                    if the {@code Dataset}
+   *                                    schema is updated
+   *                                    concurrently.
+   * @throws IncompatibleSchemaException
+   *                                    if the schema is not
+   *                                    compatible with existing
+   *                                    datasets with shared
+   *                                    storage (for example, in the
+   *                                    same HBase table).
+   * @throws DatasetRepositoryException
+   * 
+   * @since 0.15.0
+   */
+  <E> Dataset<E> create(String name, DatasetDescriptor descriptor, Class<E> type);
 
   /**
    * Update an existing {@link Dataset} to reflect the supplied
@@ -124,6 +170,42 @@ public interface DatasetRepository {
    * @since 0.3.0
    */
   <E> Dataset<E> update(String name, DatasetDescriptor descriptor);
+
+  /**
+   * Update an existing {@link Dataset} to reflect the supplied
+   * {@code descriptor}. The common case is updating a dataset schema. Depending
+   * on the underlying dataset storage, some updates might not be supported,
+   * such as a change in format or partition strategy. Any attempt to make an
+   * unsupported or incompatible update results in an exception being thrown 
+   * and no changes made to the dataset.
+   *
+   * @param name       The fully qualified dataset name
+   * @param descriptor A descriptor that describes the schema and other
+   *                   properties of the dataset
+   * @param type        the Java type of entities in the dataset
+   * @return The updated dataset
+   * @throws IllegalArgumentException      if {@code name} is null
+   * @throws DatasetNotFoundException      if there is no data set named
+   *                                       {@code name}
+   * @throws UnsupportedOperationException if descriptor updates are not
+   *                                       supported by the implementation
+   * @throws ConcurrentSchemaModificationException
+   *                                       if the {@code Dataset}
+   *                                       schema is updated
+   *                                       concurrently
+   * @throws IncompatibleSchemaException
+   *                                    if the schema is not
+   *                                    compatible with
+   *                                    previous schemas,
+   *                                    or with existing
+   *                                    datasets with shared
+   *                                    storage (for example, in the
+   *                                    same HBase table).
+   * @throws DatasetRepositoryException
+   *
+   * @since 0.15.0
+   */
+  <E> Dataset<E> update(String name, DatasetDescriptor descriptor, Class<E> type);
 
   /**
    * Delete data for the {@link Dataset} named {@code name} and remove its

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/Datasets.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/Datasets.java
@@ -26,7 +26,6 @@ import org.apache.avro.Schema;
 import org.kitesdk.data.spi.Conversions;
 import org.kitesdk.data.spi.Pair;
 import org.kitesdk.data.spi.Registration;
-import org.kitesdk.data.spi.SchemaUtil;
 import org.kitesdk.data.spi.URIBuilder;
 
 /**
@@ -50,23 +49,27 @@ public class Datasets {
    * with "dataset:" or "view:".
    *
    * @param uri a {@code Dataset} or {@code View} URI.
+   * @param type the Java type of the entities in the dataset
    * @param <E> The type of entities stored in the {@code Dataset}.
    * @param <V> The type of {@code View} expected.
    * @return a {@code View} for the given URI.
    */
   @SuppressWarnings("unchecked")
-  public static <E, V extends View<E>> V load(URI uri) {
+  public static <E, V extends View<E>> V load(URI uri, Class<E> type) {
     boolean isView = VIEW_SCHEME.equals(uri.getScheme());
     Preconditions.checkArgument(isView ||
         DATASET_SCHEME.equals(uri.getScheme()),
         "Not a dataset or view URI: " + uri);
+    Preconditions.checkNotNull(type,
+        "The entity type can't be null, use Object.class to have the type"
+        + " determined by the schema.");
 
     Pair<DatasetRepository, Map<String, String>> pair =
         Registration.lookupDatasetUri(URI.create(uri.getRawSchemeSpecificPart()));
     DatasetRepository repo = pair.first();
     Map<String, String> uriOptions = pair.second();
 
-    Dataset<E> dataset = repo.load(uriOptions.get(DATASET_NAME_OPTION));
+    Dataset<E> dataset = repo.load(uriOptions.get(DATASET_NAME_OPTION), type);
 
     if (isView) {
       return Datasets.<E, V> view(dataset, uriOptions);
@@ -85,12 +88,13 @@ public class Datasets {
    * with "dataset:" or "view:".
    *
    * @param uriString a {@code Dataset} or {@code View} URI.
+   * @param type the Java type of the entities in the dataset
    * @param <E> The type of entities stored in the {@code Dataset}.
    * @param <V> The type of {@code View} expected.
    * @return a {@code View} for the given URI.
    */
-  public static <E, V extends View<E>> V load(String uriString) {
-    return Datasets.<E, V> load(URI.create(uriString));
+  public static <E, V extends View<E>> V load(String uriString, Class<E> type) {
+    return Datasets.<E, V> load(URI.create(uriString), type);
   }
 
   /**
@@ -137,23 +141,27 @@ public class Datasets {
    * with "dataset:" or "view:".
    *
    * @param uri a {@code Dataset} or {@code View} URI.
+   * @param type the Java type of the entities in the dataset
    * @param <E> The type of entities stored in the {@code Dataset}.
    * @param <V> The type of {@code Dataset} or {@code View} expected.
    * @return a newly created {@code Dataset} responsible for the given URI.
    */
   @SuppressWarnings("unchecked")
-  public static <E, V extends View<E>> V create(URI uri, DatasetDescriptor descriptor) {
+  public static <E, V extends View<E>> V create(URI uri, DatasetDescriptor descriptor, Class<E> type) {
     boolean isView = VIEW_SCHEME.equals(uri.getScheme());
     Preconditions.checkArgument(isView ||
             DATASET_SCHEME.equals(uri.getScheme()),
         "Not a dataset or view URI: " + uri);
+    Preconditions.checkNotNull(type,
+        "The entity type can't be null, use Object.class to have the type"
+        + " determined by the schema.");
 
     Pair<DatasetRepository, Map<String, String>> pair =
         Registration.lookupDatasetUri(URI.create(uri.getRawSchemeSpecificPart()));
     DatasetRepository repo = pair.first();
     Map<String, String> uriOptions = pair.second();
 
-    Dataset<E> dataset = repo.create(uriOptions.get(DATASET_NAME_OPTION), descriptor);
+    Dataset<E> dataset = repo.create(uriOptions.get(DATASET_NAME_OPTION), descriptor, type);
 
     if (isView) {
       return Datasets.<E, V> view(dataset, uriOptions);
@@ -169,12 +177,13 @@ public class Datasets {
    * with "dataset:" or "view:".
    *
    * @param uri a {@code Dataset} or {@code View} URI string.
+   * @param type the Java type of the entities in the dataset
    * @param <E> The type of entities stored in the {@code Dataset}.
    * @param <V> The type of {@code Dataset} or {@code View} expected.
    * @return a newly created {@code Dataset} responsible for the given URI.
    */
-  public static <E, V extends View<E>> V create(String uri, DatasetDescriptor descriptor) {
-    return Datasets.<E, V> create(URI.create(uri), descriptor);
+  public static <E, V extends View<E>> V create(String uri, DatasetDescriptor descriptor, Class<E> type) {
+    return Datasets.<E, V> create(URI.create(uri), descriptor, type);
   }
 
   /**
@@ -184,23 +193,27 @@ public class Datasets {
    * with "dataset:" or "view:".
    *
    * @param uri a {@code Dataset} or {@code View} URI.
+   * @param type the Java type of the entities in the dataset
    * @param <E> The type of entities stored in the {@code Dataset}.
    * @param <D> The type of {@code Dataset} expected.
    * @return a newly created {@code Dataset} responsible for the given URI.
    */
   @SuppressWarnings("unchecked")
   public static <E, D extends Dataset<E>> D update(
-      URI uri, DatasetDescriptor descriptor) {
+      URI uri, DatasetDescriptor descriptor, Class<E> type) {
     Preconditions.checkArgument(
         DATASET_SCHEME.equals(uri.getScheme()),
         "Not a dataset or view URI: " + uri);
+    Preconditions.checkNotNull(type,
+        "The entity type can't be null, use Object.class to have the type"
+        + " determined by the schema.");
 
     Pair<DatasetRepository, Map<String, String>> pair =
         Registration.lookupDatasetUri(URI.create(uri.getRawSchemeSpecificPart()));
     DatasetRepository repo = pair.first();
     Map<String, String> uriOptions = pair.second();
 
-    return (D) repo.update(uriOptions.get(DATASET_NAME_OPTION), descriptor);
+    return (D) repo.update(uriOptions.get(DATASET_NAME_OPTION), descriptor, type);
   }
 
   /**
@@ -210,12 +223,13 @@ public class Datasets {
    * with "dataset:" or "view:".
    *
    * @param uri a {@code Dataset} or {@code View} URI string.
+   * @param type the Java type of the entities in the dataset
    * @param <E> The type of entities stored in the {@code Dataset}.
    * @param <D> The type of {@code Dataset} expected.
    * @return a newly created {@code Dataset} responsible for the given URI.
    */
-  public static <E, D extends Dataset<E>> D update(String uri, DatasetDescriptor descriptor) {
-    return Datasets.<E, D> update(URI.create(uri), descriptor);
+  public static <E, D extends Dataset<E>> D update(String uri, DatasetDescriptor descriptor, Class<E> type) {
+    return Datasets.<E, D> update(URI.create(uri), descriptor, type);
   }
 
   /**
@@ -335,9 +349,8 @@ public class Datasets {
     for (Schema.Field field : schema.getFields()) {
       String name = field.name();
       if (uriOptions.containsKey(name)) {
-        view = view.with(name, Conversions.convert(
-            uriOptions.get(name),
-            SchemaUtil.getClassForType(field.schema().getType())));
+        view = view.with(name,
+            Conversions.convertField(uriOptions.get(name), schema, name));
       }
     }
     return (V) view;

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/RandomAccessDatasetRepository.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/RandomAccessDatasetRepository.java
@@ -41,10 +41,19 @@ public interface RandomAccessDatasetRepository extends DatasetRepository {
 
   @Override
   <E> RandomAccessDataset<E> load(String name);
+  
+  @Override
+  <E> RandomAccessDataset<E> load(String name, Class<E> type);
 
   @Override
   <E> RandomAccessDataset<E> create(String name, DatasetDescriptor descriptor);
 
   @Override
+  <E> RandomAccessDataset<E> create(String name, DatasetDescriptor descriptor, Class<E> type);
+
+  @Override
   <E> RandomAccessDataset<E> update(String name, DatasetDescriptor descriptor);
+
+  @Override
+  <E> RandomAccessDataset<E> update(String name, DatasetDescriptor descriptor, Class<E> type);
 }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/TypeNotFoundException.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/TypeNotFoundException.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2013 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kitesdk.data;
+
+/**
+ * <p>
+ * Exception thrown to indicate that there is a problem
+ * finding a given type.
+ * <p>
+ * @since 0.15.0
+ */
+public class TypeNotFoundException extends DatasetException {
+
+  public TypeNotFoundException(String message) {
+    super(message);
+  }
+
+  public TypeNotFoundException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public TypeNotFoundException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/View.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/View.java
@@ -97,4 +97,13 @@ public interface View<E> {
    * @since 0.12.0
    */
   public boolean deleteAll();
+
+  /**
+   * Get the runtime type of entities contained in this {@code View}.
+   * 
+   * @return the runtime type of entities contained in this view
+   * 
+   * @since 0.15.0
+   */
+  public Class<E> getType();
 }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractDataset.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractDataset.java
@@ -22,6 +22,7 @@ import org.kitesdk.data.DatasetReader;
 import org.kitesdk.data.DatasetWriter;
 import org.kitesdk.data.RefinableView;
 import javax.annotation.concurrent.Immutable;
+import org.apache.avro.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +38,11 @@ public abstract class AbstractDataset<E> implements Dataset<E>, RefinableView<E>
   private static final Logger LOG = LoggerFactory.getLogger(AbstractDataset.class);
 
   protected abstract RefinableView<E> asRefinableView();
+  protected final Class<E> type;
+
+  public AbstractDataset(Class<E> type, Schema schema) {
+    this.type = DataModelUtil.resolveType(type, schema);
+  }
 
   @Override
   public Dataset<E> getDataset() {
@@ -62,6 +68,11 @@ public abstract class AbstractDataset<E> implements Dataset<E>, RefinableView<E>
   @Override
   public boolean includes(E entity) {
     return true;
+  }
+
+  @Override
+  public Class<E> getType() {
+    return type;
   }
 
   @Override

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractDatasetRepository.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractDatasetRepository.java
@@ -15,6 +15,8 @@
  */
 package org.kitesdk.data.spi;
 
+import org.kitesdk.data.Dataset;
+import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.DatasetRepository;
 
 /**
@@ -26,4 +28,22 @@ import org.kitesdk.data.DatasetRepository;
  * need to implement deprecated methods.
  */
 public abstract class AbstractDatasetRepository implements DatasetRepository {
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <E> Dataset<E> create(String name, DatasetDescriptor descriptor) {
+    return (Dataset<E>) create(name, descriptor, Object.class);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <E> Dataset<E> load(String name) {
+    return (Dataset<E>) load(name, Object.class);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <E> Dataset<E> update(String name, DatasetDescriptor descriptor) {
+    return (Dataset<E>) update(name, descriptor, Object.class);
+  }
 }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/DataModelUtil.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/DataModelUtil.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2014 Cloudera, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data.spi;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Field;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.reflect.ReflectData;
+import org.apache.avro.reflect.ReflectDatumWriter;
+import org.apache.avro.specific.SpecificData;
+import org.apache.avro.specific.SpecificRecord;
+import org.kitesdk.data.IncompatibleSchemaException;
+
+/**
+ * Utilities for determining the appropriate data model at runtime.
+ *
+ * @since 0.15.0
+ */
+public class DataModelUtil {
+
+  /**
+   * Get the data model for the given type.
+   *
+   * @param <E> The entity type
+   * @param type The Java class of the entity type
+   * @return The appropriate data model for the given type
+   */
+  public static <E> GenericData getDataModelForType(Class<E> type) {
+    // Need to check if SpecificRecord first because specific records also
+    // implement GenericRecord
+    if (SpecificRecord.class.isAssignableFrom(type)) {
+      return new SpecificData(type.getClassLoader());
+    } else if (GenericRecord.class.isAssignableFrom(type)) {
+      return GenericData.get();
+    } else {
+      return ReflectData.get();
+    }
+  }
+
+  /**
+   * Get the DatumReader for the given type.
+   *
+   * @param <E> The entity type
+   * @param type The Java class of the entity type
+   * @param writerSchema The {@link Schema} for entities
+   * @return The DatumReader for the given type
+   */
+  @SuppressWarnings("unchecked")
+  public static <E> DatumReader<E> getDatumReaderForType(Class<E> type, Schema writerSchema) {
+    Schema readerSchema = getReaderSchema(type, writerSchema);
+    return getDataModelForType(type).createDatumReader(writerSchema, readerSchema);
+  }
+
+  /**
+   * Resolves the type based on the given schema. In most cases, the type should
+   * stay as is. However, if the type is Object, then that means that the old
+   * default behavior of determining the class from ReflectData#getClass(Schema)
+   * should be used. If a class can't be found, it will default to
+   * GenericData.Record.
+   *
+   * @param <E> The entity type
+   * @param type The Java class of the entity type
+   * @param schema The {@link Schema} for the entity
+   * @return The resolved Java class object
+   * @throws IncompatibleSchemaException The schema for the resolved type is not
+   * compatible with the schema that was given.
+   */
+  @SuppressWarnings("unchecked")
+  public static <E> Class<E> resolveType(Class<E> type, Schema schema) {
+    if (type == Object.class) {
+      type = ReflectData.get().getClass(schema);
+    }
+
+    if (type == null) {
+      type = (Class<E>) GenericData.Record.class;
+    }
+
+    Schema readerSchema = getReaderSchema(type, schema);
+    if (false == SchemaValidationUtil.canRead(schema, readerSchema)) {
+      throw new IncompatibleSchemaException(
+          String.format("The reader schema derived from %s is not compatible "
+          + "with the dataset's given writer schema.", type.toString()));
+    }
+
+    return type;
+  }
+
+  /**
+   * Get the reader schema based on the given type and writer schema.
+   *
+   * @param <E> The entity type
+   * @param type The Java class of the entity type
+   * @param writerSchema The writer {@link Schema} for the entity
+   * @return The reader schema based on the given type and writer schema
+   */
+  public static <E> Schema getReaderSchema(Class<E> type, Schema writerSchema) {
+    Schema readerSchema = writerSchema;
+    GenericData dataModel = getDataModelForType(type);
+
+    if (dataModel instanceof SpecificData) {
+      readerSchema = ((SpecificData)dataModel).getSchema(type);
+    }
+
+    return readerSchema;
+  }
+
+  /**
+   * Take the given writerField name and value and round trip the value through
+   * Avro serialization using the given writerSchema.
+   *
+   * @param <E> The entity type
+   * @param writerSchema The {@link Schema} for the entity
+   * @param type The Java class of the entity type
+   * @param name The name of the writerField
+   * @param value The value of the writerField
+   * @return The value after being serialized/deserialized
+   * @throws IOException There was an IO error with (de)serialization
+   */
+  @SuppressWarnings("unchecked")
+  public static <E> Object roundTripFieldValue(Schema writerSchema, Class<E> type,
+      String name, Object value) throws IOException {
+    GenericData dataModel = getDataModelForType(type);
+    Field writerField = writerSchema.getField(name);
+    Schema writerFieldSchema = writerField.schema();
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DatumWriter<Object> writer = new ReflectDatumWriter<Object>(writerFieldSchema);
+    BinaryEncoder binaryEncoder = EncoderFactory.get().binaryEncoder(out, null);
+    writer.write(value, binaryEncoder);
+    binaryEncoder.flush();
+
+    Field readerField = getReaderSchema(type, writerSchema).getField(name);
+    Schema readerFieldSchema = readerField.schema();
+
+    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+    DatumReader reader = dataModel.createDatumReader(writerFieldSchema, readerFieldSchema);
+    Object newValue = reader.read(null, DecoderFactory.get().binaryDecoder(in, null));
+
+    return newValue;
+  }
+
+  /**
+   * Take the given writerField name and array of values and round trip each value through
+   * Avro serialization using the given schema.
+   *
+   * @param <E> The entity type
+   * @param schema The {@link Schema} for the entity
+   * @param type The Java class of the entity type
+   * @param name The name of the writerField
+   * @param value The values of the writerField
+   * @return The values after being serialized/deserialized
+   * @throws IOException There was an IO error with (de)serialization
+   */
+  public static <E> Object[] roundTripFieldValues(Schema schema, Class<E> type,
+      String name, Object[] values) throws IOException {
+    Object[] result = new Object[values.length];
+    for (int i = 0; i < values.length; i++) {
+      result[i] = roundTripFieldValue(schema, type, name, values[i]);
+    }
+
+    return result;
+  }
+}

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/InputFormatAccessor.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/InputFormatAccessor.java
@@ -15,6 +15,7 @@
  */
 package org.kitesdk.data.spi;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.InputFormat;
 
 /**
@@ -24,5 +25,5 @@ public interface InputFormatAccessor<E> {
   /**
    * @return an input format for this dataset or view
    */
-  public InputFormat<E, Void> getInputFormat();
+  public InputFormat<E, Void> getInputFormat(Configuration conf);
 }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/SchemaValidationUtil.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/SchemaValidationUtil.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kitesdk.data.spi.filesystem;
+package org.kitesdk.data.spi;
 
 import java.io.IOException;
 import org.apache.avro.Schema;

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/URIBuilder.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/URIBuilder.java
@@ -29,27 +29,27 @@ import org.kitesdk.data.View;
 import com.google.common.collect.Maps;
 
 /**
- * Builds dataset and view URIs 
+ * Builds dataset and view URIs
  */
 public class URIBuilder {
   private URI repoUri;
   private String datasetName;
   // LinkedHashMap preserves the order so that constructed URIs are more predictable
-  private Map<String, String> equalityConstraints = Maps.newLinkedHashMap(); 
+  private Map<String, String> equalityConstraints = Maps.newLinkedHashMap();
 
   /**
    * Constructs a builder based on the given repository URI and {@link Dataset#getName() dataset name}.
-   * 
+   *
    * @param repoUri the {@link DatasetRepository} URI
    * @param datasetName the {@link Dataset} name
    */
   public URIBuilder(String repoUri, String datasetName) {
     this(URI.create(repoUri), datasetName);
   }
-  
+
   /**
    * Constructs a builder based on the given repository URI and {@link Dataset#getName() dataset name}.
-   * 
+   *
    * @param repoUri the {@link DatasetRepository} URI
    * @param datasetName the {@link Dataset} name
    */
@@ -59,11 +59,11 @@ public class URIBuilder {
     this.repoUri = repoUri;
     this.datasetName = datasetName;
   }
-  
+
   /**
    * Adds a view constraint equivalent to
    * {@link org.kitesdk.data.RefinableView#with(String, Object...)}
-   * 
+   *
    * @param name the field name of the Entity
    * @param value the field value
    * @return this builder
@@ -72,12 +72,12 @@ public class URIBuilder {
     equalityConstraints.put(name, Conversions.makeString(value));
     return this;
   }
-  
+
   /**
    * Returns the URI encompassing the given constraints. The referenced
    * {@link Dataset} or {@link View} may be loaded again with
-   * {@link Datasets#load(URI)}.
-   * 
+   * {@link Datasets#load(java.net.URI, java.lang.Class)}.
+   *
    * @return the URI
    */
   public URI build() {

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVInputFormat.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVInputFormat.java
@@ -28,13 +28,17 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 import org.kitesdk.compat.Hadoop;
 import org.kitesdk.data.DatasetDescriptor;
-import org.kitesdk.data.DatasetReader;
 
 class CSVInputFormat<E> extends FileInputFormat<E, Void> {
   private DatasetDescriptor descriptor;
+  private Class<E> type;
 
   public void setDescriptor(DatasetDescriptor descriptor) {
     this.descriptor = descriptor;
+  }
+
+  public void setType(Class<E> type) {
+    this.type = type;
   }
 
   @Override
@@ -55,7 +59,7 @@ class CSVInputFormat<E> extends FileInputFormat<E, Void> {
         .getConfiguration.invoke(context);
     Path path = ((FileSplit) split).getPath();
     CSVFileReader<E> reader = new CSVFileReader<E>(
-        path.getFileSystem(conf), path, descriptor);
+        path.getFileSystem(conf), path, descriptor, type);
     reader.initialize();
     return reader.asRecordReader();
   }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemDatasetRepository.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemDatasetRepository.java
@@ -15,6 +15,7 @@
  */
 package org.kitesdk.data.spi.filesystem;
 
+import org.kitesdk.data.spi.SchemaValidationUtil;
 import org.kitesdk.data.Dataset;
 import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.DatasetException;
@@ -119,7 +120,7 @@ public class FileSystemDatasetRepository extends AbstractDatasetRepository
   }
 
   @Override
-  public <E> Dataset<E> create(String name, DatasetDescriptor descriptor) {
+  public <E> Dataset<E> create(String name, DatasetDescriptor descriptor, Class<E> type) {
     Preconditions.checkNotNull(name, "Dataset name cannot be null");
     Preconditions.checkNotNull(descriptor, "Descriptor cannot be null");
 
@@ -137,10 +138,11 @@ public class FileSystemDatasetRepository extends AbstractDatasetRepository
     LOG.debug("Created dataset: {} schema: {} datasetPath: {}", new Object[] {
         name, newDescriptor.getSchema(), newDescriptor.getLocation() });
 
-    return new FileSystemDataset.Builder()
+    return new FileSystemDataset.Builder<E>()
         .name(name)
         .configuration(conf)
         .descriptor(newDescriptor)
+        .type(type)
         .uri(new URIBuilder(getUri(), name).build())
         .partitionKey(newDescriptor.isPartitioned() ?
             org.kitesdk.data.impl.Accessor.getDefault().newPartitionKey() :
@@ -150,7 +152,7 @@ public class FileSystemDatasetRepository extends AbstractDatasetRepository
   }
 
   @Override
-  public <E> Dataset<E> update(String name, DatasetDescriptor descriptor) {
+  public <E> Dataset<E> update(String name, DatasetDescriptor descriptor, Class<E> type) {
     Preconditions.checkNotNull(name, "Dataset name cannot be null");
     Preconditions.checkNotNull(descriptor, "Descriptor cannot be null");
 
@@ -193,10 +195,11 @@ public class FileSystemDatasetRepository extends AbstractDatasetRepository
     LOG.debug("Updated dataset: {} schema: {} location: {}", new Object[] {
         name, updatedDescriptor.getSchema(), updatedDescriptor.getLocation() });
 
-    return new FileSystemDataset.Builder()
+    return new FileSystemDataset.Builder<E>()
         .name(name)
         .configuration(conf)
         .descriptor(updatedDescriptor)
+        .type(type)
         .uri(new URIBuilder(getUri(), name).build())
         .partitionKey(updatedDescriptor.isPartitioned() ?
             org.kitesdk.data.impl.Accessor.getDefault().newPartitionKey() :
@@ -206,17 +209,18 @@ public class FileSystemDatasetRepository extends AbstractDatasetRepository
   }
 
   @Override
-  public <E> Dataset<E> load(String name) {
+  public <E> Dataset<E> load(String name, Class<E> type) {
     Preconditions.checkNotNull(name, "Dataset name cannot be null");
 
     LOG.debug("Loading dataset: {}", name);
 
     DatasetDescriptor descriptor = metadataProvider.load(name);
 
-    FileSystemDataset<E> ds = new FileSystemDataset.Builder()
+    FileSystemDataset<E> ds = new FileSystemDataset.Builder<E>()
         .name(name)
         .configuration(conf)
         .descriptor(descriptor)
+        .type(type)
         .uri(new URIBuilder(getUri(), name).build())
         .partitionKey(descriptor.isPartitioned() ?
             org.kitesdk.data.impl.Accessor.getDefault().newPartitionKey() :

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemView.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemView.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.fs.Path;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,8 +61,8 @@ class FileSystemView<E> extends AbstractRefinableView<E> implements InputFormatA
   private final FileSystem fs;
   private final Path root;
 
-  FileSystemView(FileSystemDataset<E> dataset) {
-    super(dataset);
+  FileSystemView(FileSystemDataset<E> dataset, Class<E> type) {
+    super(dataset, type);
     this.fs = dataset.getFileSystem();
     this.root = dataset.getDirectory();
   }
@@ -80,7 +81,7 @@ class FileSystemView<E> extends AbstractRefinableView<E> implements InputFormatA
   @Override
   public DatasetReader<E> newReader() {
     AbstractDatasetReader<E> reader = new MultiFileDatasetReader<E>(
-        fs, pathIterator(), dataset.getDescriptor(), constraints);
+        fs, pathIterator(), dataset.getDescriptor(), constraints, type);
     reader.initialize();
     return reader;
   }
@@ -113,8 +114,8 @@ class FileSystemView<E> extends AbstractRefinableView<E> implements InputFormatA
   }
 
   @Override
-  public InputFormat<E, Void> getInputFormat() {
-    return new FileSystemViewKeyInputFormat<E>(this);
+  public InputFormat<E, Void> getInputFormat(Configuration conf) {
+    return new FileSystemViewKeyInputFormat<E>(this, conf);
   }
 
   PathIterator pathIterator() {

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/ParquetFileSystemDatasetReader.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/ParquetFileSystemDatasetReader.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 import java.io.EOFException;
 import java.io.IOException;
 import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -35,6 +36,7 @@ class ParquetFileSystemDatasetReader<E extends IndexedRecord> extends AbstractDa
   private FileSystem fileSystem;
   private Path path;
   private Schema schema;
+  private Class<E> type;
 
   private ReaderWriterState state;
   private AvroParquetReader<E> reader;
@@ -44,14 +46,19 @@ class ParquetFileSystemDatasetReader<E extends IndexedRecord> extends AbstractDa
   private static final Logger LOG = LoggerFactory
     .getLogger(ParquetFileSystemDatasetReader.class);
 
-  public ParquetFileSystemDatasetReader(FileSystem fileSystem, Path path, Schema schema) {
+  public ParquetFileSystemDatasetReader(FileSystem fileSystem, Path path,
+      Schema schema, Class<E> type) {
     Preconditions.checkArgument(fileSystem != null, "FileSystem cannot be null");
     Preconditions.checkArgument(path != null, "Path cannot be null");
     Preconditions.checkArgument(schema != null, "Schema cannot be null");
+    Preconditions.checkArgument(IndexedRecord.class.isAssignableFrom(type) ||
+        (Class<?>)type == Object.class,
+        "The entity type must implement IndexedRecord");
 
     this.fileSystem = fileSystem;
     this.path = path;
     this.schema = schema;
+    this.type = type;
 
     this.state = ReaderWriterState.NEW;
   }

--- a/kite-data/kite-data-core/src/test/avro/incompatible_event.avsc
+++ b/kite-data/kite-data-core/src/test/avro/incompatible_event.avsc
@@ -1,0 +1,18 @@
+{
+  "name": "IncompatibleEvent",
+  "namespace": "org.kitesdk.data.event",
+  "type": "record",
+  "doc": "An incompatible projection of standard event type for logging, based on the paper 'The Unified Logging Infrastructure for Data Analytics at Twitter' by Lee et al, http://vldb.org/pvldb/vol5/p1771_georgelee_vldb2012.pdf",
+  "fields": [
+    {
+      "name": "userId",
+      "type": "string",
+      "doc": "A unique identifier for the user. Required."
+    },
+    {
+      "name": "sessionId",
+      "type": "string",
+      "doc": "A unique identifier for the session. Required."
+    }
+  ]
+}

--- a/kite-data/kite-data-core/src/test/avro/small_event.avsc
+++ b/kite-data/kite-data-core/src/test/avro/small_event.avsc
@@ -1,0 +1,18 @@
+{
+  "name": "SmallEvent",
+  "namespace": "org.kitesdk.data.event",
+  "type": "record",
+  "doc": "A projection of standard event type for logging, based on the paper 'The Unified Logging Infrastructure for Data Analytics at Twitter' by Lee et al, http://vldb.org/pvldb/vol5/p1771_georgelee_vldb2012.pdf",
+  "fields": [
+    {
+      "name": "user_id",
+      "type": "long",
+      "doc": "A unique identifier for the user. Required."
+    },
+    {
+      "name": "session_id",
+      "type": "string",
+      "doc": "A unique identifier for the session. Required."
+    }
+  ]
+}

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/TestDatasets.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/TestDatasets.java
@@ -51,16 +51,27 @@ public class TestDatasets {
         .build();
 
     Dataset<Object> expected = mock(Dataset.class);
-    when(repo.create("test", descriptor)).thenReturn(expected);
+    when(repo.create("test", descriptor, Object.class)).thenReturn(expected);
 
-    Dataset<Object> ds = Datasets.create(datasetUri, descriptor);
+    Dataset<Object> ds = Datasets.<Object, Dataset<Object>>
+        create(datasetUri, descriptor, Object.class);
 
-    verify(repo).create("test", descriptor);
+    verify(repo).create("test", descriptor, Object.class);
     verifyNoMoreInteractions(repo);
 
     verifyNoMoreInteractions(expected);
 
     Assert.assertEquals(expected, ds);
+  }
+
+  @Test(expected=NullPointerException.class)
+  public void testCreateNullType() {
+    URI datasetUri = new URIBuilder(repoUri, "test").build();
+    DatasetDescriptor descriptor = new DatasetDescriptor.Builder()
+        .schemaLiteral("\"string\"")
+        .build();
+
+    Datasets.<Object, Dataset<Object>> create(datasetUri, descriptor, null);
   }
 
   @Test
@@ -71,11 +82,12 @@ public class TestDatasets {
         .build();
 
     Dataset<Object> expected = mock(Dataset.class);
-    when(repo.create("test", descriptor)).thenReturn(expected);
+    when(repo.create("test", descriptor, Object.class)).thenReturn(expected);
 
-    Dataset<Object> ds = Datasets.create(datasetUri.toString(), descriptor);
+    Dataset<Object> ds = Datasets.<Object, Dataset<Object>>
+        create(datasetUri.toString(), descriptor, Object.class);
 
-    verify(repo).create("test", descriptor);
+    verify(repo).create("test", descriptor, Object.class);
     verifyNoMoreInteractions(repo);
 
     verifyNoMoreInteractions(expected);
@@ -90,7 +102,7 @@ public class TestDatasets {
         .build();
 
     Dataset<Object> ds = mock(Dataset.class);
-    when(repo.create("test", descriptor)).thenReturn(ds);
+    when(repo.create("test", descriptor, Object.class)).thenReturn(ds);
     when(ds.getDescriptor()).thenReturn(descriptor);
 
     RefinableView<Object> userView = mock(RefinableView.class);
@@ -106,9 +118,10 @@ public class TestDatasets {
         .with("ignoredOption", "abc")
         .build();
 
-    RefinableView<Object> view = Datasets.create(datasetUri, descriptor);
+    RefinableView<Object> view = Datasets.<Object, RefinableView<Object>>
+        create(datasetUri, descriptor, Object.class);
 
-    verify(repo).create("test", descriptor);
+    verify(repo).create("test", descriptor, Object.class);
     verifyNoMoreInteractions(repo);
 
     verify(ds).getDescriptor();
@@ -130,7 +143,7 @@ public class TestDatasets {
         .build();
 
     Dataset<Object> ds = mock(Dataset.class);
-    when(repo.create("test", descriptor)).thenReturn(ds);
+    when(repo.create("test", descriptor, Object.class)).thenReturn(ds);
     when(ds.getDescriptor()).thenReturn(descriptor);
 
     RefinableView<Object> userView = mock(RefinableView.class);
@@ -146,10 +159,10 @@ public class TestDatasets {
         .with("ignoredOption", "abc")
         .build();
 
-    RefinableView<Object> view = Datasets
-        .create(datasetUri.toString(), descriptor);
+    RefinableView<Object> view = Datasets.<Object, RefinableView<Object>>
+        create(datasetUri.toString(), descriptor, Object.class);
 
-    verify(repo).create("test", descriptor);
+    verify(repo).create("test", descriptor, Object.class);
     verifyNoMoreInteractions(repo);
 
     verify(ds).getDescriptor();
@@ -167,13 +180,14 @@ public class TestDatasets {
   @Test
   public void testLoad() {
     Dataset<Object> expected = mock(Dataset.class);
-    when(repo.load("test")).thenReturn(expected);
+    when(repo.load("test", Object.class)).thenReturn(expected);
 
     URI datasetUri = new URIBuilder(repoUri, "test").build();
 
-    Dataset<Object> ds = Datasets.load(datasetUri);
+    Dataset<Object> ds = Datasets.<Object, Dataset<Object>>
+        load(datasetUri, Object.class);
 
-    verify(repo).load("test");
+    verify(repo).load("test", Object.class);
     verifyNoMoreInteractions(repo);
 
     verifyNoMoreInteractions(expected);
@@ -181,16 +195,24 @@ public class TestDatasets {
     Assert.assertEquals(expected, ds);
   }
 
+  @Test(expected=NullPointerException.class)
+  public void testLoadNullType() {
+    URI datasetUri = new URIBuilder(repoUri, "test").build();
+
+    Datasets.<Object, Dataset<Object>> load(datasetUri, null);
+  }
+
   @Test
   public void testLoadStringUri() {
     Dataset<Object> expected = mock(Dataset.class);
-    when(repo.load("test")).thenReturn(expected);
+    when(repo.load("test", Object.class)).thenReturn(expected);
 
     URI datasetUri = new URIBuilder(repoUri, "test").build();
 
-    Dataset<Object> ds = Datasets.load(datasetUri);
+    Dataset<Object> ds = Datasets.<Object, Dataset<Object>>
+        load(datasetUri, Object.class);
 
-    verify(repo).load("test");
+    verify(repo).load("test", Object.class);
     verifyNoMoreInteractions(repo);
 
     verifyNoMoreInteractions(expected);
@@ -205,7 +227,7 @@ public class TestDatasets {
         .build();
 
     Dataset<Object> ds = mock(Dataset.class);
-    when(repo.load("test")).thenReturn(ds);
+    when(repo.load("test", Object.class)).thenReturn(ds);
     when(ds.getDescriptor()).thenReturn(descriptor);
 
     RefinableView<Object> userView = mock(RefinableView.class);
@@ -221,9 +243,10 @@ public class TestDatasets {
         .with("ignoredOption", "abc")
         .build();
 
-    RefinableView<Object> view = Datasets.load(datasetUri);
+    RefinableView<Object> view = Datasets.<Object, RefinableView<Object>>
+        load(datasetUri, Object.class);
 
-    verify(repo).load("test");
+    verify(repo).load("test", Object.class);
     verifyNoMoreInteractions(repo);
 
     verify(ds).getDescriptor();
@@ -245,7 +268,7 @@ public class TestDatasets {
         .build();
 
     Dataset<Object> ds = mock(Dataset.class);
-    when(repo.load("test")).thenReturn(ds);
+    when(repo.load("test", Object.class)).thenReturn(ds);
     when(ds.getDescriptor()).thenReturn(descriptor);
 
     RefinableView<Object> userView = mock(RefinableView.class);
@@ -261,9 +284,10 @@ public class TestDatasets {
         .with("ignoredOption", "abc")
         .build();
 
-    RefinableView<Object> view = Datasets.load(datasetUri.toString());
+    RefinableView<Object> view = Datasets.<Object, RefinableView<Object>>
+        load(datasetUri.toString(), Object.class);
 
-    verify(repo).load("test");
+    verify(repo).load("test", Object.class);
     verifyNoMoreInteractions(repo);
 
     verify(ds).getDescriptor();
@@ -364,16 +388,27 @@ public class TestDatasets {
         .build();
 
     Dataset<Object> expected = mock(Dataset.class);
-    when(repo.update("test", descriptor)).thenReturn(expected);
+    when(repo.update("test", descriptor, Object.class)).thenReturn(expected);
 
-    Dataset<Object> ds = Datasets.update(datasetUri, descriptor);
+    Dataset<Object> ds = Datasets.<Object, Dataset<Object>>
+        update(datasetUri, descriptor, Object.class);
 
-    verify(repo).update("test", descriptor);
+    verify(repo).update("test", descriptor, Object.class);
     verifyNoMoreInteractions(repo);
 
     verifyNoMoreInteractions(expected);
 
     Assert.assertEquals(expected, ds);
+  }
+
+  @Test(expected=NullPointerException.class)
+  public void testUpdateNullType() {
+    URI datasetUri = new URIBuilder(repoUri, "test").build();
+    DatasetDescriptor descriptor = new DatasetDescriptor.Builder()
+        .schemaLiteral("\"string\"")
+        .build();
+
+    Datasets.<Object, Dataset<Object>> update(datasetUri, descriptor, null);
   }
 
   @Test
@@ -384,11 +419,12 @@ public class TestDatasets {
         .build();
 
     Dataset<Object> expected = mock(Dataset.class);
-    when(repo.update("test", descriptor)).thenReturn(expected);
+    when(repo.update("test", descriptor, Object.class)).thenReturn(expected);
 
-    Dataset<Object> ds = Datasets.update(datasetUri.toString(), descriptor);
+    Dataset<Object> ds = Datasets.<Object, Dataset<Object>>
+        update(datasetUri.toString(), descriptor, Object.class);
 
-    verify(repo).update("test", descriptor);
+    verify(repo).update("test", descriptor, Object.class);
     verifyNoMoreInteractions(repo);
 
     verifyNoMoreInteractions(expected);
@@ -409,7 +445,7 @@ public class TestDatasets {
         IllegalArgumentException.class, new Runnable() {
           @Override
           public void run() {
-            Datasets.<Object, Dataset<Object>>update(datasetUri, descriptor);
+            Datasets.<Object, Dataset<Object>>update(datasetUri, descriptor, Object.class);
           }
         });
 

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/TestSchemaValidationUtil.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/TestSchemaValidationUtil.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kitesdk.data.spi.filesystem;
+package org.kitesdk.data.spi;
 
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/DatasetTestUtilities.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/DatasetTestUtilities.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.avro.util.Utf8;
 import org.junit.Assert;
 import org.kitesdk.data.View;
 import org.kitesdk.data.spi.InitializeAccessor;
@@ -109,7 +110,7 @@ public class DatasetTestUtilities {
         new RecordValidator<GenericData.Record>() {
           @Override
           public void validate(GenericData.Record record, int recordNum) {
-            Assert.assertTrue(usernames.remove((String) record.get("username")));
+            Assert.assertTrue(usernames.remove(record.get("username").toString()));
             for (String field : fields) {
               Assert.assertNotNull(record.get(field));
             }
@@ -128,8 +129,8 @@ public class DatasetTestUtilities {
       usernames.add("test-" + i);
     }
     for (GenericData.Record actualRecord : records) {
-      Assert.assertTrue(usernames.remove((String) actualRecord
-          .get("username")));
+      Assert.assertTrue(usernames.remove(actualRecord
+          .get("username").toString()));
       Assert.assertNotNull(actualRecord.get("email"));
     }
     Assert.assertTrue(usernames.isEmpty());

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestCSVFileReader.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestCSVFileReader.java
@@ -119,7 +119,8 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
         .property("kite.csv.has-header", "true")
         .schema(VALIDATOR_SCHEMA)
         .build();
-    return new CSVFileReader<GenericData.Record>(localfs, validatorFile, desc);
+    return new CSVFileReader<GenericData.Record>(localfs, validatorFile, desc,
+        GenericData.Record.class);
   }
 
   @Override
@@ -145,7 +146,7 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
     final DatasetDescriptor desc = new DatasetDescriptor.Builder()
         .schema(SchemaBuilder.array().items().stringType())
         .build();
-    new CSVFileReader(localfs, csvFile, desc);
+    new CSVFileReader<GenericData.Record>(localfs, csvFile, desc, GenericData.Record.class);
   }
 
   @Test
@@ -154,7 +155,8 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
         .schema(STRINGS)
         .build();
     final CSVFileReader<GenericData.Record> reader =
-        new CSVFileReader<GenericData.Record>(localfs, csvFile, desc);
+        new CSVFileReader<GenericData.Record>(localfs, csvFile, desc,
+            GenericData.Record.class);
 
     reader.initialize();
     Assert.assertTrue(reader.hasNext());
@@ -189,7 +191,8 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
         .schema(STRINGS)
         .build();
     final CSVFileReader<GenericData.Record> reader =
-        new CSVFileReader<GenericData.Record>(localfs, tsvFile, desc);
+        new CSVFileReader<GenericData.Record>(localfs, tsvFile, desc,
+            GenericData.Record.class);
 
     reader.initialize();
     Assert.assertTrue(reader.hasNext());
@@ -224,7 +227,8 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
         .schema(STRINGS)
         .build();
     final CSVFileReader<GenericData.Record> reader =
-        new CSVFileReader<GenericData.Record>(localfs, tsvFile, desc);
+        new CSVFileReader<GenericData.Record>(localfs, tsvFile, desc,
+            GenericData.Record.class);
 
     reader.initialize();
     Assert.assertTrue(reader.hasNext());
@@ -257,7 +261,8 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
         .schema(SCHEMA)
         .build();
     final CSVFileReader<GenericData.Record> reader =
-        new CSVFileReader<GenericData.Record>(localfs, csvFile, desc);
+        new CSVFileReader<GenericData.Record>(localfs, csvFile, desc,
+            GenericData.Record.class);
 
     reader.initialize();
     Assert.assertTrue(reader.hasNext());
@@ -292,7 +297,7 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
         .schema(BEAN_SCHEMA)
         .build();
     final CSVFileReader<TestBean> reader =
-        new CSVFileReader<TestBean>(localfs, csvFile, desc);
+        new CSVFileReader<TestBean>(localfs, csvFile, desc, TestBean.class);
 
     reader.initialize();
     Assert.assertTrue(reader.hasNext());

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemDataset.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemDataset.java
@@ -91,7 +91,7 @@ public class TestFileSystemDataset extends MiniDFSTest {
 
   @Test
   public void testWriteAndRead() throws IOException {
-    FileSystemDataset<Record> ds = new FileSystemDataset.Builder()
+    FileSystemDataset<Record> ds = new FileSystemDataset.Builder<Record>()
         .name("test")
         .configuration(getConfiguration())
         .descriptor(new DatasetDescriptor.Builder()
@@ -99,6 +99,7 @@ public class TestFileSystemDataset extends MiniDFSTest {
             .format(format)
             .location(testDirectory)
             .build())
+        .type(Record.class)
         .build();
 
     Assert.assertFalse("Dataset is not partitioned", ds.getDescriptor()
@@ -114,7 +115,7 @@ public class TestFileSystemDataset extends MiniDFSTest {
     PartitionStrategy partitionStrategy = new PartitionStrategy.Builder().hash(
       "username", 2).build();
 
-    FileSystemDataset<Record> ds = new FileSystemDataset.Builder()
+    FileSystemDataset<Record> ds = new FileSystemDataset.Builder<Record>()
         .name("partitioned-users")
         .configuration(getConfiguration())
         .descriptor(new DatasetDescriptor.Builder()
@@ -123,6 +124,7 @@ public class TestFileSystemDataset extends MiniDFSTest {
             .location(testDirectory)
             .partitionStrategy(partitionStrategy)
             .build())
+        .type(Record.class)
         .build();
 
     Assert.assertTrue("Dataset is partitioned", ds.getDescriptor()
@@ -159,7 +161,7 @@ public class TestFileSystemDataset extends MiniDFSTest {
     PartitionStrategy partitionStrategy = new PartitionStrategy.Builder()
       .hash("username", 2).hash("email", 3).build();
 
-    FileSystemDataset<Record> ds = new FileSystemDataset.Builder()
+    FileSystemDataset<Record> ds = new FileSystemDataset.Builder<Record>()
         .name("partitioned-users")
         .configuration(getConfiguration())
         .descriptor(new DatasetDescriptor.Builder()
@@ -168,6 +170,7 @@ public class TestFileSystemDataset extends MiniDFSTest {
             .location(testDirectory)
             .partitionStrategy(partitionStrategy)
             .build())
+        .type(Record.class)
         .build();
 
     Assert.assertTrue("Dataset is partitioned", ds.getDescriptor()
@@ -213,7 +216,7 @@ public class TestFileSystemDataset extends MiniDFSTest {
     PartitionStrategy partitionStrategy = new PartitionStrategy.Builder().hash(
       "username", 2).build();
 
-    FileSystemDataset<Record> ds = new FileSystemDataset.Builder()
+    FileSystemDataset<Record> ds = new FileSystemDataset.Builder<Record>()
         .name("partitioned-users")
         .configuration(getConfiguration())
         .descriptor(new DatasetDescriptor.Builder()
@@ -222,6 +225,7 @@ public class TestFileSystemDataset extends MiniDFSTest {
             .location(testDirectory)
             .partitionStrategy(partitionStrategy)
             .build())
+        .type(Record.class)
         .build();
 
     Assert
@@ -234,7 +238,7 @@ public class TestFileSystemDataset extends MiniDFSTest {
     PartitionStrategy partitionStrategy = new PartitionStrategy.Builder()
       .hash("username", "username_part", 2).hash("email", 3).build();
 
-    FileSystemDataset<Record> ds = new FileSystemDataset.Builder()
+    FileSystemDataset<Record> ds = new FileSystemDataset.Builder<Record>()
         .name("partitioned-users")
         .configuration(getConfiguration())
         .descriptor(new DatasetDescriptor.Builder()
@@ -243,6 +247,7 @@ public class TestFileSystemDataset extends MiniDFSTest {
             .location(testDirectory)
             .partitionStrategy(partitionStrategy)
             .build())
+        .type(Record.class)
         .build();
 
     PartitionKey key = Accessor.getDefault().newPartitionKey(1);
@@ -261,7 +266,7 @@ public class TestFileSystemDataset extends MiniDFSTest {
     PartitionStrategy partitionStrategy = new PartitionStrategy.Builder()
       .hash("username", 2).build();
 
-    FileSystemDataset<Record> ds = new FileSystemDataset.Builder()
+    FileSystemDataset<Record> ds = new FileSystemDataset.Builder<Record>()
         .name("partitioned-users")
         .configuration(getConfiguration())
         .descriptor(new DatasetDescriptor.Builder()
@@ -270,6 +275,7 @@ public class TestFileSystemDataset extends MiniDFSTest {
             .location(testDirectory)
             .partitionStrategy(partitionStrategy)
             .build())
+        .type(Record.class)
         .build();
 
     writeTestUsers(ds, 10);
@@ -303,7 +309,7 @@ public class TestFileSystemDataset extends MiniDFSTest {
     PartitionStrategy partitionStrategy = new PartitionStrategy.Builder().hash(
         "username", 2).build();
 
-    FileSystemDataset<Record> ds = new FileSystemDataset.Builder()
+    FileSystemDataset<Record> ds = new FileSystemDataset.Builder<Record>()
         .name("partitioned-users")
         .configuration(getConfiguration())
         .descriptor(new DatasetDescriptor.Builder()
@@ -312,6 +318,7 @@ public class TestFileSystemDataset extends MiniDFSTest {
             .location(testDirectory)
             .partitionStrategy(partitionStrategy)
             .build())
+        .type(Record.class)
         .build();
 
     writeTestUsers(ds, 10);
@@ -320,7 +327,7 @@ public class TestFileSystemDataset extends MiniDFSTest {
     Path newTestDirectory = fileSystem.makeQualified(
         new Path(Files.createTempDir().getAbsolutePath()));
 
-    FileSystemDataset<Record> dsUpdate = new FileSystemDataset.Builder()
+    FileSystemDataset<Record> dsUpdate = new FileSystemDataset.Builder<Record>()
         .name("partitioned-users")
         .configuration(getConfiguration())
         .descriptor(new DatasetDescriptor.Builder()
@@ -329,6 +336,7 @@ public class TestFileSystemDataset extends MiniDFSTest {
             .location(newTestDirectory)
             .partitionStrategy(partitionStrategy)
             .build())
+        .type(Record.class)
         .build();
 
     writeTestUsers(dsUpdate, 5, 10);
@@ -343,7 +351,7 @@ public class TestFileSystemDataset extends MiniDFSTest {
 
   @Test(expected = DatasetRepositoryException.class)
   public void testCannotMergeDatasetsWithDifferentFormats() throws IOException {
-    FileSystemDataset<Record> ds = new FileSystemDataset.Builder()
+    FileSystemDataset<Record> ds = new FileSystemDataset.Builder<Record>()
         .name("users")
         .configuration(getConfiguration())
         .descriptor(new DatasetDescriptor.Builder()
@@ -351,8 +359,9 @@ public class TestFileSystemDataset extends MiniDFSTest {
             .format(Formats.AVRO)
             .location(testDirectory)
             .build())
+        .type(Record.class)
         .build();
-    FileSystemDataset<Record> dsUpdate = new FileSystemDataset.Builder()
+    FileSystemDataset<Record> dsUpdate = new FileSystemDataset.Builder<Record>()
         .name("users")
         .configuration(getConfiguration())
         .descriptor(new DatasetDescriptor.Builder()
@@ -360,13 +369,14 @@ public class TestFileSystemDataset extends MiniDFSTest {
             .format(Formats.PARQUET)
             .location(testDirectory)
             .build())
+        .type(Record.class)
         .build();
     ds.merge(dsUpdate);
   }
 
   @Test(expected = DatasetRepositoryException.class)
   public void testCannotMergeDatasetsWithDifferentPartitionStrategies() throws IOException {
-    FileSystemDataset<Record> ds = new FileSystemDataset.Builder()
+    FileSystemDataset<Record> ds = new FileSystemDataset.Builder<Record>()
         .name("users")
         .configuration(getConfiguration())
         .descriptor(new DatasetDescriptor.Builder()
@@ -375,8 +385,9 @@ public class TestFileSystemDataset extends MiniDFSTest {
             .partitionStrategy(new PartitionStrategy.Builder()
                 .hash("username", 2).build())
             .build())
+        .type(Record.class)
         .build();
-    FileSystemDataset<Record> dsUpdate = new FileSystemDataset.Builder()
+    FileSystemDataset<Record> dsUpdate = new FileSystemDataset.Builder<Record>()
         .name("users")
         .configuration(getConfiguration())
         .descriptor(new DatasetDescriptor.Builder()
@@ -385,34 +396,37 @@ public class TestFileSystemDataset extends MiniDFSTest {
             .partitionStrategy(new PartitionStrategy.Builder()
                 .hash("username", 2).hash("email", 3).build())
             .build())
+        .type(Record.class)
         .build();
     ds.merge(dsUpdate);
   }
 
   @Test(expected = DatasetRepositoryException.class)
   public void testCannotMergeDatasetsWithDifferentSchemas() throws IOException {
-    FileSystemDataset<Record> ds = new FileSystemDataset.Builder()
+    FileSystemDataset<Record> ds = new FileSystemDataset.Builder<Record>()
         .name("users")
         .configuration(getConfiguration())
         .descriptor(new DatasetDescriptor.Builder()
             .schema(STRING_SCHEMA)
             .location(testDirectory)
             .build())
+        .type(Record.class)
         .build();
-    FileSystemDataset<Record> dsUpdate = new FileSystemDataset.Builder()
+    FileSystemDataset<Record> dsUpdate = new FileSystemDataset.Builder<Record>()
         .name("users")
         .configuration(getConfiguration())
         .descriptor(new DatasetDescriptor.Builder()
             .schema(USER_SCHEMA)
             .location(testDirectory)
             .build())
+        .type(Record.class)
         .build();
     ds.merge(dsUpdate);
   }
 
   @Test
   public void testPathIterator_Directory() {
-    FileSystemDataset<Record> ds = new FileSystemDataset.Builder()
+    FileSystemDataset<Record> ds = new FileSystemDataset.Builder<Record>()
         .name("users")
         .configuration(getConfiguration())
         .descriptor(new DatasetDescriptor.Builder()
@@ -420,6 +434,7 @@ public class TestFileSystemDataset extends MiniDFSTest {
             .format(format)
             .location(testDirectory)
             .build())
+        .type(Record.class)
         .build();
 
     List<Path> dirPaths = Lists.newArrayList(ds.dirIterator());
@@ -433,7 +448,7 @@ public class TestFileSystemDataset extends MiniDFSTest {
     PartitionStrategy partitionStrategy = new PartitionStrategy.Builder()
         .hash("username", 2).hash("email", 3).build();
 
-    final FileSystemDataset<Record> ds = new FileSystemDataset.Builder()
+    final FileSystemDataset<Record> ds = new FileSystemDataset.Builder<Record>()
         .name("partitioned-users")
         .configuration(getConfiguration())
         .descriptor(new DatasetDescriptor.Builder()
@@ -442,6 +457,7 @@ public class TestFileSystemDataset extends MiniDFSTest {
             .location(testDirectory)
             .partitionStrategy(partitionStrategy)
             .build())
+        .type(Record.class)
         .build();
 
     Assert.assertTrue("Dataset is partitioned", ds.getDescriptor()
@@ -489,12 +505,14 @@ public class TestFileSystemDataset extends MiniDFSTest {
   
   @Test
   public void testDeleteAllWithoutPartitions() {
-    final FileSystemDataset<Record> ds = new FileSystemDataset.Builder()
+    final FileSystemDataset<Record> ds = new FileSystemDataset.Builder<Record>()
         .name("users")
         .configuration(getConfiguration())
         .descriptor(
             new DatasetDescriptor.Builder().schema(USER_SCHEMA).format(format)
-                .location(testDirectory).build()).build();
+                .location(testDirectory).build())
+        .type(Record.class)
+        .build();
     
     writeTestUsers(ds, 10);
     

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemDatasetPartitionKeyForPath.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemDatasetPartitionKeyForPath.java
@@ -50,7 +50,7 @@ public class TestFileSystemDatasetPartitionKeyForPath {
     partitionStrategy = new PartitionStrategy.Builder()
         .hash("username", "username_part", 2).hash("email", 3).build();
 
-    dataset = new FileSystemDataset.Builder()
+    dataset = new FileSystemDataset.Builder<Record>()
         .name("partitioned-users")
         .configuration(new Configuration())
         .uri(URI.create("test"))
@@ -59,6 +59,7 @@ public class TestFileSystemDatasetPartitionKeyForPath {
             .location(testDirectory)
             .partitionStrategy(partitionStrategy)
             .build())
+        .type(Record.class)
         .build();
   }
 

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemDatasetReader.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemDatasetReader.java
@@ -37,14 +37,14 @@ import static org.kitesdk.data.spi.filesystem.DatasetTestUtilities.*;
 import org.apache.avro.generic.GenericData;
 import org.kitesdk.data.spi.AbstractDatasetReader;
 
-public class TestFileSystemDatasetReader extends TestDatasetReaders {
+public class TestFileSystemDatasetReader extends TestDatasetReaders<Record> {
 
   @Override
-  public DatasetReader newReader() throws IOException {
-    return new FileSystemDatasetReader<String>(
+  public DatasetReader<Record> newReader() throws IOException {
+    return new FileSystemDatasetReader<Record>(
         FileSystem.getLocal(new Configuration()),
         new Path(Resources.getResource("data/strings-100.avro").getFile()),
-        STRING_SCHEMA);
+        STRING_SCHEMA, Record.class);
   }
 
   @Override
@@ -53,11 +53,11 @@ public class TestFileSystemDatasetReader extends TestDatasetReaders {
   }
 
   @Override
-  public DatasetTestUtilities.RecordValidator getValidator() {
-    return new DatasetTestUtilities.RecordValidator<GenericData.Record>() {
+  public DatasetTestUtilities.RecordValidator<Record> getValidator() {
+    return new DatasetTestUtilities.RecordValidator<Record>() {
       @Override
-      public void validate(GenericData.Record record, int recordNum) {
-        Assert.assertEquals(String.valueOf(recordNum), record.get("text"));
+      public void validate(Record record, int recordNum) {
+        Assert.assertEquals(String.valueOf(recordNum), record.get("text").toString());
       }
     };
   }
@@ -79,13 +79,13 @@ public class TestFileSystemDatasetReader extends TestDatasetReaders {
 
     FileSystemDatasetReader<Record> reader = new FileSystemDatasetReader<Record>(
         fileSystem, new Path(Resources.getResource("data/strings-100.avro")
-            .getFile()), schema);
+            .getFile()), schema, Record.class);
 
     checkReaderBehavior(reader, 100, new RecordValidator<Record>() {
       @Override
       public void validate(Record record, int recordNum) {
-        Assert.assertEquals(String.valueOf(recordNum), record.get("text"));
-        Assert.assertEquals("N/A", record.get("text2"));
+        Assert.assertEquals(String.valueOf(recordNum), record.get("text").toString());
+        Assert.assertEquals("N/A", record.get("text2").toString());
       }
     });
   }
@@ -93,19 +93,20 @@ public class TestFileSystemDatasetReader extends TestDatasetReaders {
   @Test(expected = IllegalArgumentException.class)
   public void testNullFileSystem() {
     DatasetReader<String> reader = new FileSystemDatasetReader<String>(
-        null, new Path("/tmp/does-not-exist.avro"), STRING_SCHEMA);
+        null, new Path("/tmp/does-not-exist.avro"), STRING_SCHEMA, String.class);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testNullFile() {
     DatasetReader<String> reader = new FileSystemDatasetReader<String>(
-        fileSystem, null, STRING_SCHEMA);
+        fileSystem, null, STRING_SCHEMA, String.class);
   }
 
   @Test(expected = DatasetReaderException.class)
   public void testMissingFile() {
     AbstractDatasetReader<String> reader = new FileSystemDatasetReader<String>(
-        fileSystem, new Path("/tmp/does-not-exist.avro"), STRING_SCHEMA);
+        fileSystem, new Path("/tmp/does-not-exist.avro"), STRING_SCHEMA,
+        String.class);
 
     // the reader should not fail until open()
     Assert.assertNotNull(reader);
@@ -123,7 +124,7 @@ public class TestFileSystemDatasetReader extends TestDatasetReaders {
 
     try {
       AbstractDatasetReader<String> reader = new FileSystemDatasetReader<String>(
-          fileSystem, emptyFile, STRING_SCHEMA);
+          fileSystem, emptyFile, STRING_SCHEMA, String.class);
 
       // the reader should not fail until open()
       Assert.assertNotNull(reader);

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestHDFSDatasetURIs.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestHDFSDatasetURIs.java
@@ -50,8 +50,8 @@ public class TestHDFSDatasetURIs extends MiniDFSTest {
     repo.delete("test");
     repo.create("test", descriptor);
 
-    Dataset<Object> ds = Datasets
-        .load("dataset:hdfs://" + hdfsAuth + "/tmp/data/test");
+    Dataset<Object> ds = Datasets.<Object, Dataset<Object>>
+        load("dataset:hdfs://" + hdfsAuth + "/tmp/data/test", Object.class);
 
     Assert.assertNotNull("Should load dataset", ds);
     Assert.assertTrue(ds instanceof FileSystemDataset);
@@ -71,7 +71,9 @@ public class TestHDFSDatasetURIs extends MiniDFSTest {
     repo.delete("test");
     repo.create("test", descriptor);
 
-    Dataset<Object> ds = Datasets.load("dataset:hdfs://" + hdfsAuth + "/test");
+    Dataset<Object> ds = Datasets.<Object, Dataset<Object>>
+        load("dataset:hdfs://" + hdfsAuth + "/test",
+        Object.class);
 
     Assert.assertNotNull("Should load dataset", ds);
     Assert.assertTrue(ds instanceof FileSystemDataset);
@@ -91,8 +93,9 @@ public class TestHDFSDatasetURIs extends MiniDFSTest {
     repo.delete("test");
     repo.create("test", descriptor);
 
-    Dataset<Object> ds = Datasets
-        .load("dataset:hdfs://" + hdfsAuth + "/data/test?absolute=false");
+    Dataset<Object> ds = Datasets.<Object, Dataset<Object>>
+        load("dataset:hdfs://" + hdfsAuth + "/data/test?absolute=false",
+        Object.class);
 
     Assert.assertNotNull("Should load dataset", ds);
     Assert.assertTrue(ds instanceof FileSystemDataset);
@@ -111,8 +114,9 @@ public class TestHDFSDatasetURIs extends MiniDFSTest {
         DatasetNotFoundException.class, new Runnable() {
       @Override
       public void run() {
-        Dataset<Object> ds = Datasets
-            .load("dataset:hdfs://" + hdfsAuth + "/tmp/data/nosuchdataset");
+        Dataset<Object> ds = Datasets.<Object, Dataset<Object>>
+            load("dataset:hdfs://" + hdfsAuth + "/tmp/data/nosuchdataset",
+            Object.class);
       }
     });
   }
@@ -123,8 +127,9 @@ public class TestHDFSDatasetURIs extends MiniDFSTest {
         DatasetNotFoundException.class, new Runnable() {
           @Override
           public void run() {
-            Dataset<Object> ds = Datasets
-                .load("dataset:unknown://" + hdfsAuth + "/tmp/data/test");
+            Dataset<Object> ds = Datasets.<Object, Dataset<Object>>
+                load("dataset:unknown://" + hdfsAuth + "/tmp/data/test",
+                Object.class);
           }
         });
   }

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestLocalDatasetURIs.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestLocalDatasetURIs.java
@@ -17,6 +17,9 @@
 package org.kitesdk.data.spi.filesystem;
 
 import java.net.URI;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericData.Record;
+import org.apache.avro.util.Utf8;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -52,7 +55,8 @@ public class TestLocalDatasetURIs {
     repo.delete("test");
     repo.create("test", descriptor);
 
-    Dataset<Object> ds = Datasets.load("dataset:file:/tmp/data/test");
+    Dataset<Record> ds = Datasets.<Record, Dataset<Record>>
+        load("dataset:file:/tmp/data/test", Record.class);
 
     Assert.assertNotNull("Should load dataset", ds);
     Assert.assertTrue(ds instanceof FileSystemDataset);
@@ -71,7 +75,8 @@ public class TestLocalDatasetURIs {
     repo.delete("test");
     repo.create("test", descriptor);
 
-    Dataset<Object> ds = Datasets.load("dataset:file:target/data/test");
+    Dataset<Record> ds = Datasets.<Record, Dataset<Record>>
+        load("dataset:file:target/data/test", Record.class);
 
     Assert.assertNotNull("Should load dataset", ds);
     Assert.assertTrue(ds instanceof FileSystemDataset);
@@ -90,8 +95,8 @@ public class TestLocalDatasetURIs {
     repo.delete("test");
     repo.create("test", descriptor);
 
-    RefinableView<Object> v = Datasets
-        .load("view:file:/tmp/data/test?username=user");
+    RefinableView<Record> v = Datasets.<Record, RefinableView<Record>>
+        load("view:file:/tmp/data/test?username=user", Record.class);
 
     Assert.assertNotNull("Should load view", v);
     Assert.assertTrue(v instanceof FileSystemView);
@@ -104,7 +109,7 @@ public class TestLocalDatasetURIs {
         loaded, v.getDataset().getDescriptor());
 
     Constraints withUser = new Constraints(loaded.getSchema())
-        .with("username", "user");
+        .with("username", new Utf8("user"));
     Assert.assertEquals("Constraints should be username=user",
         withUser, ((FileSystemView) v).getConstraints());
 
@@ -117,7 +122,8 @@ public class TestLocalDatasetURIs {
         DatasetNotFoundException.class, new Runnable() {
       @Override
       public void run() {
-        Dataset<Object> ds = Datasets.load("dataset:file:/tmp/data/nosuchdataset");
+        Dataset<Record> ds = Datasets.<Record, Dataset<Record>>
+            load("dataset:file:/tmp/data/nosuchdataset", Record.class);
       }
     });
   }
@@ -128,7 +134,8 @@ public class TestLocalDatasetURIs {
         DatasetNotFoundException.class, new Runnable() {
           @Override
           public void run() {
-            Dataset<Object> ds = Datasets.load("dataset:unknown:/tmp/data/test");
+            Dataset<Record> ds = Datasets.<Record, Dataset<Record>>
+                load("dataset:unknown:/tmp/data/test", Record.class);
           }
         });
   }

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestMultiFileDatasetReader.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestMultiFileDatasetReader.java
@@ -46,7 +46,7 @@ public class TestMultiFileDatasetReader extends TestDatasetReaders {
       @Override
       public void validate(Record record, int recordNum) {
         Assert.assertNotNull(record);
-        Assert.assertEquals(String.valueOf(recordNum % 100), record.get("text"));
+        Assert.assertEquals(String.valueOf(recordNum % 100), record.get("text").toString());
       }
     };
   public static final DatasetDescriptor DESCRIPTOR = new DatasetDescriptor
@@ -57,7 +57,7 @@ public class TestMultiFileDatasetReader extends TestDatasetReaders {
     return new MultiFileDatasetReader<GenericData.Record>(
         FileSystem.get(new Configuration()),
         Lists.newArrayList(TEST_FILE, TEST_FILE),
-        DESCRIPTOR, CONSTRAINTS);
+        DESCRIPTOR, CONSTRAINTS, GenericData.Record.class);
   }
 
   @Override
@@ -79,7 +79,7 @@ public class TestMultiFileDatasetReader extends TestDatasetReaders {
   @Test
   public void testEmptyPathList() throws IOException {
     MultiFileDatasetReader<Record> reader = new MultiFileDatasetReader<Record>(
-        fileSystem, Lists.<Path>newArrayList(), DESCRIPTOR, CONSTRAINTS);
+        fileSystem, Lists.<Path>newArrayList(), DESCRIPTOR, CONSTRAINTS, Record.class);
 
     checkReaderBehavior(reader, 0, VALIDATOR);
   }
@@ -87,7 +87,7 @@ public class TestMultiFileDatasetReader extends TestDatasetReaders {
   @Test
   public void testSingleFile() throws IOException {
     MultiFileDatasetReader<Record> reader = new MultiFileDatasetReader<Record>(
-        fileSystem, Lists.newArrayList(TEST_FILE), DESCRIPTOR, CONSTRAINTS);
+        fileSystem, Lists.newArrayList(TEST_FILE), DESCRIPTOR, CONSTRAINTS, Record.class);
 
     checkReaderBehavior(reader, 100, VALIDATOR);
   }
@@ -96,27 +96,27 @@ public class TestMultiFileDatasetReader extends TestDatasetReaders {
   public void testRequriesFileSystem() throws IOException {
     new MultiFileDatasetReader<Record>(
         null, Lists.newArrayList(TEST_FILE, TEST_FILE), DESCRIPTOR,
-        CONSTRAINTS);
+        CONSTRAINTS, Record.class);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testRequriesFiles() throws IOException {
     new MultiFileDatasetReader<Record>(
-        fileSystem, null, DESCRIPTOR, CONSTRAINTS);
+        fileSystem, null, DESCRIPTOR, CONSTRAINTS, Record.class);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testRequriesDescriptor() throws IOException {
     new MultiFileDatasetReader<Record>(
         fileSystem, Lists.newArrayList(TEST_FILE, TEST_FILE), null,
-        CONSTRAINTS);
+        CONSTRAINTS, Record.class);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testRejectsNullPaths() throws IOException {
     MultiFileDatasetReader<Record> reader = new MultiFileDatasetReader<Record>(
         fileSystem, Lists.newArrayList(null, TEST_FILE), DESCRIPTOR,
-        CONSTRAINTS);
+        CONSTRAINTS, Record.class);
     reader.initialize();
     reader.hasNext();
   }
@@ -129,7 +129,7 @@ public class TestMultiFileDatasetReader extends TestDatasetReaders {
         .build();
 
     MultiFileDatasetReader<Record> reader = new MultiFileDatasetReader<Record>(
-        fileSystem, Lists.newArrayList(TEST_FILE), descriptor, CONSTRAINTS);
+        fileSystem, Lists.newArrayList(TEST_FILE), descriptor, CONSTRAINTS, Record.class);
 
     try {
       reader.initialize();
@@ -153,7 +153,7 @@ public class TestMultiFileDatasetReader extends TestDatasetReaders {
 
     MultiFileDatasetReader<Record> reader = new MultiFileDatasetReader<Record>(
         fileSystem, Lists.newArrayList(missingFile, TEST_FILE), DESCRIPTOR,
-        CONSTRAINTS);
+        CONSTRAINTS, Record.class);
 
     try {
       try {
@@ -191,7 +191,7 @@ public class TestMultiFileDatasetReader extends TestDatasetReaders {
     try {
       MultiFileDatasetReader<Record> reader = new MultiFileDatasetReader<Record>(
           fileSystem, Lists.newArrayList(emptyFile, TEST_FILE), DESCRIPTOR,
-          CONSTRAINTS);
+          CONSTRAINTS, Record.class);
 
       try {
         try {

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestPartitionedDatasetWriter.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestPartitionedDatasetWriter.java
@@ -56,7 +56,7 @@ public class TestPartitionedDatasetWriter {
             .partitionStrategy(partitionStrategy)
             .build());
     writer = new PartitionedDatasetWriter<Object>(
-        new FileSystemView<Object>(users));
+        new FileSystemView<Object>(users, Object.class));
   }
 
   @After

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestProjection.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestProjection.java
@@ -1,0 +1,330 @@
+/*
+ * Copyright 2014 Cloudera, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kitesdk.data.spi.filesystem;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.Sets;
+import com.google.common.io.Closeables;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Set;
+import org.apache.hadoop.fs.Path;
+import org.junit.After;
+import org.junit.Test;
+import org.kitesdk.data.Dataset;
+import org.kitesdk.data.DatasetDescriptor;
+import org.kitesdk.data.DatasetRepository;
+import org.kitesdk.data.DatasetWriter;
+import org.kitesdk.data.IncompatibleSchemaException;
+import org.kitesdk.data.event.IncompatibleEvent;
+import org.kitesdk.data.event.SmallEvent;
+import org.kitesdk.data.event.StandardEvent;
+import org.kitesdk.data.spi.TestRefinableViews;
+
+public class TestProjection extends TestRefinableViews {
+
+  public TestProjection(boolean distributed) {
+    super(distributed);
+  }
+
+  @Override
+  public DatasetRepository newRepo() {
+    return new FileSystemDatasetRepository.Builder()
+        .configuration(conf)
+        .rootDirectory(URI.create("target/data"))
+        .build();
+  }
+
+  @After
+  public void removeDataPath() throws IOException {
+    fs.delete(new Path("target/data"), true);
+  }
+
+  @Test
+  public void testSpecificProjection() throws IOException {
+    DatasetWriter<StandardEvent> writer = null;
+    try {
+      writer = unbounded.newWriter();
+      writer.write(sepEvent);
+      writer.write(octEvent);
+      writer.write(novEvent);
+    } finally {
+      Closeables.close(writer, false);
+    }
+
+    Dataset<SmallEvent> dataset = repo.load(unbounded.getDataset().getName(),
+        SmallEvent.class);
+
+    Set<SmallEvent> expected = Sets.newHashSet(toSmallEvent(sepEvent),
+        toSmallEvent(octEvent), toSmallEvent(novEvent));
+
+    assertContentEquals(expected, dataset);
+  }
+
+  @Test
+  public void testReflectProjection() throws IOException {
+    Dataset<ReflectStandardEvent> original = repo.create("reflectProjection",
+        new DatasetDescriptor.Builder()
+            .schema(ReflectStandardEvent.class)
+            .build(), ReflectStandardEvent.class);
+
+    DatasetWriter<ReflectStandardEvent> writer = null;
+    try {
+      writer = original.newWriter();
+      writer.write(new ReflectStandardEvent(sepEvent));
+      writer.write(new ReflectStandardEvent(octEvent));
+      writer.write(new ReflectStandardEvent(novEvent));
+    } finally {
+      Closeables.close(writer, false);
+    }
+
+    Dataset<ReflectSmallEvent> dataset = repo.load(original.getName(),
+        ReflectSmallEvent.class);
+
+    Set<ReflectSmallEvent> expected = Sets.newHashSet(
+        new ReflectSmallEvent(sepEvent), new ReflectSmallEvent(octEvent),
+        new ReflectSmallEvent(novEvent));
+
+    assertContentEquals(expected, dataset);
+  }
+
+  @Test
+  public void testMixedProjection() throws IOException {
+    Dataset<StandardEvent> original = repo.create("mixedProjection",
+        new DatasetDescriptor.Builder()
+            .schema(StandardEvent.class)
+            .build(), StandardEvent.class);
+
+    DatasetWriter<StandardEvent> writer = null;
+    try {
+      writer = original.newWriter();
+      writer.write(sepEvent);
+      writer.write(octEvent);
+      writer.write(novEvent);
+    } finally {
+      Closeables.close(writer, false);
+    }
+
+    Dataset<ReflectSmallEvent> dataset = repo.load(original.getName(),
+        ReflectSmallEvent.class);
+
+    Set<ReflectSmallEvent> expected = Sets.newHashSet(
+        new ReflectSmallEvent(sepEvent), new ReflectSmallEvent(octEvent),
+        new ReflectSmallEvent(novEvent));
+
+    assertContentEquals(expected, dataset);
+  }
+
+  @Test(expected=IncompatibleSchemaException.class)
+  public void testIncompatibleProjection() throws IOException {
+    DatasetWriter<StandardEvent> writer = null;
+    try {
+      writer = unbounded.newWriter();
+      writer.write(sepEvent);
+      writer.write(octEvent);
+      writer.write(novEvent);
+    } finally {
+      Closeables.close(writer, false);
+    }
+
+    repo.load(unbounded.getDataset().getName(), IncompatibleEvent.class);
+  }
+
+  private static SmallEvent toSmallEvent(StandardEvent event) {
+    return SmallEvent.newBuilder()
+        .setUserId(event.getUserId())
+        .setSessionId(event.getSessionId())
+        .build();
+  }
+
+  private static IncompatibleEvent toIncompatibleEvent(StandardEvent event) {
+    return IncompatibleEvent.newBuilder()
+        .setUserId(String.valueOf(event.getUserId()))
+        .setSessionId(event.getSessionId())
+        .build();
+  }
+
+  private static class ReflectStandardEvent {
+
+    /**
+     * Where the event was triggered from in the format
+     * {client,server}_{user,app}, e.g. 'client_user'. Required.
+     */
+    private String event_initiator;
+    /**
+     * A hierarchical name for the event, with parts separated by ':'. Required.
+     */
+    private String event_name;
+    /**
+     * A unique identifier for the user. Required.
+     */
+    private long user_id;
+    /**
+     * A unique identifier for the session. Required.
+     */
+    private String session_id;
+    /**
+     * The IP address of the host where the event originated. Required.
+     */
+    private String ip;
+    /**
+     * The point in time when the event occurred, represented as the number of
+     * milliseconds since January 1, 1970, 00:00:00 GMT. Required.
+     */
+    private long timestamp;
+
+    public ReflectStandardEvent() {
+    }
+
+    public ReflectStandardEvent(StandardEvent event) {
+      setEvent_initiator(event.getEventInitiator());
+      setEvent_name(event.getEventName());
+      setIp(event.getIp());
+      setSession_id(event.getSessionId());
+      setTimestamp(event.getTimestamp());
+      setUser_id(event.getUserId());
+    }
+
+    public String getEvent_initiator() {
+      return event_initiator;
+    }
+
+    public final void setEvent_initiator(String event_initiator) {
+      this.event_initiator = event_initiator;
+    }
+
+    public String getEvent_name() {
+      return event_name;
+    }
+
+    public final void setEvent_name(String event_name) {
+      this.event_name = event_name;
+    }
+
+    public String getIp() {
+      return ip;
+    }
+
+    public final void setIp(String ip) {
+      this.ip = ip;
+    }
+
+    public String getSession_id() {
+      return session_id;
+    }
+
+    public final void setSession_id(String session_id) {
+      this.session_id = session_id;
+    }
+
+    public long getTimestamp() {
+      return timestamp;
+    }
+
+    public final void setTimestamp(long timestamp) {
+      this.timestamp = timestamp;
+    }
+
+    public long getUser_id() {
+      return user_id;
+    }
+
+    public final void setUser_id(long user_id) {
+      this.user_id = user_id;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+
+      if (obj == null || !Objects.equal(getClass(), obj.getClass())) {
+        return false;
+      }
+
+      final ReflectStandardEvent other = (ReflectStandardEvent) obj;
+      return Objects.equal(this.getEvent_initiator(), other.getEvent_initiator()) &&
+          Objects.equal(this.getEvent_name(), other.getEvent_name()) &&
+          Objects.equal(this.getIp(), other.getIp()) &&
+          Objects.equal(this.getSession_id(), other.getSession_id()) &&
+          Objects.equal(this.getTimestamp(), other.getTimestamp()) &&
+          Objects.equal(this.getUser_id(), other.getUser_id());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(getEvent_initiator(), getEvent_name(), getIp(),
+          getSession_id(), getTimestamp(), getUser_id());
+    }
+  }
+
+  private static class ReflectSmallEvent {
+
+    /**
+     * A unique identifier for the user. Required.
+     */
+    private long user_id;
+    /**
+     * A unique identifier for the session. Required.
+     */
+    private String session_id;
+
+    public ReflectSmallEvent() {
+    }
+
+    public ReflectSmallEvent(StandardEvent event) {
+      setSession_id(event.getSessionId());
+      setUser_id(event.getUserId());
+    }
+
+    public String getSession_id() {
+      return session_id;
+    }
+
+    public final void setSession_id(String session_id) {
+      this.session_id = session_id;
+    }
+
+    public long getUser_id() {
+      return user_id;
+    }
+
+    public final void setUser_id(long user_id) {
+      this.user_id = user_id;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+
+      if (obj == null || !Objects.equal(getClass(), obj.getClass())) {
+        return false;
+      }
+
+      final ReflectSmallEvent other = (ReflectSmallEvent) obj;
+      return Objects.equal(this.getSession_id(), other.getSession_id()) &&
+          Objects.equal(this.getUser_id(), other.getUser_id());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(getSession_id(), getUser_id());
+    }
+  }
+}

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestWriteReflectReadGeneric.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestWriteReflectReadGeneric.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2014 Cloudera, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data.spi.filesystem;
+
+import com.google.common.io.Files;
+import java.io.IOException;
+import org.apache.avro.generic.GenericData.Record;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.kitesdk.data.*;
+import org.kitesdk.data.spi.filesystem.DatasetTestUtilities.RecordValidator;
+
+public class TestWriteReflectReadGeneric extends TestDatasetReaders<Record> {
+
+  private static final int totalRecords = 100;
+  protected static FileSystem fs = null;
+  protected static Path testDirectory = null;
+  protected static Dataset<Record> readerDataset;
+
+  @BeforeClass
+  public static void setup() throws IOException {
+    Configuration conf = new Configuration();
+    fs = FileSystem.getLocal(conf);
+    testDirectory = new Path(Files.createTempDir().getAbsolutePath());
+    FileSystemDatasetRepository repo = new FileSystemDatasetRepository(conf, testDirectory);
+    Dataset<MyRecord> writerDataset = repo.create("test", new DatasetDescriptor.Builder()
+                                   .schema(MyRecord.class)
+                                   .build(), MyRecord.class);
+    DatasetWriter<MyRecord> writer = writerDataset.newWriter();
+    for (int i = 0; i < totalRecords; i++) {
+      writer.write(new MyRecord(String.valueOf(i), i));
+    }
+    writer.close();
+
+    readerDataset = repo.load("test", Record.class);
+  }
+
+  @AfterClass
+  public static void tearDown() throws IOException {
+    fs.delete(testDirectory, true);
+  }
+
+  @Override
+  public DatasetReader<Record> newReader() throws IOException {
+    return readerDataset.newReader();
+  }
+
+  @Override
+  public int getTotalRecords() {
+    return totalRecords;
+  }
+
+  @Override
+  public RecordValidator<Record> getValidator() {
+    return new RecordValidator<Record>() {
+
+      @Override
+      public void validate(Record record, int recordNum) {
+        Assert.assertEquals(String.valueOf(recordNum), record.get("text").toString());
+        Assert.assertEquals(recordNum, record.get("value"));
+      }
+    };
+  }
+
+  public static class MyRecord {
+
+    private String text;
+    private int value;
+
+    public MyRecord() {
+    }
+
+    public MyRecord(String text, int value) {
+      this.text = text;
+      this.value = value;
+    }
+  }
+}

--- a/kite-data/kite-data-crunch/src/main/java/org/kitesdk/data/crunch/DatasetSourceTarget.java
+++ b/kite-data/kite-data-crunch/src/main/java/org/kitesdk/data/crunch/DatasetSourceTarget.java
@@ -58,6 +58,10 @@ class DatasetSourceTarget<E> extends DatasetTarget<E> implements ReadableSourceT
   private FormatBundle formatBundle;
   private AvroType<E> avroType;
 
+  public DatasetSourceTarget(View<E> view) {
+    this(view, view.getType());
+  }
+
   @SuppressWarnings("unchecked")
   public DatasetSourceTarget(View<E> view, Class<E> type) {
     super(view);
@@ -85,7 +89,7 @@ class DatasetSourceTarget<E> extends DatasetTarget<E> implements ReadableSourceT
   }
 
   public DatasetSourceTarget(URI uri, Class<E> type) {
-    this(Datasets.<E, View<E>>load(uri), type);
+    this(Datasets.<E, View<E>>load(uri, type));
   }
 
   @Override

--- a/kite-data/kite-data-crunch/src/test/java/org/kitesdk/data/crunch/TestCrunchDatasets.java
+++ b/kite-data/kite-data-crunch/src/test/java/org/kitesdk/data/crunch/TestCrunchDatasets.java
@@ -279,7 +279,8 @@ public abstract class TestCrunchDatasets extends MiniDFSTest {
 
     URI sourceViewUri = new URIBuilder(repo.getUri(), "in").with("username",
         "test-0").build();
-    View<Record> inputView = Datasets.<Record, Dataset<Record>> load(sourceViewUri);
+    View<Record> inputView = Datasets.<Record, Dataset<Record>> load(sourceViewUri,
+        Record.class);
     Assert.assertEquals(1, datasetSize(inputView));
     
     Pipeline pipeline = new MRPipeline(TestCrunchDatasets.class);

--- a/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/DaoView.java
+++ b/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/DaoView.java
@@ -38,13 +38,14 @@ import org.kitesdk.data.spi.StorageKey;
 import org.kitesdk.data.spi.Marker;
 import org.kitesdk.data.spi.MarkerRange;
 import java.util.List;
+import org.apache.hadoop.conf.Configuration;
 
 class DaoView<E> extends AbstractRefinableView<E> implements InputFormatAccessor<E> {
 
   private final DaoDataset<E> dataset;
 
-  DaoView(DaoDataset<E> dataset) {
-    super(dataset);
+  DaoView(DaoDataset<E> dataset, Class<E> type) {
+    super(dataset, type);
     this.dataset = dataset;
   }
 
@@ -196,7 +197,7 @@ class DaoView<E> extends AbstractRefinableView<E> implements InputFormatAccessor
   }
 
   @Override
-  public InputFormat<E, Void> getInputFormat() {
+  public InputFormat<E, Void> getInputFormat(Configuration conf) {
     return new HBaseViewKeyInputFormat<E>(this);
   }
 }

--- a/kite-data/kite-data-hbase/src/test/java/org/kitesdk/data/hbase/DaoViewTest.java
+++ b/kite-data/kite-data-hbase/src/test/java/org/kitesdk/data/hbase/DaoViewTest.java
@@ -90,7 +90,7 @@ public class DaoViewTest {
   public void testRange() {
     populateTestEntities(10);
 
-    final AbstractRefinableView<TestEntity> range = new DaoView<TestEntity>(ds)
+    final AbstractRefinableView<TestEntity> range = new DaoView<TestEntity>(ds, TestEntity.class)
             .fromAfter(NAMES[0], "1").to(NAMES[0], "9")
             .fromAfter(NAMES[1], "1").to(NAMES[1], "9");
 
@@ -124,17 +124,17 @@ public class DaoViewTest {
   public void testLimitedReader() {
     populateTestEntities(10);
 
-    AbstractRefinableView<TestEntity> range = new DaoView<TestEntity>(ds)
+    AbstractRefinableView<TestEntity> range = new DaoView<TestEntity>(ds, TestEntity.class)
         .from(NAMES[0], "0").to(NAMES[0], "9")
         .from(NAMES[1], "0").to(NAMES[1], "9");
     validRange(range, 0, 10);
 
-    range = new DaoView<TestEntity>(ds)
+    range = new DaoView<TestEntity>(ds, TestEntity.class)
         .fromAfter(NAMES[0], "1").to(NAMES[0], "9")
         .fromAfter(NAMES[1], "1").to(NAMES[1], "9");
     validRange(range, 2, 10);
 
-    range = new DaoView<TestEntity>(ds)
+    range = new DaoView<TestEntity>(ds, TestEntity.class)
         .from(NAMES[0], "0").toBefore(NAMES[0], "9")
         .from(NAMES[1], "0").toBefore(NAMES[1], "9");
     validRange(range, 0, 9);

--- a/kite-data/kite-data-hbase/src/test/java/org/kitesdk/data/hbase/HBaseDatasetRepositoryTest.java
+++ b/kite-data/kite-data-hbase/src/test/java/org/kitesdk/data/hbase/HBaseDatasetRepositoryTest.java
@@ -145,7 +145,7 @@ public class HBaseDatasetRepositoryTest {
 
     // test a partial scan
     cnt = 3;
-    reader = new DaoView<GenericRecord>(ds)
+    reader = new DaoView<GenericRecord>(ds, GenericRecord.class)
         .from("part1", new Utf8("part1_3")).from("part2", new Utf8("part2_3"))
         .to("part1", new Utf8("part1_7")).to("part2", new Utf8("part2_7"))
         .newReader();

--- a/kite-data/kite-data-hbase/src/test/java/org/kitesdk/data/hbase/TestHBaseDatasetURIs.java
+++ b/kite-data/kite-data-hbase/src/test/java/org/kitesdk/data/hbase/TestHBaseDatasetURIs.java
@@ -57,8 +57,8 @@ public class TestHBaseDatasetURIs {
     repo.delete("test");
     repo.create("test", descriptor);
 
-    RandomAccessDataset<Object> ds =
-        Datasets.load(URI.create("dataset:hbase:" + zk + "/test")) ;
+    RandomAccessDataset<Object> ds = Datasets
+	.<Object, RandomAccessDataset<Object>>load(URI.create("dataset:hbase:" + zk + "/test"), Object.class);
 
     Assert.assertNotNull("Should load dataset", ds);
     Assert.assertTrue(ds instanceof DaoDataset);
@@ -75,7 +75,7 @@ public class TestHBaseDatasetURIs {
           @Override
           public void run() {
             Dataset<Object> ds = Datasets
-                .load("dataset:hbase:" + zk + "/nosuchdataset");
+                .<Object, Dataset<Object>>load("dataset:hbase:" + zk + "/nosuchdataset", Object.class);
           }
         }
     );
@@ -87,7 +87,8 @@ public class TestHBaseDatasetURIs {
         DatasetNotFoundException.class, new Runnable() {
           @Override
           public void run() {
-            Dataset<Object> ds = Datasets.load("dataset:unknown:" + zk + "/test");
+            Dataset<Object> ds = Datasets
+                .<Object, Dataset<Object>>load("dataset:unknown:" + zk + "/test", Object.class);
           }
         });
   }

--- a/kite-data/kite-data-hcatalog/src/test/java/org/kitesdk/data/hcatalog/TestHiveDatasetURIs.java
+++ b/kite-data/kite-data-hcatalog/src/test/java/org/kitesdk/data/hcatalog/TestHiveDatasetURIs.java
@@ -58,7 +58,7 @@ public class TestHiveDatasetURIs extends MiniDFSTest {
     repo.create("test", descriptor);
 
     Dataset<Object> ds = Datasets
-        .load("dataset:hive:/tmp/data/test?" + hdfsQueryArgs);
+        .<Object, Dataset<Object>>load("dataset:hive:/tmp/data/test?" + hdfsQueryArgs, Object.class);
 
     Assert.assertNotNull("Should load dataset", ds);
     Assert.assertTrue(ds instanceof FileSystemDataset);
@@ -79,7 +79,7 @@ public class TestHiveDatasetURIs extends MiniDFSTest {
     repo.create("test", descriptor);
 
     Dataset<Object> ds = Datasets
-        .load("dataset:hive:/tmp/data/test?" + hdfsQueryArgsOld);
+        .<Object, Dataset<Object>>load("dataset:hive:/tmp/data/test?" + hdfsQueryArgsOld, Object.class);
 
     Assert.assertNotNull("Should load dataset", ds);
     Assert.assertTrue(ds instanceof FileSystemDataset);
@@ -99,7 +99,8 @@ public class TestHiveDatasetURIs extends MiniDFSTest {
     repo.delete("test");
     repo.create("test", descriptor);
 
-    Dataset<Object> ds = Datasets.load("dataset:hive:/test?" + hdfsQueryArgs);
+    Dataset<Object> ds = Datasets
+        .<Object, Dataset<Object>>load("dataset:hive:/test?" + hdfsQueryArgs, Object.class);
 
     Assert.assertNotNull("Should load dataset", ds);
     Assert.assertTrue(ds instanceof FileSystemDataset);
@@ -120,7 +121,7 @@ public class TestHiveDatasetURIs extends MiniDFSTest {
     repo.create("test", descriptor);
 
     Dataset<Object> ds = Datasets
-        .load("dataset:hive:data/test?" + hdfsQueryArgs);
+        .<Object, Dataset<Object>>load("dataset:hive:data/test?" + hdfsQueryArgs, Object.class);
 
     Assert.assertNotNull("Should load dataset", ds);
     Assert.assertTrue(ds instanceof FileSystemDataset);
@@ -141,7 +142,7 @@ public class TestHiveDatasetURIs extends MiniDFSTest {
     repo.create("test", descriptor);
 
     Dataset<Object> ds = Datasets
-        .load("dataset:hive?dataset=test&" + hdfsQueryArgs);
+        .<Object, Dataset<Object>>load("dataset:hive?dataset=test&" + hdfsQueryArgs, Object.class);
 
     Assert.assertNotNull("Should load dataset", ds);
     Assert.assertTrue(ds instanceof FileSystemDataset);
@@ -159,7 +160,7 @@ public class TestHiveDatasetURIs extends MiniDFSTest {
     repo.create("test", descriptor);
 
     Dataset<Object> ds = Datasets
-        .load("dataset:hive?dataset=test&" + hdfsQueryArgsOld);
+        .<Object, Dataset<Object>>load("dataset:hive?dataset=test&" + hdfsQueryArgsOld, Object.class);
 
     Assert.assertNotNull("Should load dataset", ds);
     Assert.assertTrue(ds instanceof FileSystemDataset);
@@ -176,7 +177,7 @@ public class TestHiveDatasetURIs extends MiniDFSTest {
       @Override
       public void run() {
         Dataset<Object> ds = Datasets
-            .load("dataset:hive:/tmp/data/nosuchdataset?" + hdfsQueryArgs);
+            .<Object, Dataset<Object>>load("dataset:hive:/tmp/data/nosuchdataset?" + hdfsQueryArgs, Object.class);
       }
     });
   }
@@ -188,7 +189,7 @@ public class TestHiveDatasetURIs extends MiniDFSTest {
           @Override
           public void run() {
             Dataset<Object> ds = Datasets
-                .load("dataset:unknown://" + hdfsAuth + "/tmp/data/test");
+                .<Object, Dataset<Object>>load("dataset:unknown://" + hdfsAuth + "/tmp/data/test", Object.class);
           }
         });
   }

--- a/kite-data/kite-data-mapreduce/src/test/java/org/kitesdk/data/mapreduce/TestMapReduce.java
+++ b/kite-data/kite-data-mapreduce/src/test/java/org/kitesdk/data/mapreduce/TestMapReduce.java
@@ -129,7 +129,7 @@ public class TestMapReduce {
             .property("kite.allow.csv", "true")
             .schema(STRING_SCHEMA)
             .format(format)
-            .build());
+            .build(), GenericData.Record.class);
     DatasetWriter<GenericData.Record> writer = inputDataset.newWriter();
     writer.write(newStringRecord("apple"));
     writer.write(newStringRecord("banana"));
@@ -139,7 +139,7 @@ public class TestMapReduce {
     writer.write(newStringRecord("apple"));
     writer.close();
 
-    DatasetKeyInputFormat.configure(job).readFrom(inputDataset);
+    DatasetKeyInputFormat.configure(job).readFrom(inputDataset).withType(GenericData.Record.class);
 
     job.setMapperClass(LineCountMapper.class);
     job.setMapOutputKeyClass(Text.class);
@@ -152,9 +152,9 @@ public class TestMapReduce {
             .property("kite.allow.csv", "true")
             .schema(STATS_SCHEMA)
             .format(format)
-            .build());
+            .build(), GenericData.Record.class);
 
-    DatasetKeyOutputFormat.configure(job).writeTo(outputDataset);
+    DatasetKeyOutputFormat.configure(job).writeTo(outputDataset).withType(GenericData.Record.class);
 
     Assert.assertTrue(job.waitForCompletion(true));
 

--- a/kite-tools/src/main/java/org/kitesdk/cli/commands/BaseDatasetCommand.java
+++ b/kite-tools/src/main/java/org/kitesdk/cli/commands/BaseDatasetCommand.java
@@ -80,9 +80,9 @@ abstract class BaseDatasetCommand extends BaseCommand {
     return uriOrName.startsWith("repo:");
   }
 
-  protected <E> View<E> load(String uriOrName) {
+  protected <E> View<E> load(String uriOrName, Class<E> type) {
     if (isDataUri(uriOrName)) {
-      return Datasets.<E, View<E>>load(uriOrName);
+      return Datasets.<E, View<E>>load(uriOrName, type);
     } else {
       return getDatasetRepository().load(uriOrName);
     }

--- a/kite-tools/src/main/java/org/kitesdk/cli/commands/CSVImportCommand.java
+++ b/kite-tools/src/main/java/org/kitesdk/cli/commands/CSVImportCommand.java
@@ -37,7 +37,7 @@ import org.kitesdk.data.spi.PartitionStrategyParser;
 import org.kitesdk.data.spi.filesystem.CSVProperties;
 import org.kitesdk.data.spi.filesystem.CSVUtil;
 import org.kitesdk.data.spi.filesystem.FileSystemDataset;
-import org.kitesdk.data.spi.filesystem.SchemaValidationUtil;
+import org.kitesdk.data.spi.SchemaValidationUtil;
 import org.kitesdk.data.spi.filesystem.TemporaryFileSystemDatasetRepository;
 import org.kitesdk.tools.CopyTask;
 import org.slf4j.Logger;
@@ -104,7 +104,7 @@ public class CSVImportCommand extends BaseDatasetCommand {
 
     String dataset = targets.get(1);
 
-    View<GenericData.Record> target = load(dataset);
+    View<GenericData.Record> target = load(dataset, GenericData.Record.class);
     Schema datasetSchema = target.getDataset().getDescriptor().getSchema();
 
     // TODO: replace this with a temporary Dataset from a FS repo

--- a/kite-tools/src/main/java/org/kitesdk/cli/commands/CopyCommand.java
+++ b/kite-tools/src/main/java/org/kitesdk/cli/commands/CopyCommand.java
@@ -53,8 +53,8 @@ public class CopyCommand extends BaseDatasetCommand {
     Preconditions.checkArgument(datasets.size() == 2,
         "Cannot copy multiple datasets");
 
-    View<GenericData.Record> source = load(datasets.get(0));
-    View<GenericData.Record> dest = load(datasets.get(1));
+    View<GenericData.Record> source = load(datasets.get(0), GenericData.Record.class);
+    View<GenericData.Record> dest = load(datasets.get(1), GenericData.Record.class);
 
     CopyTask task = new CopyTask<GenericData.Record>(
         source, dest, GenericData.Record.class);

--- a/kite-tools/src/main/java/org/kitesdk/cli/commands/CreateDatasetCommand.java
+++ b/kite-tools/src/main/java/org/kitesdk/cli/commands/CreateDatasetCommand.java
@@ -81,7 +81,7 @@ public class CreateDatasetCommand extends BaseDatasetCommand {
 
     DatasetDescriptor descriptor = descriptorBuilder.build();
     if (isDataUri(datasets.get(0))) {
-      Datasets.<Object, Dataset<Object>> create(datasets.get(0), descriptor);
+      Datasets.<Object, Dataset<Object>> create(datasets.get(0), descriptor, Object.class);
     } else {
       getDatasetRepository().create(datasets.get(0), descriptor);
     }

--- a/kite-tools/src/main/java/org/kitesdk/cli/commands/SchemaCommand.java
+++ b/kite-tools/src/main/java/org/kitesdk/cli/commands/SchemaCommand.java
@@ -50,7 +50,7 @@ public class SchemaCommand extends BaseDatasetCommand {
         datasets != null && !datasets.isEmpty(),
         "Missing dataset name");
     if (datasets.size() == 1) {
-      String schema = load(datasets.get(0))
+      String schema = load(datasets.get(0), Object.class)
           .getDataset()
           .getDescriptor()
           .getSchema()
@@ -61,7 +61,7 @@ public class SchemaCommand extends BaseDatasetCommand {
       Preconditions.checkArgument(outputPath == null,
           "Cannot output multiple schemas to one file");
       for (String name : datasets) {
-        console.info("Dataset \"{}\" schema: {}", name, load(name)
+        console.info("Dataset \"{}\" schema: {}", name, load(name, Object.class)
             .getDataset()
             .getDescriptor()
             .getSchema()

--- a/kite-tools/src/main/java/org/kitesdk/cli/commands/ShowRecordsCommand.java
+++ b/kite-tools/src/main/java/org/kitesdk/cli/commands/ShowRecordsCommand.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import com.google.common.io.Closeables;
 import java.io.IOException;
 import java.util.List;
+import org.apache.avro.generic.GenericData;
 import org.kitesdk.data.DatasetReader;
 import org.kitesdk.data.View;
 import org.slf4j.Logger;
@@ -49,15 +50,13 @@ public class ShowRecordsCommand extends BaseDatasetCommand {
     Preconditions.checkArgument(datasets.size() == 1,
         "Only one dataset name can be given");
 
-    // TODO: CDK-92: always use GenericRecord to have consistent record strings
-
-    View<Object> dataset = load(datasets.get(0));
-    DatasetReader<Object> reader = null;
+    View<GenericData.Record> dataset = load(datasets.get(0), GenericData.Record.class);
+    DatasetReader<GenericData.Record> reader = null;
     boolean threw = true;
     try {
       reader = dataset.newReader();
       int i = 0;
-      for (Object record : reader) {
+      for (GenericData.Record record : reader) {
         if (i >= numRecords) {
           break;
         }

--- a/kite-tools/src/main/java/org/kitesdk/cli/commands/UpdateDatasetCommand.java
+++ b/kite-tools/src/main/java/org/kitesdk/cli/commands/UpdateDatasetCommand.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
+import org.apache.avro.generic.GenericData;
 import org.kitesdk.data.Dataset;
 import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.Datasets;
@@ -56,7 +57,7 @@ public class UpdateDatasetCommand extends BaseDatasetCommand {
     }
 
     String dataset = datasets.remove(0);
-    Dataset<Object> currentDataset = load(dataset).getDataset();
+    Dataset<GenericData.Record> currentDataset = load(dataset, GenericData.Record.class).getDataset();
 
     DatasetDescriptor.Builder descriptorBuilder = new DatasetDescriptor
         .Builder(currentDataset.getDescriptor());
@@ -77,7 +78,7 @@ public class UpdateDatasetCommand extends BaseDatasetCommand {
     DatasetDescriptor descriptor = descriptorBuilder.build();
 
     if (isDataUri(dataset)) {
-      Datasets.<Object, Dataset<Object>> update(dataset, descriptor);
+      Datasets.<GenericData.Record, Dataset<GenericData.Record>> update(dataset, descriptor, GenericData.Record.class);
     } else {
       getDatasetRepository().update(dataset, descriptor);
     }

--- a/kite-tools/src/test/java/org/kitesdk/cli/commands/TestCopyCommandCluster.java
+++ b/kite-tools/src/test/java/org/kitesdk/cli/commands/TestCopyCommandCluster.java
@@ -207,7 +207,7 @@ public class TestCopyCommandCluster extends MiniDFSTest {
             .optionalString("username")
             .optionalString("email")
             .endRecord())
-        .build());
+        .build(), Object.class);
 
     int rc = command.run();
     Assert.assertEquals("Should return success", 0, rc);


### PR DESCRIPTION
I also went through and extended the use of the type parameter down to at least Avro files
and CSV files. In order to support Parquet and HBase, I think more work needs to be done
on the underlying stores. But if I missed something, I can get those in before the merge.
