### PR TITLE
CDK-332: Deprecate DatasetReader#open and DatasetWriter#open.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetReader.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetReader.java
@@ -32,10 +32,9 @@ import edu.umd.cs.findbugs.annotations.SuppressWarnings;
  * expected to instantiate implementations directly.
  * Instead, use the containing dataset's
  * {@link Dataset#newReader()} method to get an appropriate implementation.
- * Normally, you receive an instance of this interface from a dataset, call
- * {@link #open()} to prepare for IO operations, invoke {@link #hasNext()} and
- * {@link #next()} as necessary, and {@link #close()} when they are done or no
- * more data exists.
+ * Normally, you receive an instance of this interface from a dataset, invoke
+ * {@link #hasNext()} and {@link #next()} as necessary, and {@link #close()}
+ * when you are done or no more data exists.
  * </p>
  * <p>
  * Implementations can hold system resources until the {@link #close()} method
@@ -74,7 +73,9 @@ public interface DatasetReader<E> extends Iterator<E>, Iterable<E>, Closeable {
    *
    * @throws UnknownFormatException
    * @throws DatasetReaderException
+   * @deprecated will be removed in 0.16.0; no longer required
    */
+  @Deprecated
   void open();
 
   /**

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetWriter.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetWriter.java
@@ -30,9 +30,8 @@ import javax.annotation.concurrent.NotThreadSafe;
  * not expected to instantiate implementations directly. Instead, use the
  * containing dataset's {@link Dataset#newWriter()} method to get an appropriate
  * implementation. You should receive an instance of this interface from a
- * dataset, call {@link #open()} to prepare for IO operations, invoke
- * {@link #write(Object)} and {@link #flush()} as necessary, and
- * {@link #close()} when they are done, or no more data exists.
+ * dataset, invoke {@link #write(Object)} and {@link #flush()} as necessary,
+ * and {@link #close()} when they are done, or no more data exists.
  * </p>
  * <p>
  * Implementations can hold system resources until the {@link #close()} method
@@ -69,7 +68,9 @@ public interface DatasetWriter<E> extends Flushable, Closeable {
    * </p>
    *
    * @throws DatasetWriterException
+   * @deprecated will be removed in 0.16.0; no longer required
    */
+  @Deprecated
   void open();
 
   /**

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractDatasetReader.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractDatasetReader.java
@@ -17,13 +17,24 @@ package org.kitesdk.data.spi;
 
 import org.kitesdk.data.DatasetReader;
 import java.util.Iterator;
+import org.kitesdk.data.DatasetWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A common DatasetReader base class to simplify implementations.
  *
  * @param <E> The type of entities returned by this DatasetReader.
  */
-public abstract class AbstractDatasetReader<E> implements DatasetReader<E> {
+public abstract class AbstractDatasetReader<E>
+    implements DatasetReader<E>, InitializeAccessor {
+  private static final Logger LOG = LoggerFactory.getLogger(DatasetReader.class);
+
+  @Override
+  @Deprecated
+  public void open() {
+    LOG.warn("DatasetReader#open is no longer needed and will be removed");
+  }
 
   @Override
   public void remove() {

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractDatasetWriter.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractDatasetWriter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2013 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data.spi;
+
+import org.kitesdk.data.DatasetWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A common DatasetWriter base class to simplify implementations.
+ *
+ * @param <E> The type of entities accepted by this DatasetWriter.
+ */
+public abstract class AbstractDatasetWriter<E>
+    implements DatasetWriter<E>, InitializeAccessor {
+  private static final Logger LOG = LoggerFactory.getLogger(DatasetWriter.class);
+
+  @Override
+  @Deprecated
+  public void open() {
+    LOG.warn("DatasetWriter#open is no longer needed and will be removed");
+  }
+}

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/InitializeAccessor.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/InitializeAccessor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2013 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data.spi;
+
+public interface InitializeAccessor {
+
+  /**
+   * <p>
+   * Prepare the reader or writer, allocating any necessary resources required
+   * to produce entities.
+   * </p>
+   * <p>
+   * This method must be invoked prior to any other methods calls. This should
+   * be done by the view or dataset implementation inside of
+   * {@link org.kitesdk.data.View#newReader} or
+   * {@link org.kitesdk.data.View#newWriter}.
+   * </p>
+   * @return the initialized target object
+   * @throws org.kitesdk.data.UnknownFormatException
+   * @throws org.kitesdk.data.DatasetIOException to wrap any IOException
+   */
+  void initialize();
+
+}

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVFileReader.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVFileReader.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.kitesdk.data.DatasetDescriptor;
+import org.kitesdk.data.DatasetReader;
 import org.kitesdk.data.DatasetReaderException;
 import org.kitesdk.data.spi.AbstractDatasetReader;
 import org.kitesdk.data.spi.ReaderWriterState;
@@ -78,7 +79,7 @@ class CSVFileReader<E> extends AbstractDatasetReader<E> {
 
   @Override
   @SuppressWarnings("unchecked")
-  public void open() {
+  public void initialize() {
     Preconditions.checkState(state.equals(ReaderWriterState.NEW),
         "A reader may not be opened more than once - current state:%s", state);
 
@@ -308,9 +309,6 @@ class CSVFileReader<E> extends AbstractDatasetReader<E> {
     @Override
     public void initialize(InputSplit split, TaskAttemptContext context)
         throws IOException, InterruptedException {
-      if (!isOpen()) {
-        open();
-      }
     }
 
     @Override

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVInputFormat.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVInputFormat.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 import org.kitesdk.compat.Hadoop;
 import org.kitesdk.data.DatasetDescriptor;
+import org.kitesdk.data.DatasetReader;
 
 class CSVInputFormat<E> extends FileInputFormat<E, Void> {
   private DatasetDescriptor descriptor;
@@ -53,7 +54,9 @@ class CSVInputFormat<E> extends FileInputFormat<E, Void> {
     Configuration conf = Hadoop.TaskAttemptContext
         .getConfiguration.invoke(context);
     Path path = ((FileSplit) split).getPath();
-    return new CSVFileReader<E>(path.getFileSystem(conf), path, descriptor)
-        .asRecordReader();
+    CSVFileReader<E> reader = new CSVFileReader<E>(
+        path.getFileSystem(conf), path, descriptor);
+    reader.initialize();
+    return reader.asRecordReader();
   }
 }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemDatasetReader.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemDatasetReader.java
@@ -55,7 +55,7 @@ class FileSystemDatasetReader<E> extends AbstractDatasetReader<E> {
   }
 
   @Override
-  public void open() {
+  public void initialize() {
     Preconditions.checkState(state.equals(ReaderWriterState.NEW),
       "A reader may not be opened more than once - current state:%s", state);
 

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemView.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemView.java
@@ -25,6 +25,9 @@ import org.kitesdk.data.DatasetException;
 import org.kitesdk.data.DatasetIOException;
 import org.kitesdk.data.DatasetReader;
 import org.kitesdk.data.DatasetWriter;
+import org.kitesdk.data.spi.AbstractDataset;
+import org.kitesdk.data.spi.AbstractDatasetReader;
+import org.kitesdk.data.spi.AbstractDatasetWriter;
 import org.kitesdk.data.spi.AbstractRefinableView;
 import org.kitesdk.data.spi.Constraints;
 import org.kitesdk.data.spi.InputFormatAccessor;
@@ -76,17 +79,22 @@ class FileSystemView<E> extends AbstractRefinableView<E> implements InputFormatA
 
   @Override
   public DatasetReader<E> newReader() {
-    return new MultiFileDatasetReader<E>(
+    AbstractDatasetReader<E> reader = new MultiFileDatasetReader<E>(
         fs, pathIterator(), dataset.getDescriptor(), constraints);
+    reader.initialize();
+    return reader;
   }
 
   @Override
   public DatasetWriter<E> newWriter() {
+    AbstractDatasetWriter<E> writer;
     if (dataset.getDescriptor().isPartitioned()) {
-      return new PartitionedDatasetWriter<E>(this);
+      writer = new PartitionedDatasetWriter<E>(this);
     } else {
-      return new FileSystemWriter<E>(fs, root, dataset.getDescriptor());
+      writer = new FileSystemWriter<E>(fs, root, dataset.getDescriptor());
     }
+    writer.initialize();
+    return writer;
   }
 
   @Override

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemWriter.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemWriter.java
@@ -27,15 +27,15 @@ import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.DatasetIOException;
-import org.kitesdk.data.DatasetWriter;
 import org.kitesdk.data.DatasetWriterException;
 import org.kitesdk.data.Format;
 import org.kitesdk.data.Formats;
+import org.kitesdk.data.spi.AbstractDatasetWriter;
 import org.kitesdk.data.spi.ReaderWriterState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class FileSystemWriter<E> implements DatasetWriter<E> {
+class FileSystemWriter<E> extends AbstractDatasetWriter<E> {
 
   private static final Logger LOG = LoggerFactory.getLogger(FileSystemWriter.class);
 
@@ -64,7 +64,7 @@ class FileSystemWriter<E> implements DatasetWriter<E> {
   }
 
   @Override
-  public final void open() {
+  public final void initialize() {
     Preconditions.checkState(state.equals(ReaderWriterState.NEW),
         "Unable to open a writer from state:%s", state);
 

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/MultiFileDatasetReader.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/MultiFileDatasetReader.java
@@ -18,7 +18,6 @@ package org.kitesdk.data.spi.filesystem;
 import com.google.common.collect.Iterators;
 import org.apache.hadoop.fs.Path;
 import org.kitesdk.data.DatasetDescriptor;
-import org.kitesdk.data.DatasetReader;
 import org.kitesdk.data.Format;
 import org.kitesdk.data.Formats;
 import org.kitesdk.data.UnknownFormatException;
@@ -40,7 +39,7 @@ class MultiFileDatasetReader<E> extends AbstractDatasetReader<E> {
 
   private final Iterator<Path> filesIter;
   private final PathIterator pathIter;
-  private DatasetReader<E> reader = null;
+  private AbstractDatasetReader<E> reader = null;
   private Iterator<E> readerIterator = null;
 
   private ReaderWriterState state;
@@ -64,7 +63,7 @@ class MultiFileDatasetReader<E> extends AbstractDatasetReader<E> {
   }
 
   @Override
-  public void open() {
+  public void initialize() {
     Preconditions.checkState(state.equals(ReaderWriterState.NEW),
       "A reader may not be opened more than once - current state:%s", state);
 
@@ -89,7 +88,7 @@ class MultiFileDatasetReader<E> extends AbstractDatasetReader<E> {
       this.reader = new FileSystemDatasetReader<E>(fileSystem, filesIter.next(),
           descriptor.getSchema());
     }
-    reader.open();
+    reader.initialize();
     this.readerIterator = Iterators.filter(reader,
         constraints.toEntityPredicate(
             pathIter != null ? pathIter.getStorageKey() : null));

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/ParquetFileSystemDatasetReader.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/ParquetFileSystemDatasetReader.java
@@ -57,7 +57,7 @@ class ParquetFileSystemDatasetReader<E extends IndexedRecord> extends AbstractDa
   }
 
   @Override
-  public void open() {
+  public void initialize() {
     Preconditions.checkState(state.equals(ReaderWriterState.NEW),
       "A reader may not be opened more than once - current state:%s", state);
 

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/PartitionedDatasetWriter.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/PartitionedDatasetWriter.java
@@ -18,6 +18,7 @@ package org.kitesdk.data.spi.filesystem;
 import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.DatasetWriter;
 import org.kitesdk.data.PartitionStrategy;
+import org.kitesdk.data.spi.AbstractDatasetWriter;
 import org.kitesdk.data.spi.FieldPartitioner;
 import org.kitesdk.data.spi.PartitionListener;
 import org.kitesdk.data.spi.StorageKey;
@@ -34,7 +35,7 @@ import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class PartitionedDatasetWriter<E> implements DatasetWriter<E> {
+class PartitionedDatasetWriter<E> extends AbstractDatasetWriter<E> {
 
   private static final Logger LOG = LoggerFactory
     .getLogger(PartitionedDatasetWriter.class);
@@ -79,7 +80,7 @@ class PartitionedDatasetWriter<E> implements DatasetWriter<E> {
   }
 
   @Override
-  public void open() {
+  public void initialize() {
     Preconditions.checkState(state.equals(ReaderWriterState.NEW),
       "Unable to open a writer from state:%s", state);
 
@@ -187,7 +188,7 @@ class PartitionedDatasetWriter<E> implements DatasetWriter<E> {
 
       FileSystemDataset dataset = (FileSystemDataset) view.getDataset();
       Path partition = convert.fromKey(key);
-      DatasetWriter<E> writer = new FileSystemWriter<E>(
+      AbstractDatasetWriter<E> writer = new FileSystemWriter<E>(
           dataset.getFileSystem(),
           new Path(dataset.getDirectory(), partition),
           dataset.getDescriptor());
@@ -197,7 +198,7 @@ class PartitionedDatasetWriter<E> implements DatasetWriter<E> {
         listener.partitionAdded(dataset.getName(), partition.toString());
       }
 
-      writer.open();
+      writer.initialize();
 
       return writer;
     }

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestCSVFileReader.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestCSVFileReader.java
@@ -156,7 +156,7 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
     final CSVFileReader<GenericData.Record> reader =
         new CSVFileReader<GenericData.Record>(localfs, csvFile, desc);
 
-    reader.open();
+    reader.initialize();
     Assert.assertTrue(reader.hasNext());
     GenericData.Record rec = reader.next();
     Assert.assertEquals("str", rec.get(0));
@@ -191,7 +191,7 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
     final CSVFileReader<GenericData.Record> reader =
         new CSVFileReader<GenericData.Record>(localfs, tsvFile, desc);
 
-    reader.open();
+    reader.initialize();
     Assert.assertTrue(reader.hasNext());
     GenericData.Record rec = reader.next();
     Assert.assertEquals("str", rec.get(0));
@@ -226,7 +226,7 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
     final CSVFileReader<GenericData.Record> reader =
         new CSVFileReader<GenericData.Record>(localfs, tsvFile, desc);
 
-    reader.open();
+    reader.initialize();
     Assert.assertTrue(reader.hasNext());
     GenericData.Record rec = reader.next();
     Assert.assertEquals("str", rec.get(0));
@@ -259,7 +259,7 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
     final CSVFileReader<GenericData.Record> reader =
         new CSVFileReader<GenericData.Record>(localfs, csvFile, desc);
 
-    reader.open();
+    reader.initialize();
     Assert.assertTrue(reader.hasNext());
     GenericData.Record rec = reader.next();
     Assert.assertEquals("str", rec.get(0));
@@ -294,7 +294,7 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
     final CSVFileReader<TestBean> reader =
         new CSVFileReader<TestBean>(localfs, csvFile, desc);
 
-    reader.open();
+    reader.initialize();
     Assert.assertTrue(reader.hasNext());
     TestBean bean = reader.next();
     Assert.assertEquals("str", bean.myStr);

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemDataset.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemDataset.java
@@ -517,7 +517,6 @@ public class TestFileSystemDataset extends MiniDFSTest {
             .getName());
       }
       reader = partition.newReader();
-      reader.open();
       for (GenericData.Record actualRecord : reader) {
         Assert.assertEquals(actualRecord.toString(), key.get(0), (actualRecord
             .get("username").hashCode() & Integer.MAX_VALUE) % 2);

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemDatasetReader.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemDatasetReader.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 
 import static org.kitesdk.data.spi.filesystem.DatasetTestUtilities.*;
 import org.apache.avro.generic.GenericData;
+import org.kitesdk.data.spi.AbstractDatasetReader;
 
 public class TestFileSystemDatasetReader extends TestDatasetReaders {
 
@@ -103,13 +104,13 @@ public class TestFileSystemDatasetReader extends TestDatasetReaders {
 
   @Test(expected = DatasetReaderException.class)
   public void testMissingFile() {
-    DatasetReader<String> reader = new FileSystemDatasetReader<String>(
+    AbstractDatasetReader<String> reader = new FileSystemDatasetReader<String>(
         fileSystem, new Path("/tmp/does-not-exist.avro"), STRING_SCHEMA);
 
     // the reader should not fail until open()
     Assert.assertNotNull(reader);
 
-    reader.open();
+    reader.initialize();
   }
 
   @Test(expected = DatasetReaderException.class)
@@ -121,13 +122,13 @@ public class TestFileSystemDatasetReader extends TestDatasetReaders {
         fileSystem.createNewFile(emptyFile));
 
     try {
-      DatasetReader<String> reader = new FileSystemDatasetReader<String>(
+      AbstractDatasetReader<String> reader = new FileSystemDatasetReader<String>(
           fileSystem, emptyFile, STRING_SCHEMA);
 
       // the reader should not fail until open()
       Assert.assertNotNull(reader);
 
-      reader.open();
+      reader.initialize();
     } finally {
       Assert.assertTrue("Failed to clean up empty file",
           fileSystem.delete(emptyFile, true));

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemView.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemView.java
@@ -16,6 +16,7 @@
 
 package org.kitesdk.data.spi.filesystem;
 
+import com.google.common.io.Closeables;
 import java.util.Iterator;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -60,16 +61,16 @@ public class TestFileSystemView extends TestRefinableViews {
   @Test
   @Ignore("getCoveringPartitions is not yet implemented")
   @SuppressWarnings("unchecked")
-  public void testCoveringPartitions() {
+  public void testCoveringPartitions() throws IOException {
     // NOTE: this is an un-restricted write so all should succeed
-    final DatasetWriter<StandardEvent> writer = unbounded.newWriter();
+    DatasetWriter<StandardEvent> writer = null;
     try {
-      writer.open();
+      writer = unbounded.newWriter();
       writer.write(sepEvent);
       writer.write(octEvent);
       writer.write(novEvent);
     } finally {
-      writer.close();
+      Closeables.close(writer, false);
     }
 
     Iterator<View<StandardEvent>> coveringPartitions =
@@ -104,14 +105,14 @@ public class TestFileSystemView extends TestRefinableViews {
   @SuppressWarnings("unchecked")
   public void testDelete() throws Exception {
     // NOTE: this is an un-restricted write so all should succeed
-    final DatasetWriter<StandardEvent> writer = unbounded.newWriter();
+    DatasetWriter<StandardEvent> writer = null;
     try {
-      writer.open();
+      writer = unbounded.newWriter();
       writer.write(sepEvent);
       writer.write(octEvent);
       writer.write(novEvent);
     } finally {
-      writer.close();
+      Closeables.close(writer, false);
     }
 
     final Path root = new Path("target/data/test");
@@ -245,14 +246,14 @@ public class TestFileSystemView extends TestRefinableViews {
   @SuppressWarnings("unchecked")
   public void testUnboundedDelete() throws Exception {
     // NOTE: this is an un-restricted write so all should succeed
-    final DatasetWriter<StandardEvent> writer = unbounded.newWriter();
+    DatasetWriter<StandardEvent> writer = null;
     try {
-      writer.open();
+      writer = unbounded.newWriter();
       writer.write(sepEvent);
       writer.write(octEvent);
       writer.write(novEvent);
     } finally {
-      writer.close();
+      Closeables.close(writer, false);
     }
 
     final Path root = new Path("target/data/test");

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemWriters.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemWriters.java
@@ -28,6 +28,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.kitesdk.data.DatasetWriter;
+import org.kitesdk.data.spi.InitializeAccessor;
 
 public abstract class TestFileSystemWriters<E> {
 
@@ -51,7 +52,7 @@ public abstract class TestFileSystemWriters<E> {
 
   @Test
   public void testDiscardEmptyFiles() throws IOException {
-    fsWriter.open();
+    init(fsWriter);
     fsWriter.close();
     Assert.assertEquals("Should not contain any files", 0,
         ImmutableList.copyOf(fs.listStatus(testDirectory)).size());
@@ -74,5 +75,11 @@ public abstract class TestFileSystemWriters<E> {
     }
 
     writer.close();
+  }
+
+  public void init(DatasetWriter<?> writer) {
+    if (writer instanceof InitializeAccessor) {
+      ((InitializeAccessor) writer).initialize();
+    }
   }
 }

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestMultiFileDatasetReader.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestMultiFileDatasetReader.java
@@ -117,7 +117,7 @@ public class TestMultiFileDatasetReader extends TestDatasetReaders {
     MultiFileDatasetReader<Record> reader = new MultiFileDatasetReader<Record>(
         fileSystem, Lists.newArrayList(null, TEST_FILE), DESCRIPTOR,
         CONSTRAINTS);
-    reader.open();
+    reader.initialize();
     reader.hasNext();
   }
 
@@ -132,7 +132,7 @@ public class TestMultiFileDatasetReader extends TestDatasetReaders {
         fileSystem, Lists.newArrayList(TEST_FILE), descriptor, CONSTRAINTS);
 
     try {
-      reader.open();
+      reader.initialize();
     } finally {
       reader.close();
     }
@@ -157,7 +157,7 @@ public class TestMultiFileDatasetReader extends TestDatasetReaders {
 
     try {
       try {
-        reader.open();
+        reader.initialize();
       } catch (Throwable t) {
         Assert.fail("Reader failed in open: " + t.getClass().getName());
       }
@@ -195,7 +195,7 @@ public class TestMultiFileDatasetReader extends TestDatasetReaders {
 
       try {
         try {
-          reader.open();
+          reader.initialize();
         } catch (Throwable t) {
           Assert.fail("Reader failed in open: " + t.getClass().getName());
         }

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestPartitionedDatasetWriter.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestPartitionedDatasetWriter.java
@@ -65,8 +65,8 @@ public class TestPartitionedDatasetWriter {
   }
 
   @Test
-  public void testBasicOpenClose() throws IOException {
-    writer.open();
+  public void testBasicInitClose() throws IOException {
+    writer.initialize();
     writer.close();
   }
 
@@ -75,7 +75,7 @@ public class TestPartitionedDatasetWriter {
     Record record = new GenericRecordBuilder(USER_SCHEMA)
         .set("username", "test1").set("email", "a@example.com").build();
     try {
-      writer.open();
+      writer.initialize();
       writer.write(record);
       writer.flush();
       writer.close();
@@ -88,7 +88,7 @@ public class TestPartitionedDatasetWriter {
   public void testWriteToClosedWriterFails() throws IOException {
     Record record = new GenericRecordBuilder(USER_SCHEMA)
         .set("username", "test1").set("email", "a@example.com").build();
-    writer.open();
+    writer.initialize();
     writer.close();
     writer.write(record);
   }

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestSimpleView.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestSimpleView.java
@@ -17,6 +17,7 @@
 package org.kitesdk.data.spi.filesystem;
 
 import com.google.common.collect.Sets;
+import com.google.common.io.Closeables;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Set;
@@ -102,28 +103,28 @@ public class TestSimpleView {
     fs.delete(new Path("target/data"), true);
   }
 
-  public static <E> void assertContentEquals(Set<E> expected, View<E> view) {
-    DatasetReader<E> reader = view.newReader();
+  public static <E> void assertContentEquals(Set<E> expected, View<E> view) throws IOException {
+    DatasetReader<E> reader = null;
     try {
-      reader.open();
+      reader = view.newReader();
       Assert.assertEquals(expected,
           Sets.newHashSet((Iterable<E>) reader));
     } finally {
-      reader.close();
+      Closeables.close(reader, false);
     }
   }
 
   @Test
-  public void testLimitedReader() {
+  public void testLimitedReader() throws IOException {
     // NOTE: this is an un-restricted write so all should succeed
-    DatasetWriter<StandardEvent> writer = testDataset.newWriter();
+    DatasetWriter<StandardEvent> writer = null;
     try {
-      writer.open();
+      writer = testDataset.newWriter();
       writer.write(sepEvent);
       writer.write(octEvent);
       writer.write(novEvent);
     } finally {
-      writer.close();
+      Closeables.close(writer, false);
     }
 
     // unbounded

--- a/kite-data/kite-data-crunch/src/main/java/org/kitesdk/data/crunch/DatasetSourceTarget.java
+++ b/kite-data/kite-data-crunch/src/main/java/org/kitesdk/data/crunch/DatasetSourceTarget.java
@@ -38,7 +38,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.TaskInputOutputContext;
 import org.kitesdk.data.Dataset;
-import org.kitesdk.data.DatasetReader;
 import org.kitesdk.data.Datasets;
 import org.kitesdk.data.Format;
 import org.kitesdk.data.Formats;
@@ -140,9 +139,7 @@ class DatasetSourceTarget<E> extends DatasetTarget<E> implements ReadableSourceT
   @Override
   public Iterable<E> read(Configuration configuration) throws IOException {
     // TODO: what to do with Configuration? create new view?
-    DatasetReader<E> reader = view.newReader();
-    reader.open();
-    return reader; // TODO: who calls close?
+    return view.newReader(); // TODO: who calls close?
   }
 
   @Override
@@ -161,9 +158,7 @@ class DatasetSourceTarget<E> extends DatasetTarget<E> implements ReadableSourceT
 
       @Override
       public Iterable<E> read(TaskInputOutputContext<?, ?, ?, ?> context) throws IOException {
-        DatasetReader<E> reader = view.newReader();
-        reader.open();
-        return reader;
+        return view.newReader();
       }
     };
   }

--- a/kite-data/kite-data-crunch/src/test/java/org/kitesdk/data/crunch/TestCrunchDatasetsHBase.java
+++ b/kite-data/kite-data-crunch/src/test/java/org/kitesdk/data/crunch/TestCrunchDatasetsHBase.java
@@ -141,7 +141,6 @@ public class TestCrunchDatasetsHBase {
 
   private void writeRecords(Dataset<GenericRecord> dataset, int count) {
     DatasetWriter<GenericRecord> writer = dataset.newWriter();
-    writer.open();
     try {
       for (int i = 0; i < count; ++i) {
         GenericRecord entity = HBaseDatasetRepositoryTest.createGenericEntity(i);
@@ -155,7 +154,6 @@ public class TestCrunchDatasetsHBase {
   private void checkRecords(Dataset<GenericRecord> dataset, int count, int start) {
     int cnt = start;
     DatasetReader<GenericRecord> reader = dataset.newReader();
-    reader.open();
     try {
       for (GenericRecord entity : reader) {
         HBaseDatasetRepositoryTest.compareEntitiesWithUtf8(cnt, entity);

--- a/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/avro/example/UserProfileDatasetExample.java
+++ b/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/avro/example/UserProfileDatasetExample.java
@@ -104,7 +104,6 @@ public class UserProfileDatasetExample {
    */
   public void printUserProfies() {
     DatasetReader<UserProfileModel2> reader = userProfileDataset.newReader();
-    reader.open();
     try {
       for (UserProfileModel2 userProfile : reader) {
         System.out.println(userProfile.toString());
@@ -129,7 +128,6 @@ public class UserProfileDatasetExample {
   public void printUserProfileActionsForLastName(String lastName) {
     // TODO: use a reader with a start key
     DatasetReader<UserProfileActionsModel2> reader = userProfileActionsDataset.newReader();
-    reader.open();
     try {
       for (UserProfileActionsModel2 entity : reader) {
         UserProfileModel2 userProfile = entity.getUserProfileModel();

--- a/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/avro/example/UserProfileExample.java
+++ b/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/avro/example/UserProfileExample.java
@@ -92,7 +92,7 @@ public class UserProfileExample {
    */
   public void printUserProfies() {
     EntityScanner<UserProfileModel> scanner = userProfileDao.getScanner();
-    scanner.open();
+    scanner.initialize();
     try {
       for (UserProfileModel entity : scanner) {
         System.out.println(entity.toString());
@@ -126,7 +126,7 @@ public class UserProfileExample {
 
     EntityScanner<UserProfileActionsModel> scanner = userProfileActionsDao
         .getScanner(startKey, null);
-    scanner.open();
+    scanner.initialize();
     try {
       // scan until we find a last name not equal to the one provided
       for (UserProfileActionsModel entity : scanner) {

--- a/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/impl/BaseEntityBatch.java
+++ b/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/impl/BaseEntityBatch.java
@@ -16,6 +16,7 @@
 package org.kitesdk.data.hbase.impl;
 
 import org.kitesdk.data.DatasetIOException;
+import org.kitesdk.data.spi.AbstractDatasetWriter;
 import org.kitesdk.data.spi.ReaderWriterState;
 import com.google.common.base.Preconditions;
 
@@ -24,7 +25,8 @@ import java.io.IOException;
 import org.apache.hadoop.hbase.client.HTableInterface;
 import org.apache.hadoop.hbase.client.HTablePool;
 
-public class BaseEntityBatch<E> implements EntityBatch<E> {
+public class BaseEntityBatch<E> extends AbstractDatasetWriter<E>
+    implements EntityBatch<E> {
   private final HTableInterface table;
   private final EntityMapper<E> entityMapper;
   private final HBaseClientTemplate clientTemplate;
@@ -92,7 +94,7 @@ public class BaseEntityBatch<E> implements EntityBatch<E> {
   }
 
   @Override
-  public void open() {
+  public void initialize() {
     Preconditions.checkState(state.equals(ReaderWriterState.NEW),
         "Unable to open a writer from state:%s", state);
     state = ReaderWriterState.OPEN;

--- a/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/impl/BaseEntityScanner.java
+++ b/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/impl/BaseEntityScanner.java
@@ -16,6 +16,7 @@
 package org.kitesdk.data.hbase.impl;
 
 import org.kitesdk.data.DatasetIOException;
+import org.kitesdk.data.spi.AbstractDatasetReader;
 import org.kitesdk.data.spi.ReaderWriterState;
 import com.google.common.base.Preconditions;
 
@@ -37,7 +38,8 @@ import org.apache.hadoop.hbase.filter.FilterList;
  * @param <E>
  *          The entity type this scanner scans.
  */
-public class BaseEntityScanner<E> implements EntityScanner<E> {
+public class BaseEntityScanner<E> extends AbstractDatasetReader<E>
+    implements EntityScanner<E> {
 
   private final EntityMapper<E> entityMapper;
   private final HTablePool tablePool;
@@ -132,7 +134,7 @@ public class BaseEntityScanner<E> implements EntityScanner<E> {
   }
 
   @Override
-  public void open() {
+  public void initialize() {
     Preconditions.checkState(state.equals(ReaderWriterState.NEW),
         "A scanner may not be opened more than once - current state:%s", state);
 

--- a/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/impl/EntityBatch.java
+++ b/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/impl/EntityBatch.java
@@ -16,8 +16,9 @@
 package org.kitesdk.data.hbase.impl;
 
 import org.kitesdk.data.DatasetWriter;
+import org.kitesdk.data.spi.InitializeAccessor;
 
-public interface EntityBatch<E> extends DatasetWriter<E> {
+public interface EntityBatch<E> extends DatasetWriter<E>, InitializeAccessor {
 
   /**
    * Put the entity into the HBase table. Since this is a part of a batch

--- a/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/impl/EntityScanner.java
+++ b/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/impl/EntityScanner.java
@@ -16,6 +16,7 @@
 package org.kitesdk.data.hbase.impl;
 
 import org.kitesdk.data.DatasetReader;
+import org.kitesdk.data.spi.InitializeAccessor;
 
 /**
  * A Scanner interface that represents an Iterable that allows us to iterate
@@ -24,5 +25,5 @@ import org.kitesdk.data.DatasetReader;
  * @param <E>
  *          The type of the entity to return
  */
-public interface EntityScanner<E> extends DatasetReader<E> {
+public interface EntityScanner<E> extends DatasetReader<E>, InitializeAccessor {
 }

--- a/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/manager/ManagedSchemaHBaseDao.java
+++ b/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/manager/ManagedSchemaHBaseDao.java
@@ -79,7 +79,7 @@ class ManagedSchemaHBaseDao implements ManagedSchemaDao {
   public List<ManagedSchema> getManagedSchemas() {
     List<ManagedSchema> returnList = new ArrayList<ManagedSchema>();
     EntityScanner<ManagedSchema> entityScanner = managedSchemaDao.getScanner();
-    entityScanner.open();
+    entityScanner.initialize();
     try {
       for (ManagedSchema entity : entityScanner) {
         returnList.add(entity);

--- a/kite-data/kite-data-hbase/src/test/java/org/kitesdk/data/hbase/DaoViewTest.java
+++ b/kite-data/kite-data-hbase/src/test/java/org/kitesdk/data/hbase/DaoViewTest.java
@@ -106,7 +106,6 @@ public class DaoViewTest {
     Assert.assertFalse(range.includes(newTestEntity("9", "99")));
 
     DatasetReader<TestEntity> reader = range.newReader();
-    reader.open();
     int cnt = 2;
     try {
       for (TestEntity entity : reader) {
@@ -147,7 +146,6 @@ public class DaoViewTest {
         .fromAfter(NAMES[0], "1").to(NAMES[0], "5")
         .fromAfter(NAMES[1], "1").to(NAMES[1], "5");
     DatasetWriter<TestEntity> writer = range.newWriter();
-    writer.open();
     try {
       writer.write(newTestEntity("3", "3"));
       writer.write(newTestEntity("5", "5"));
@@ -188,7 +186,6 @@ public class DaoViewTest {
   private void validRange(View<TestEntity> range, int startIdx, int endIdx) {
     int cnt = startIdx;
     DatasetReader<TestEntity> reader = range.newReader();
-    reader.open();
     try {
       for (TestEntity entity : reader) {
         Assert.assertEquals(Integer.toString(cnt), entity.getPart1());

--- a/kite-data/kite-data-hbase/src/test/java/org/kitesdk/data/hbase/HBaseDatasetRepositoryTest.java
+++ b/kite-data/kite-data-hbase/src/test/java/org/kitesdk/data/hbase/HBaseDatasetRepositoryTest.java
@@ -105,9 +105,7 @@ public class HBaseDatasetRepositoryTest {
     ds.put(createGenericEntity(1));
 
     DatasetWriter<GenericRecord> writer = ds.newWriter();
-    assertFalse("Writer should not be open before calling open", writer.isOpen());
-    writer.open();
-    assertTrue("Writer should be open after calling open", writer.isOpen());
+    assertTrue("Writer should be open initially", writer.isOpen());
     try {
       for (int i = 2; i < 10; ++i) {
         GenericRecord entity = createGenericEntity(i);
@@ -133,9 +131,7 @@ public class HBaseDatasetRepositoryTest {
     // ensure the new entities are what we expect with scan operations
     int cnt = 0;
     DatasetReader<GenericRecord> reader = ds.newReader();
-    assertFalse("Reader should not be open before calling open", reader.isOpen());
-    reader.open();
-    assertTrue("Reader should be open after calling open", reader.isOpen());
+    assertTrue("Reader should be open initially", reader.isOpen());
     try {
       for (GenericRecord entity : reader) {
         compareEntitiesWithUtf8(cnt, entity);
@@ -153,7 +149,6 @@ public class HBaseDatasetRepositoryTest {
         .from("part1", new Utf8("part1_3")).from("part2", new Utf8("part2_3"))
         .to("part1", new Utf8("part1_7")).to("part2", new Utf8("part2_7"))
         .newReader();
-    reader.open();
     try {
       for (GenericRecord entity : reader) {
         compareEntitiesWithUtf8(cnt, entity);
@@ -190,7 +185,6 @@ public class HBaseDatasetRepositoryTest {
     ds.put(createSpecificEntity(1));
 
     DatasetWriter<TestEntity> writer = ds.newWriter();
-    writer.open();
     try {
       for (int i = 2; i < 10; ++i) {
         TestEntity entity = createSpecificEntity(i);
@@ -212,7 +206,6 @@ public class HBaseDatasetRepositoryTest {
     // ensure the new entities are what we expect with scan operations
     int cnt = 0;
     DatasetReader<TestEntity> reader = ds.newReader();
-    reader.open();
     try {
       for (TestEntity entity : reader) {
         compareEntitiesWithString(cnt, entity);

--- a/kite-data/kite-data-hbase/src/test/java/org/kitesdk/data/hbase/avro/AvroDaoTest.java
+++ b/kite-data/kite-data-hbase/src/test/java/org/kitesdk/data/hbase/avro/AvroDaoTest.java
@@ -123,7 +123,7 @@ public class AvroDaoTest {
 
     int cnt = 0;
     EntityScanner<GenericRecord> entityScanner = dao.getScanner();
-    entityScanner.open();
+    entityScanner.initialize();
     try {
       for (GenericRecord entity : entityScanner) {
         assertEquals("field1_" + cnt, entity.get("field1").toString());
@@ -138,7 +138,7 @@ public class AvroDaoTest {
     cnt = 5;
     PartitionKey startKey = dao.getPartitionStrategy().partitionKey("part1_5");
     entityScanner = dao.getScanner(startKey, null);
-    entityScanner.open();
+    entityScanner.initialize();
     try {
       for (GenericRecord entity : entityScanner) {
         assertEquals("field1_" + cnt, entity.get("field1").toString());
@@ -193,7 +193,7 @@ public class AvroDaoTest {
 
     int cnt = 0;
     EntityScanner<TestRecord> entityScanner = dao.getScanner();
-    entityScanner.open();
+    entityScanner.initialize();
     try {
       for (TestRecord entity : entityScanner) {
         assertEquals("field1_" + cnt, entity.getField1());
@@ -208,11 +208,11 @@ public class AvroDaoTest {
     // Test scanner with null keys
     PartitionKey key1 = dao.getPartitionStrategy().partitionKey("part1_5");
     entityScanner = dao.getScanner(key1, null);
-    entityScanner.open();
+    entityScanner.initialize();
     assertEquals("field1_5", entityScanner.iterator().next().getField1());
 
     entityScanner = dao.getScanner(null, key1);
-    entityScanner.open();
+    entityScanner.initialize();
     assertEquals("field1_0", entityScanner.iterator().next().getField1());
 
     PartitionKey deleteKey = dao.getPartitionStrategy().partitionKey("part1_5",
@@ -335,7 +335,7 @@ public class AvroDaoTest {
         schemaString, TestRecord.class);
 
     EntityBatch<TestRecord> batch = dao.newBatch();
-    batch.open();
+    batch.initialize();
     for (TestRecord entity : createSpecificEntities(100)) {
       batch.put(entity);
     }

--- a/kite-data/kite-data-hbase/src/test/java/org/kitesdk/data/hbase/avro/ManagedDaoTest.java
+++ b/kite-data/kite-data-hbase/src/test/java/org/kitesdk/data/hbase/avro/ManagedDaoTest.java
@@ -339,7 +339,7 @@ public class ManagedDaoTest {
     // ensure the new entities are what we expect with scan operations
     int cnt = 0;
     EntityScanner<GenericRecord> entityScanner = dao.getScanner();
-    entityScanner.open();
+    entityScanner.initialize();
     try {
       for (GenericRecord entity : entityScanner) {
         compareEntitiesWithUtf8(cnt, entity);
@@ -371,7 +371,7 @@ public class ManagedDaoTest {
     // ensure the new entities are what we expect with scan operations
     int cnt = 0;
     EntityScanner<TestRecord> entityScanner = dao.getScanner();
-    entityScanner.open();
+    entityScanner.initialize();
     try {
       for (TestRecord entity : entityScanner) {
         compareEntitiesWithString(cnt, entity);
@@ -449,7 +449,7 @@ public class ManagedDaoTest {
     // ensure the new entities are what we expect with scan operations
     int cnt = 0;
     EntityScanner<GenericRecord> entityScanner = dao.getScanner();
-    entityScanner.open();
+    entityScanner.initialize();
     try {
       for (GenericRecord entity : entityScanner) {
         compareEntitiesWithUtf8(cnt, entity);

--- a/kite-data/kite-data-hbase/src/test/java/org/kitesdk/data/hbase/filters/ScannerFilterTest.java
+++ b/kite-data/kite-data-hbase/src/test/java/org/kitesdk/data/hbase/filters/ScannerFilterTest.java
@@ -118,7 +118,7 @@ public class ScannerFilterTest {
     // Scan and make sure all of the values are in the list
     int cnt = 0;
 
-    entityScanner.open();
+    entityScanner.initialize();
     try {
       for (GenericRecord entity : entityScanner) {
         assertTrue(values.contains(entity.get("field1").toString()));

--- a/kite-data/kite-data-hcatalog/src/test/java/org/kitesdk/data/hcatalog/TestExternalHCatalogDatasetRepository.java
+++ b/kite-data/kite-data-hcatalog/src/test/java/org/kitesdk/data/hcatalog/TestExternalHCatalogDatasetRepository.java
@@ -147,7 +147,6 @@ public class TestExternalHCatalogDatasetRepository extends TestFileSystemDataset
     PartitionKey key = dataset.getDescriptor()
         .getPartitionStrategy().partitionKey(partition);
     DatasetWriter<GenericRecord> writer = dataset.getPartition(key, true).newWriter();
-    writer.open();
     try {
       GenericRecordBuilder recordBuilder = new GenericRecordBuilder(
           dataset.getDescriptor().getSchema())

--- a/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/DatasetKeyOutputFormat.java
+++ b/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/DatasetKeyOutputFormat.java
@@ -189,7 +189,6 @@ public class DatasetKeyOutputFormat<E> extends OutputFormat<E, Void> {
 
     public DatasetRecordWriter(View<E> view) {
       this.datasetWriter = view.newWriter();
-      this.datasetWriter.open();
     }
 
     @Override

--- a/kite-data/kite-data-mapreduce/src/test/java/org/kitesdk/data/mapreduce/TestMapReduce.java
+++ b/kite-data/kite-data-mapreduce/src/test/java/org/kitesdk/data/mapreduce/TestMapReduce.java
@@ -131,7 +131,6 @@ public class TestMapReduce {
             .format(format)
             .build());
     DatasetWriter<GenericData.Record> writer = inputDataset.newWriter();
-    writer.open();
     writer.write(newStringRecord("apple"));
     writer.write(newStringRecord("banana"));
     writer.write(newStringRecord("banana"));
@@ -160,7 +159,6 @@ public class TestMapReduce {
     Assert.assertTrue(job.waitForCompletion(true));
 
     DatasetReader<GenericData.Record> reader = outputDataset.newReader();
-    reader.open();
     Map<String, Integer> counts = new HashMap<String, Integer>();
     for (GenericData.Record record : reader) {
       counts.put(record.get("name").toString(), (Integer) record.get("count"));

--- a/kite-data/kite-data-mapreduce/src/test/java/org/kitesdk/data/mapreduce/TestMapReduceHBase.java
+++ b/kite-data/kite-data-mapreduce/src/test/java/org/kitesdk/data/mapreduce/TestMapReduceHBase.java
@@ -126,7 +126,6 @@ public class TestMapReduceHBase {
     Dataset<GenericRecord> outputDataset = repo.create(datasetName, descriptor);
 
     DatasetWriter<GenericRecord> writer = inputDataset.newWriter();
-    writer.open();
     try {
       for (int i = 0; i < 10; ++i) {
         GenericRecord entity = HBaseDatasetRepositoryTest.createGenericEntity(i);
@@ -154,7 +153,6 @@ public class TestMapReduceHBase {
 
     int cnt = 0;
     DatasetReader<GenericRecord> reader = outputDataset.newReader();
-    reader.open();
     try {
       for (GenericRecord entity : reader) {
         HBaseDatasetRepositoryTest.compareEntitiesWithUtf8(cnt, entity);

--- a/kite-tools/src/main/java/org/kitesdk/cli/commands/ShowRecordsCommand.java
+++ b/kite-tools/src/main/java/org/kitesdk/cli/commands/ShowRecordsCommand.java
@@ -52,10 +52,10 @@ public class ShowRecordsCommand extends BaseDatasetCommand {
     // TODO: CDK-92: always use GenericRecord to have consistent record strings
 
     View<Object> dataset = load(datasets.get(0));
-    DatasetReader<Object> reader = dataset.newReader();
+    DatasetReader<Object> reader = null;
     boolean threw = true;
     try {
-      reader.open();
+      reader = dataset.newReader();
       int i = 0;
       for (Object record : reader) {
         if (i >= numRecords) {

--- a/kite-tools/src/main/java/org/kitesdk/tools/CopyTask.java
+++ b/kite-tools/src/main/java/org/kitesdk/tools/CopyTask.java
@@ -146,9 +146,10 @@ public class CopyTask<E> extends Configured {
           CrunchDatasets.asSource(from, entityClass));
 
       boolean threw = true;
-      DatasetWriter<E> writer = to.newWriter();
+      DatasetWriter<E> writer = null;
       try {
-        writer.open();
+        writer = to.newWriter();
+
         for (E entity : collection.materialize()) {
           writer.write(entity);
           count += 1;


### PR DESCRIPTION
This deprecates the reader and writer open methods so that users know
not to use them the design of the readers and writers remains the same,
with an initialization step. But, the initialization is done in an SPI
method, initialize, that is called after the reader or writer is
constructed, but before it is returned from newReader or newWriter.

The code has been moved to the new method by adding open to the
AbstractDatasetReader and a new AbstractDatasetWriter that logs a
warning that the call is no longer required. Tests that called log have
been migrated by either replacing the open call with a call to
initialize, or by removing the call to open. The first case is used
whenever the test instantiates the reader (or writer) itself, as in
TestCSVFileReader, and the latter is used when the reader comes from a
dataset or view.

Some helper methods expected an unopened reader either from newReader or
instantiated directly. These methods now check if the reader is open
and will call initialize if needed.
