### PR TITLE
CDK-565: Update FS writer to pass properties to Configuration.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/DurableParquetAppender.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/DurableParquetAppender.java
@@ -21,6 +21,7 @@ import com.google.common.io.Closeables;
 import java.io.IOException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
@@ -41,8 +42,8 @@ class DurableParquetAppender<E extends IndexedRecord> implements FileSystemWrite
   private final Schema schema;
   private final FileSystem fs;
 
-  public DurableParquetAppender(FileSystem fs, Path path,
-                         Schema schema, boolean enableCompression) {
+  public DurableParquetAppender(FileSystem fs, Path path, Schema schema,
+                                Configuration conf, boolean enableCompression) {
     this.fs = fs;
     this.path = path;
     this.schema = schema;
@@ -50,7 +51,7 @@ class DurableParquetAppender<E extends IndexedRecord> implements FileSystemWrite
     this.avroAppender = new AvroAppender<E>(
         fs, avroPath, schema, enableCompression);
     this.parquetAppender = new ParquetAppender<E>(
-        fs, path, schema, enableCompression);
+        fs, path, schema, conf, enableCompression);
   }
 
   @Override

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/ParquetAppender.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/ParquetAppender.java
@@ -20,8 +20,10 @@ import com.google.common.io.Closeables;
 import java.io.IOException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.kitesdk.data.DatasetDescriptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import parquet.avro.AvroParquetWriter;
@@ -37,15 +39,17 @@ class ParquetAppender<E extends IndexedRecord> implements FileSystemWriter.FileA
   private final Path path;
   private final Schema schema;
   private final FileSystem fileSystem;
+  private final Configuration conf;
   private final boolean enableCompression;
 
   private AvroParquetWriter<E> avroParquetWriter = null;
 
-  public ParquetAppender(FileSystem fileSystem, Path path,
-                         Schema schema, boolean enableCompression) {
+  public ParquetAppender(FileSystem fileSystem, Path path, Schema schema,
+                         Configuration conf, boolean enableCompression) {
     this.fileSystem = fileSystem;
     this.path = path;
     this.schema = schema;
+    this.conf = conf;
     this.enableCompression = enableCompression;
   }
 
@@ -58,7 +62,7 @@ class ParquetAppender<E extends IndexedRecord> implements FileSystemWriter.FileA
     avroParquetWriter = new AvroParquetWriter<E>(fileSystem.makeQualified(path),
         schema, codecName, DEFAULT_BLOCK_SIZE,
         ParquetWriter.DEFAULT_PAGE_SIZE,
-        ParquetWriter.DEFAULT_IS_DICTIONARY_ENABLED, fileSystem.getConf());
+        ParquetWriter.DEFAULT_IS_DICTIONARY_ENABLED, conf);
   }
 
   @Override

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestParquetWriter.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestParquetWriter.java
@@ -16,8 +16,13 @@
 
 package org.kitesdk.data.spi.filesystem;
 
+import java.io.IOException;
 import org.apache.avro.SchemaBuilder;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.junit.Assert;
+import org.junit.Test;
 import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.DatasetWriter;
 
@@ -31,5 +36,22 @@ public class TestParquetWriter extends TestFileSystemWriters<Object> {
                 .endRecord())
             .format("parquet")
             .build());
+  }
+
+  @Test
+  public void testParquetConfiguration() throws IOException {
+    Configuration conf = new Configuration();
+    FileSystem fs = FileSystem.getLocal(conf);
+    FileSystemWriter<Object> writer = new FileSystemWriter<Object>(
+        fs, new Path("/tmp"),
+        new DatasetDescriptor.Builder()
+            .property("parquet.block.size", "34343434")
+            .schema(SchemaBuilder.record("test").fields()
+                .requiredString("s")
+                .endRecord())
+            .format("parquet")
+            .build());
+    Assert.assertEquals("Should copy properties to Configuration",
+        34343434, writer.conf.getInt("parquet.block.size", -1));
   }
 }


### PR DESCRIPTION
This allows users to configure the Parquet settings, like
parquet.block.size, by setting properties on the descriptor. Descriptor
properties are copied to the Configuration object that FileSystemWriter
now uses to initialize its Appenders.
