### PR TITLE
CDK-203: Add sync to DatasetWriters.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetWriter.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetWriter.java
@@ -75,7 +75,7 @@ public interface DatasetWriter<E> extends Flushable, Closeable {
 
   /**
    * <p>
-   * Force or commit any outstanding data to storage.
+   * Force or commit any outstanding buffered data to the underlying stream.
    * </p>
    * <p>
    * Implementations of this interface must declare their durability guarantees.
@@ -85,6 +85,18 @@ public interface DatasetWriter<E> extends Flushable, Closeable {
    */
   @Override
   void flush();
+
+  /**
+   * <p>
+   * Ensure that data in the underlying stream has been written to disk.
+   * </p>
+   * <p>
+   * Implementations of this interface must declare their durability guarantees.
+   * </p>
+   *
+   * @throws DatasetWriterException
+   */
+  void sync();
 
   /**
    * <p>

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/AvroAppender.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/AvroAppender.java
@@ -71,8 +71,15 @@ class AvroAppender<E> implements FileSystemWriter.FileAppender<E> {
 
   @Override
   public void flush() throws IOException {
+    // Avro sync forces the end of the current block so the data is recoverable
     dataFileWriter.flush();
     Hadoop.FSDataOutputStream.hflush.invoke(out);
+  }
+
+  @Override
+  public void sync() throws IOException {
+    flush();
+    Hadoop.FSDataOutputStream.hsync.invoke(out);
   }
 
   @Override

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVAppender.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVAppender.java
@@ -78,6 +78,12 @@ class CSVAppender<E> implements FileSystemWriter.FileAppender<E> {
     Hadoop.FSDataOutputStream.hflush.invoke(outgoing);
   }
 
+  @Override
+  public void sync() throws IOException {
+    flush();
+    Hadoop.FSDataOutputStream.hsync.invoke(outgoing);
+  }
+
   private String[] shred(E entity) {
     if (entity instanceof IndexedRecord) {
       return shredIndexed((IndexedRecord) entity, schema);

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVFileReader.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVFileReader.java
@@ -163,7 +163,7 @@ class CSVFileReader<E> extends AbstractDatasetReader<E> {
   }
 
   private E makeRecord() {
-    if (recordClass != GenericData.Record.class) {
+    if (recordClass != GenericData.Record.class && !recordClass.isInterface()) {
       E record = makeReflectRecord();
       if (record != null) {
         return record;

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/DurableParquetAppender.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/DurableParquetAppender.java
@@ -72,6 +72,11 @@ class DurableParquetAppender<E extends IndexedRecord> implements FileSystemWrite
   }
 
   @Override
+  public void sync() throws IOException {
+    avroAppender.sync();
+  }
+
+  @Override
   public void close() throws IOException {
     Closeables.close(avroAppender, false);
     Closeables.close(parquetAppender, false);

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/ParquetAppender.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/ParquetAppender.java
@@ -76,6 +76,11 @@ class ParquetAppender<E extends IndexedRecord> implements FileSystemWriter.FileA
   }
 
   @Override
+  public void sync() {
+    // Parquet doesn't (currently) expose a sync operation
+  }
+
+  @Override
   public void close() throws IOException {
     Closeables.close(avroParquetWriter, false);
   }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/PartitionedDatasetWriter.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/PartitionedDatasetWriter.java
@@ -122,7 +122,7 @@ class PartitionedDatasetWriter<E> extends AbstractDatasetWriter<E> {
   @Override
   public void flush() {
     Preconditions.checkState(state.equals(ReaderWriterState.OPEN),
-      "Attempt to write to a writer in state:%s", state);
+      "Attempt to flush a writer in state:%s", state);
 
     LOG.debug("Flushing all cached writers for view:{}", view);
 
@@ -136,6 +136,19 @@ class PartitionedDatasetWriter<E> extends AbstractDatasetWriter<E> {
     for (DatasetWriter<E> writer : cachedWriters.asMap().values()) {
       LOG.debug("Flushing partition writer:{}", writer);
       writer.flush();
+    }
+  }
+
+  @Override
+  public void sync() {
+    Preconditions.checkState(state.equals(ReaderWriterState.OPEN),
+        "Attempt to sync a writer in state:%s", state);
+
+    LOG.debug("Syncing all cached writers for view:{}", view);
+
+    for (DatasetWriter<E> writer : cachedWriters.asMap().values()) {
+      LOG.debug("Syncing partition writer:{}", writer);
+      writer.sync();
     }
   }
 

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestAvroAppender.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestAvroAppender.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2013 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data.spi.filesystem;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import org.apache.avro.Schema;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.kitesdk.data.DatasetReaderException;
+import org.kitesdk.data.MiniDFSTest;
+import org.kitesdk.data.TestHelpers;
+
+public class TestAvroAppender extends MiniDFSTest {
+  private static final Schema schema = Schema.create(Schema.Type.STRING);
+
+  @Test
+  public void testAvroSyncDFS() throws Exception {
+    String auth = getDFS().getUri().getAuthority();
+    final FileSystem fs = getDFS();
+    final Path path = new Path("hdfs://" + auth + "/tmp/test.avro");
+    AvroAppender<String> appender = new AvroAppender<String>(
+        fs, path, schema, true);
+
+    appender.open();
+    for (int i = 0; i < 10; i += 1) {
+      String s = "string-" + i;
+      appender.append(s);
+    }
+
+    TestHelpers.assertThrows("Should not be able to read file, nothing written",
+        DatasetReaderException.class, new Callable<Void>() {
+          @Override
+          public Void call() throws IOException {
+            count(fs, path);
+            return null;
+          }
+        });
+
+    appender.flush();
+    appender.sync();
+
+    // after sync, the first 10 records should be readable
+    Assert.assertEquals("Should find the first 10 records",
+        10, count(fs, path));
+
+    for (int i = 10; i < 20; i += 1) {
+      String s = "string-" + i;
+      appender.append(s);
+    }
+
+    // the records should still be buffered
+    Assert.assertEquals("Newly written records should still be buffered",
+        10, count(fs, path));
+
+    appender.close();
+    appender.cleanup();
+
+    // the records should still be buffered
+    Assert.assertEquals("All records should be found after close",
+        20, count(fs, path));
+  }
+
+  @Test
+  @Ignore(value="LocalFileSystem is broken!?")
+  public void testAvroSyncLocalFS() throws Exception {
+    final FileSystem fs = FileSystem.getLocal(getConfiguration());
+    final Path path = new Path("file:/tmp/test.avro");
+    AvroAppender<String> appender = new AvroAppender<String>(
+        fs, path, schema, true);
+
+    appender.open();
+    for (int i = 0; i < 10; i += 1) {
+      String s = "string-" + i;
+      appender.append(s);
+    }
+
+    TestHelpers.assertThrows("Should not be able to read file, nothing written",
+        DatasetReaderException.class, new Callable<Void>() {
+          @Override
+          public Void call() throws IOException {
+            count(fs, path);
+            return null;
+          }
+        });
+
+    appender.flush();
+    appender.sync();
+
+    // after sync, the first 10 records should be readable
+    Assert.assertEquals("Should find the first 10 records",
+        10, count(fs, path));
+
+    for (int i = 10; i < 20; i += 1) {
+      String s = "string-" + i;
+      appender.append(s);
+    }
+
+    // the records should still be buffered
+    Assert.assertEquals("Newly written records should still be buffered",
+        10, count(fs, path));
+
+    appender.close();
+    appender.cleanup();
+
+    // the records should still be buffered
+    Assert.assertEquals("All records should be found after close",
+        20, count(fs, path));
+  }
+
+  public int count(FileSystem fs, Path path) {
+    FileSystemDatasetReader<String> reader =
+        new FileSystemDatasetReader<String>(fs, path, schema, String.class);
+    int count = 0;
+    reader.initialize();
+    for (String s : reader) {
+      count += 1;
+      System.err.println(s);
+    }
+    reader.close();
+    return count;
+  }
+}

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestCSVAppender.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestCSVAppender.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2013 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data.spi.filesystem;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.kitesdk.data.DatasetDescriptor;
+import org.kitesdk.data.MiniDFSTest;
+
+public class TestCSVAppender extends MiniDFSTest {
+  private static final Schema schema = SchemaBuilder
+      .record("User").fields()
+      .requiredInt("id")
+      .requiredString("email")
+      .endRecord();
+
+  @Test
+  public void testCSVSyncDFS() throws Exception {
+    String auth = getDFS().getUri().getAuthority();
+    final FileSystem fs = getDFS();
+    final Path path = new Path("hdfs://" + auth + "/tmp/test.csv");
+    final DatasetDescriptor descriptor = new DatasetDescriptor.Builder()
+        .schema(schema)
+        .build();
+    CSVAppender<GenericRecord> appender = new CSVAppender<GenericRecord>(fs, path, descriptor);
+    GenericRecord record = new GenericData.Record(schema);
+
+    appender.open();
+    for (int i = 0; i < 10; i += 1) {
+      record.put("id", i);
+      record.put("email", Integer.toString(i) + "@example.com");
+      appender.append(record);
+    }
+
+    Assert.assertEquals("Should not find records before flush",
+        0, count(fs, path, descriptor));
+
+    appender.flush();
+    appender.sync();
+
+    // after sync, the first 10 records should be readable
+    Assert.assertEquals("Should find the first 10 records",
+        10, count(fs, path, descriptor));
+
+    for (int i = 10; i < 20; i += 1) {
+      record.put("id", i);
+      record.put("email", Integer.toString(i) + "@example.com");
+      appender.append(record);
+    }
+
+    // the records should still be buffered
+    Assert.assertEquals("Newly written records should still be buffered",
+        10, count(fs, path, descriptor));
+
+    appender.close();
+    appender.cleanup();
+
+    // the records should still be buffered
+    Assert.assertEquals("All records should be found after close",
+        20, count(fs, path, descriptor));
+  }
+
+  @Test
+  @Ignore(value="LocalFileSystem is broken!?")
+  public void testCSVSyncLocalFS() throws Exception {
+    final FileSystem fs = FileSystem.getLocal(getConfiguration());
+    final Path path = new Path("file:/tmp/test.csv");
+    final DatasetDescriptor descriptor = new DatasetDescriptor.Builder()
+        .schema(schema)
+        .build();
+    CSVAppender<GenericRecord> appender = new CSVAppender<GenericRecord>(fs, path, descriptor);
+    GenericRecord record = new GenericData.Record(schema);
+
+    appender.open();
+    for (int i = 0; i < 10; i += 1) {
+      record.put("id", i);
+      record.put("email", Integer.toString(i) + "@example.com");
+      appender.append(record);
+    }
+
+    Assert.assertEquals("Should not find records before flush",
+        0, count(fs, path, descriptor));
+
+    appender.flush();
+    appender.sync();
+
+    // after sync, the first 10 records should be readable
+    Assert.assertEquals("Should find the first 10 records",
+        10, count(fs, path, descriptor));
+
+    for (int i = 10; i < 20; i += 1) {
+      record.put("id", i);
+      record.put("email", Integer.toString(i) + "@example.com");
+      appender.append(record);
+    }
+
+    // the records should still be buffered
+    Assert.assertEquals("Newly written records should still be buffered",
+        10, count(fs, path, descriptor));
+
+    appender.close();
+    appender.cleanup();
+
+    // the records should still be buffered
+    Assert.assertEquals("All records should be found after close",
+        20, count(fs, path, descriptor));
+  }
+
+  public int count(FileSystem fs, Path path, DatasetDescriptor descriptor) {
+    CSVFileReader<GenericRecord> reader = new CSVFileReader<GenericRecord>(
+            fs, path, descriptor, GenericRecord.class);
+    int count = 0;
+    reader.initialize();
+    for (GenericRecord r : reader) {
+      count += 1;
+      System.err.println(r);
+    }
+    reader.close();
+    return count;
+  }
+
+}

--- a/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/DaoView.java
+++ b/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/DaoView.java
@@ -158,6 +158,11 @@ class DaoView<E> extends AbstractRefinableView<E> implements InputFormatAccessor
       }
 
       @Override
+      public void sync() {
+        wrappedWriter.sync();
+      }
+
+      @Override
       public void close() {
         wrappedWriter.close();
       }

--- a/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/impl/BaseEntityBatch.java
+++ b/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/impl/BaseEntityBatch.java
@@ -128,6 +128,11 @@ public class BaseEntityBatch<E> extends AbstractDatasetWriter<E>
   }
 
   @Override
+  public void sync() {
+    flush(); // there is no equivalent of sync, HBase manages durability
+  }
+
+  @Override
   public void close() {
     if (state.equals(ReaderWriterState.OPEN)) {
       try {


### PR DESCRIPTION
For Avro and CSV FileSystem appenders, sync is implemented as flush
followed by hsync. For Parquet, there is no implementation because there
is no way to flush or sync parquet files. For HBase, sync calls flush.

This adds tests for CSV and Avro sync behavior, which doesn't currently
work for the local FS, but does for HDFS.
