### PR TITLE
CDK-534: Add View#isEmpty test.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/View.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/View.java
@@ -106,4 +106,15 @@ public interface View<E> {
    * @since 0.15.0
    */
   public Class<E> getType();
+
+  /**
+   * Check whether this {@link View} contains any records.
+   *
+   * Implementations should return once a single record in this view is found.
+   * But this might require scanning through large amounts of data sequentially
+   * to determine if there are any records.
+   *
+   * @return {@code true} if least one record exists, {@code false} otherwise
+   */
+  public boolean isEmpty();
 }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractRefinableView.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractRefinableView.java
@@ -16,16 +16,15 @@
 
 package org.kitesdk.data.spi;
 
-import com.google.common.base.Predicate;
-import org.kitesdk.data.Dataset;
-import org.kitesdk.data.DatasetDescriptor;
 import com.google.common.base.Objects;
+import com.google.common.base.Predicate;
 import java.io.IOException;
-
 import javax.annotation.concurrent.Immutable;
 import org.apache.avro.Schema;
+import org.kitesdk.data.Dataset;
+import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.DatasetException;
-
+import org.kitesdk.data.DatasetReader;
 import org.kitesdk.data.RefinableView;
 import org.kitesdk.data.View;
 import org.slf4j.Logger;
@@ -164,6 +163,20 @@ public abstract class AbstractRefinableView<E> implements RefinableView<E> {
   @Override
   public AbstractRefinableView<E> toBefore(String name, Comparable value) {
     return filter(constraints.toBefore(name, roundTripFieldValue(name, value)));
+  }
+
+  @Override
+  public boolean isEmpty() {
+    DatasetReader<E> reader = null;
+    try {
+      // use a reader because files may be present but empty
+      reader = newReader();
+      return !reader.hasNext();
+    } finally {
+      if (reader != null) {
+        reader.close();
+      }
+    }
   }
 
   @Override

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemDataset.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemDataset.java
@@ -440,6 +440,11 @@ public class FileSystemDataset<E> extends AbstractDataset<E> implements
     return lastMod;
   }
 
+  @Override
+  public boolean isEmpty() {
+    return unbounded.isEmpty();
+  }
+
   public static class Builder<E> {
 
     private Configuration conf;

--- a/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/DaoDataset.java
+++ b/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/DaoDataset.java
@@ -95,6 +95,11 @@ class DaoDataset<E> extends AbstractDataset<E> implements RandomAccessDataset<E>
   }
 
   @Override
+  public boolean isEmpty() {
+    return unbounded.isEmpty();
+  }
+
+  @Override
   public DaoView<E> filter(Constraints c) {
     return unbounded.filter(c);
   }

--- a/kite-data/kite-data-hbase/src/test/java/org/kitesdk/data/hbase/DaoViewTest.java
+++ b/kite-data/kite-data-hbase/src/test/java/org/kitesdk/data/hbase/DaoViewTest.java
@@ -15,6 +15,7 @@
  */
 package org.kitesdk.data.hbase;
 
+import java.io.IOException;
 import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.DatasetReader;
 import org.kitesdk.data.DatasetWriter;
@@ -160,6 +161,26 @@ public class DaoViewTest {
         .fromAfter(NAMES[0], "1").to(NAMES[0], "5")
         .fromAfter(NAMES[1], "1").to(NAMES[1], "5");
     range.newWriter().write(newTestEntity("6", "6"));
+  }
+
+  @Test
+  public void testEmptyCheck() throws IOException {
+    DaoView<TestEntity> unbounded = new DaoView<TestEntity>(ds, TestEntity.class);
+
+    Assert.assertTrue("New dataset should be empty", unbounded.isEmpty());
+
+    populateTestEntities(1);
+
+    Assert.assertFalse("Should not be empty after write", unbounded.isEmpty());
+
+    Assert.assertFalse("Should find entity 0", unbounded
+        .with(NAMES[0], "0").with(NAMES[1], "0")
+        .isEmpty());
+
+    Assert.assertTrue("Should not find entity 1", unbounded
+        .with(NAMES[0], "1").with(NAMES[1], "1")
+        .isEmpty());
+
   }
 
   private TestEntity newTestEntity(String part1, String part2) {


### PR DESCRIPTION
This adds a default implementation in AbstractRefinableView that
instantiates a DatasetReader and returns false if that reader has at
least one record. The javadoc for the new View method notes that this
may be expensive in some cases.
