### PR TITLE
CDK-240: Remove key checks when writes are not bounded.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/Constraints.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/Constraints.java
@@ -501,6 +501,15 @@ public class Constraints implements Serializable{
   }
 
   /**
+   * Returns true if there are no constraints.
+   *
+   * @return {@code true} if there are no constraints, {@code false} otherwise
+   */
+  public boolean isUnbounded() {
+    return constraints.isEmpty();
+  }
+
+  /**
    * A {@link Predicate} for testing entities against a set of predicates.
    *
    * @param <E> The type of entities this predicate tests

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/TestConstraints.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/TestConstraints.java
@@ -98,6 +98,9 @@ public class TestConstraints {
 
     Assert.assertNotNull("Should produce an unbound key range",
         emptyConstraints.toKeyRanges(strategy));
+
+    Assert.assertTrue("Empty constraints should be unbounded",
+        emptyConstraints.isUnbounded());
   }
 
   @Test
@@ -119,6 +122,9 @@ public class TestConstraints {
         exists.toKeyPredicate());
     Assert.assertNotNull("Should produce a key range",
         exists.toKeyRanges(strategy));
+
+    Assert.assertFalse("Non-empty constraints (exists) should not be unbounded",
+        exists.isUnbounded());
   }
 
   @Test
@@ -173,6 +179,9 @@ public class TestConstraints {
     event.id = id;
     Assert.assertTrue("Should match event with correct id",
         withSingle.toEntityPredicate().apply(event));
+
+    Assert.assertFalse("Non-empty constraints (with) should not be unbounded",
+        withSingle.isUnbounded());
   }
 
   @Test
@@ -196,6 +205,9 @@ public class TestConstraints {
     event.id = ids[1];
     Assert.assertTrue("Should match event with correct id",
         withMultiple.toEntityPredicate().apply(event));
+
+    Assert.assertFalse("Non-empty constraints (with) should not be unbounded",
+        withMultiple.isUnbounded());
   }
 
   @Test
@@ -312,6 +324,15 @@ public class TestConstraints {
     Assert.assertEquals("Should be neg-infinity to open",
         Ranges.lessThan(2013),
         emptyConstraints.toBefore("year", 2013).get("year"));
+
+    Assert.assertFalse("Non-empty constraints (from) should not be unbounded",
+        emptyConstraints.from("year", 2013).isUnbounded());
+    Assert.assertFalse("Non-empty constraints (fromAfter) should not be unbounded",
+        emptyConstraints.fromAfter("year", 2013).isUnbounded());
+    Assert.assertFalse("Non-empty constraints (to) should not be unbounded",
+        emptyConstraints.to("year", 2013).isUnbounded());
+    Assert.assertFalse("Non-empty constraints (toBefore) should not be unbounded",
+        emptyConstraints.toBefore("year", 2013).isUnbounded());
   }
 
   @Test

--- a/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/DaoView.java
+++ b/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/DaoView.java
@@ -117,6 +117,9 @@ class DaoView<E> extends AbstractRefinableView<E> implements InputFormatAccessor
   @Override
   public DatasetWriter<E> newWriter() {
     final DatasetWriter<E> wrappedWriter = dataset.getDao().newBatch();
+    if (constraints.isUnbounded()) {
+      return wrappedWriter;
+    }
     final StorageKey partitionStratKey = new StorageKey(dataset.getDescriptor().getPartitionStrategy());
     // Return a dataset writer that checks on write that an entity is within the
     // range of the view


### PR DESCRIPTION
This adds the Constraints#isUnbounded() method from #100 to check
whether the constraints are unbounded and should be ignored.
