### PR TITLE
CDK-550. Kite does not compile against Hive 0.13.0

### DIFF
--- a/kite-data/kite-data-hcatalog/src/main/java/org/kitesdk/data/hcatalog/HiveUtils.java
+++ b/kite-data/kite-data-hcatalog/src/main/java/org/kitesdk/data/hcatalog/HiveUtils.java
@@ -95,7 +95,7 @@ class HiveUtils {
           "Unknown format for serde:" + serializationLib);
     }
 
-    final Path dataLocation = new Path(table.getDataLocation());
+    final Path dataLocation = table.getPath();
     final FileSystem fs = fsForPath(conf, dataLocation);
 
     builder.location(fs.makeQualified(dataLocation));
@@ -167,7 +167,8 @@ class HiveUtils {
       table.setTableType(TableType.EXTERNAL_TABLE);
       // but it doesn't work without some additional magic:
       table.getParameters().put("EXTERNAL", "TRUE");
-      table.setDataLocation(descriptor.getLocation());
+      // don't use table.setDataLocation since it changed incompatibly in Hive 0.13.0
+      table.getTTable().getSd().setLocation(descriptor.getLocation().toString());
     } else {
       table.setTableType(TableType.MANAGED_TABLE);
     }


### PR DESCRIPTION
I confirmed that with this change Kite compiled against Kite 0.13.0, and the Hive tests pass.
