### PR TITLE
CDK-539: Add FileSystemDatasets.viewForUri

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemDatasetRepository.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemDatasetRepository.java
@@ -16,7 +16,6 @@
 package org.kitesdk.data.spi.filesystem;
 
 import org.kitesdk.data.PartitionKey;
-import org.kitesdk.data.View;
 import org.kitesdk.data.impl.Accessor;
 import org.kitesdk.data.spi.SchemaValidationUtil;
 import org.kitesdk.data.Dataset;
@@ -377,12 +376,6 @@ public class FileSystemDatasetRepository extends AbstractDatasetRepository
           SchemaUtil.getPartitionType(fp, schema)));
     }
     return Accessor.getDefault().newPartitionKey(values.toArray(new Object[values.size()]));
-  }
-
-  @SuppressWarnings("deprecation")
-  public static <E> View<E> viewForPath(Dataset<E> dataset, URI partitionPath) {
-    PartitionKey key = partitionKeyForPath(dataset, partitionPath);
-    return dataset.getPartition(key, false);
   }
 
   @Override

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemDatasets.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemDatasets.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2013 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data.spi.filesystem;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
+import java.net.URI;
+import java.util.Iterator;
+import org.apache.avro.Schema;
+import org.apache.hadoop.fs.Path;
+import org.kitesdk.data.Dataset;
+import org.kitesdk.data.DatasetDescriptor;
+import org.kitesdk.data.PartitionStrategy;
+import org.kitesdk.data.RefinableView;
+import org.kitesdk.data.View;
+import org.kitesdk.data.spi.Conversions;
+import org.kitesdk.data.spi.FieldPartitioner;
+import org.kitesdk.data.spi.SchemaUtil;
+
+public class FileSystemDatasets {
+
+  private static final Splitter PATH_SPLITTER = Splitter.on('/');
+  private static final Splitter KV_SPILTTER = Splitter.on('=').limit(2);
+
+  public static <E> View<E> viewForUri(Dataset<E> dataset, URI uri) {
+    Preconditions.checkArgument(dataset instanceof FileSystemDataset,
+        "Not a file system dataset: " + dataset);
+
+    DatasetDescriptor descriptor = dataset.getDescriptor();
+
+    String s1 = descriptor.getLocation().getScheme();
+    String s2 = uri.getScheme();
+    Preconditions.checkArgument((s1 == null || s2 == null) || s1.equals(s2),
+        "%s is not contained in %s", uri, descriptor.getLocation());
+
+    URI location = URI.create(descriptor.getLocation().getPath());
+    URI relative = location.relativize(URI.create(uri.getPath()));
+    if (relative.toString().isEmpty()) {
+      // no partitions are selected
+      return dataset;
+    }
+
+    Preconditions.checkArgument(!relative.getPath().startsWith("/"),
+        "%s is not contained in %s", uri, location);
+    Preconditions.checkArgument(descriptor.isPartitioned(),
+        "Dataset is not partitioned");
+
+    Schema schema = descriptor.getSchema();
+    PartitionStrategy strategy = descriptor.getPartitionStrategy();
+
+    RefinableView<E> view = dataset;
+    Iterator<String> parts = PATH_SPLITTER.split(relative.toString()).iterator();
+    for (FieldPartitioner fp : strategy.getFieldPartitioners()) {
+      if (!parts.hasNext()) {
+        break;
+      }
+      String value = Iterables.getLast(KV_SPILTTER.split(parts.next()));
+      Schema fieldSchema = SchemaUtil.fieldSchema(schema, strategy, fp.getName());
+      view = view.with(fp.getName(), Conversions.convert(value, fieldSchema));
+    }
+    return view;
+  }
+
+  public static <E> View<E> viewForUri(Dataset<E> dataset, String uri) {
+    return viewForUri(dataset, URI.create(uri));
+  }
+
+  public static <E> View<E> viewForPath(Dataset<E> dataset, Path path) {
+    return viewForUri(dataset, path.toUri());
+  }
+
+}

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/TestFileSystemDatasets.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/TestFileSystemDatasets.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2013 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.kitesdk.data.spi.filesystem.FileSystemDatasets;
+
+public class TestFileSystemDatasets {
+
+  private static final Schema schema = SchemaBuilder.record("Event").fields()
+      .requiredString("id")
+      .requiredLong("timestamp")
+      .requiredString("color")
+      .endRecord();
+
+  private static PartitionStrategy ymd = new PartitionStrategy.Builder()
+      .year("timestamp", "y")
+      .month("timestamp", "m")
+      .day("timestamp", "d")
+      .build();
+
+  private Dataset<GenericRecord> dataset;
+
+  @Before
+  public void createFileSystemDataset() {
+    String uri = "dataset:file:/tmp/datasets/ns/test";
+    DatasetDescriptor descriptor = new DatasetDescriptor.Builder()
+        .schema(schema)
+        .partitionStrategy(ymd)
+        .build();
+    Datasets.delete(uri);
+    this.dataset = Datasets.create(uri, descriptor);
+  }
+
+  @Test
+  public void testViewForUri() {
+    View<GenericRecord> view = FileSystemDatasets.viewForUri(
+        dataset, "file:/tmp/datasets/ns/test/y=2014/m=03/d=14");
+    Assert.assertEquals("Should create correct view",
+        view, dataset.with("y", 2014).with("m", 3).with("d", 14));
+
+    view = FileSystemDatasets.viewForUri(
+        dataset, "/tmp/datasets/ns/test/y=2014/m=03/d=14");
+    Assert.assertEquals("Should create correct view",
+        view, dataset.with("y", 2014).with("m", 3).with("d", 14));
+  }
+
+  @Test
+  public void testViewForIncompleteUri() {
+    View<GenericRecord> view = FileSystemDatasets.viewForUri(
+        dataset, "/tmp/datasets/ns/test/y=2014/m=03");
+    Assert.assertEquals("Should create correct view",
+        view, dataset.with("y", 2014).with("m", 3));
+  }
+
+  @Test
+  public void testIgnoresAuthority() {
+    View<GenericRecord> view = FileSystemDatasets.viewForUri(
+        dataset, "file://127.0.0.1/tmp/datasets/ns/test/y=2014/m=03/d=14");
+    Assert.assertEquals("Should create correct view",
+        view, dataset.with("y", 2014).with("m", 3).with("d", 14));
+  }
+
+  @Test
+  public void testViewForRelativeUri() {
+    View<GenericRecord> view = FileSystemDatasets.viewForUri(
+        dataset, "y=2014/m=03/d=14");
+    Assert.assertEquals("Should create correct view",
+        view, dataset.with("y", 2014).with("m", 3).with("d", 14));
+  }
+
+  @Test
+  public void testViewForMissingPartitionNames() {
+    // like PathConversion, this uses names from the partition strategy
+    // and will accept partitions that don't have a "name=" component
+    View<GenericRecord> view = FileSystemDatasets.viewForUri(
+        dataset, "2014/3/14");
+    Assert.assertEquals("Should create correct view",
+        view, dataset.with("y", 2014).with("m", 3).with("d", 14));
+  }
+
+  @Test
+  public void testViewForDifferentPartitionNames() {
+    // like PathConversion, this uses names from the partition strategy
+    // and will accept partitions that have a different "name=" component
+    View<GenericRecord> view = FileSystemDatasets.viewForUri(
+        dataset, "year=2014/month=3/day=14");
+    Assert.assertEquals("Should create correct view",
+        view, dataset.with("y", 2014).with("m", 3).with("d", 14));
+  }
+
+  @Test
+  public void testNoConstraints() {
+    View<GenericRecord> view = FileSystemDatasets.viewForUri(
+        dataset, "file:/tmp/datasets/ns/test/");
+    Assert.assertEquals("Should create correct view", view, dataset);
+  }
+
+  @Test
+  public void testDatasetNotPartitioned() {
+    Datasets.delete("dataset:file:/tmp/datasets/ns/test");
+    final Dataset<GenericRecord> ds = Datasets.create(
+        "dataset:file:/tmp/datasets/ns/test",
+        new DatasetDescriptor.Builder()
+            .schema(schema)
+            .build());
+
+    Assert.assertEquals("Should work for empty relative directory",
+        ds, FileSystemDatasets.viewForUri(ds, "file:/tmp/datasets/ns/test"));
+
+    TestHelpers.assertThrows("Should reject paths in a non-partitioned dataset",
+        IllegalArgumentException.class, new Runnable() {
+          @Override
+          public void run() {
+            FileSystemDatasets.viewForUri(ds, "y=2014/m=03/d=14");
+          }
+        });
+  }
+
+  @Test
+  public void testNotContained() {
+    TestHelpers.assertThrows("Should reject paths not in the dataset",
+        IllegalArgumentException.class, new Runnable() {
+          @Override
+          public void run() {
+            FileSystemDatasets.viewForUri(
+                dataset, "file:/tmp/datasets/ns/test2/y=2014/m=03/d=14");
+          }
+        });
+  }
+
+  @Test
+  public void testOtherFileSystemRejected() {
+    TestHelpers.assertThrows("Should reject paths not in the dataset",
+        IllegalArgumentException.class, new Runnable() {
+          @Override
+          public void run() {
+            FileSystemDatasets.viewForUri(
+                dataset, "hdfs:/tmp/datasets/ns/test/y=2014/m=03/d=14");
+          }
+        });
+  }
+}


### PR DESCRIPTION
This builds on #170 and implements the review suggestions from that issue. Specifically, it moves the view helper method from FileSystemDatasetRepository to FileSystemDatasets, which is a more consistent name for a class of helper methods. It also uses the view API rather than relying on the deprecated partition API and has thorough tests.
