### PR TITLE
CDK-537: Check for empty views and return 0 splits.

### DIFF
--- a/kite-data/kite-data-mapreduce/src/test/java/org/kitesdk/data/mapreduce/TestMapReduce.java
+++ b/kite-data/kite-data-mapreduce/src/test/java/org/kitesdk/data/mapreduce/TestMapReduce.java
@@ -171,6 +171,38 @@ public class TestMapReduce {
 
   }
 
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testJobEmptyView() throws Exception {
+    Job job = new Job();
+
+    Dataset<GenericData.Record> inputDataset = repo.create("in",
+        new DatasetDescriptor.Builder()
+            .property("kite.allow.csv", "true")
+            .schema(STRING_SCHEMA)
+            .format(format)
+            .build(), GenericData.Record.class);
+
+    DatasetKeyInputFormat.configure(job).readFrom(inputDataset).withType(GenericData.Record.class);
+
+    job.setMapperClass(LineCountMapper.class);
+    job.setMapOutputKeyClass(Text.class);
+    job.setMapOutputValueClass(IntWritable.class);
+
+    job.setReducerClass(GenericStatsReducer.class);
+
+    Dataset<GenericData.Record> outputDataset = repo.create("out",
+        new DatasetDescriptor.Builder()
+            .property("kite.allow.csv", "true")
+            .schema(STATS_SCHEMA)
+            .format(format)
+            .build(), GenericData.Record.class);
+
+    DatasetKeyOutputFormat.configure(job).writeTo(outputDataset).withType(GenericData.Record.class);
+
+    Assert.assertTrue(job.waitForCompletion(true));
+  }
+
   private GenericData.Record newStringRecord(String text) {
     return new GenericRecordBuilder(STRING_SCHEMA).set("text", text).build();
   }


### PR DESCRIPTION
This updates the FS implementation's InputFormat to check the incoming
view using isEmpty to fix the setInputPaths bug. FileInputFormat assumes
that setInputPaths is called with at least one path. MR tests have been
added for both FS and HBase.
