### PR TITLE
CDK-576: Fixe Crunch tests against Hive 0.13

### DIFF
--- a/kite-data/kite-data-crunch/src/test/java/org/kitesdk/data/crunch/TestCrunchDatasetsHCatalog.java
+++ b/kite-data/kite-data-crunch/src/test/java/org/kitesdk/data/crunch/TestCrunchDatasetsHCatalog.java
@@ -16,9 +16,10 @@
 package org.kitesdk.data.crunch;
 
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.junit.After;
-import org.kitesdk.data.hcatalog.impl.HCatalog;
 import org.kitesdk.data.hcatalog.HCatalogDatasetRepository;
+import org.kitesdk.data.hcatalog.impl.HCatalog;
 import org.kitesdk.data.spi.DatasetRepository;
 
 public class TestCrunchDatasetsHCatalog extends TestCrunchDatasets {
@@ -28,6 +29,9 @@ public class TestCrunchDatasetsHCatalog extends TestCrunchDatasets {
 
   @Override
   public DatasetRepository newRepo() {
+    // Workaround for HIVE-7633
+    fileSystem.getConf().setBoolean(HiveConf.ConfVars.HIVESTATSAUTOGATHER.varname,
+        false);
     return new HCatalogDatasetRepository.Builder()
         .configuration(fileSystem.getConf())
         .rootDirectory(testDirectory).build();


### PR DESCRIPTION
- Implemented a workaround for HIVE-7633
