### PR TITLE
CDK-281. Push Kite artifacts to maven central

### DIFF
--- a/kite-app-parent/cdh4/pom.xml
+++ b/kite-app-parent/cdh4/pom.xml
@@ -26,6 +26,45 @@
   <description>
     This POM can be used as a parent POM to manage Kite and Hadoop dependencies for CDH4.
   </description>
+  <url>http://kitesdk.org/</url>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <id>tomwhite</id>
+      <name>Tom White</name>
+      <organization>Cloudera</organization>
+    </developer>
+    <developer>
+      <id>esammer</id>
+      <name>Eric Sammer</name>
+      <organization>Cloudera</organization>
+    </developer>
+    <developer>
+      <id>whoschek</id>
+      <name>Wolfgang Hoschek</name>
+      <organization>Cloudera</organization>
+    </developer>
+    <developer>
+      <id>awarrington</id>
+      <name>Adam Warrington</name>
+      <organization>Cloudera</organization>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:git://github.com/kite-sdk/kite.git</connection>
+    <url>https://github.com/kite-sdk/kite</url>
+    <developerConnection>scm:git:git@github.com:kite-sdk/kite.git
+    </developerConnection>
+    <tag>HEAD</tag>
+  </scm>
 
   <properties>
     <!-- dependency version properties -->
@@ -279,5 +318,50 @@
     </dependency>
 
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.5</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.2</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>false</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+      <distributionManagement>
+        <snapshotRepository>
+          <id>ossrh</id>
+          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+          <id>ossrh</id>
+          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+      </distributionManagement>
+    </profile>
+  </profiles>
 
 </project>

--- a/kite-app-parent/pom.xml
+++ b/kite-app-parent/pom.xml
@@ -22,6 +22,12 @@
   <version>0.14.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
+  <parent>
+    <groupId>org.kitesdk</groupId>
+    <artifactId>kite-parent</artifactId>
+    <version>0.14.2-SNAPSHOT</version>
+  </parent>
+
   <name>Kite Application POM Modules</name>
   <description>
     These POMs can be used as parent POM to manage Kite and Hadoop dependencies.

--- a/kite-data/kite-data-hbase/pom.xml
+++ b/kite-data/kite-data-hbase/pom.xml
@@ -34,6 +34,24 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <tasks>
+                <echo message="Create empty javadoc JAR to satisfy Maven central" />
+                <mkdir dir="target/apidocs"/>
+              </tasks>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <compilerArgs>

--- a/kite-hadoop-compatibility/pom.xml
+++ b/kite-hadoop-compatibility/pom.xml
@@ -34,6 +34,24 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <tasks>
+                <echo message="Create empty javadoc JAR to satisfy Maven central" />
+                <mkdir dir="target/apidocs"/>
+              </tasks>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -267,6 +267,7 @@
         <artifactId>maven-release-plugin</artifactId>
         <version>${vers.maven-release-plugin}</version>
         <configuration>
+          <autoVersionSubmodules>true</autoVersionSubmodules>
           <goals>deploy</goals>
           <tagNameFormat>release-@{project.version}</tagNameFormat>
         </configuration>
@@ -349,6 +350,17 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.2</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>false</autoReleaseAfterClose>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>com.github.github</groupId>
@@ -1044,14 +1056,14 @@
   </dependencyManagement>
 
   <distributionManagement>
-    <repository>
-      <id>cloudera.repo</id>
-      <url>https://repository.cloudera.com/artifactory/libs-release-local</url>
-    </repository>
     <snapshotRepository>
-      <id>cloudera.snapshots.repo</id>
-      <url>http://maven.jenkins.cloudera.com:8081/artifactory/cdh-snapshot-local</url>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
     </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
     <site>
       <id>kitesdk.website</id>
       <name>Kite SDK documentation</name>
@@ -1111,6 +1123,28 @@
             </plugin>
           </plugins>
         </pluginManagement>
+      </build>
+    </profile>
+
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.5</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
       </build>
     </profile>
 


### PR DESCRIPTION
Note that this has some POM information duplicated between kite-app-parent/cdh4/pom.xml and the top-level POM - this is to avoid having to make the application POM extend the Kite top-level POM, which has lots of things in it that users won't need. And Maven Central requires certain POM elements which is why I put them in the app POM.
