### PR TITLE
CDK-583: Fix non-string types with id partitioner.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemDataset.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemDataset.java
@@ -95,7 +95,7 @@ public class FileSystemDataset<E> extends AbstractDataset<E> implements
     this.partitionStrategy =
         descriptor.isPartitioned() ? descriptor.getPartitionStrategy() : null;
     this.partitionListener = partitionListener;
-    this.convert = new PathConversion();
+    this.convert = new PathConversion(descriptor.getSchema());
     this.uri = uri;
 
     this.unbounded = new FileSystemView<E>(this, type);

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemPartitionIterator.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemPartitionIterator.java
@@ -19,6 +19,7 @@ package org.kitesdk.data.spi.filesystem;
 import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import javax.annotation.Nullable;
+import org.apache.avro.Schema;
 import org.kitesdk.data.DatasetException;
 import org.kitesdk.data.spi.FieldPartitioner;
 import org.kitesdk.data.PartitionStrategy;
@@ -91,10 +92,10 @@ class FileSystemPartitionIterator implements
     private final StorageKey reusableKey;
     private final PathConversion convert;
 
-    public MakeKey(PartitionStrategy strategy) {
+    public MakeKey(PartitionStrategy strategy, Schema schema) {
       this.partitioners = strategy.getFieldPartitioners();
       this.reusableKey = new StorageKey(strategy);
-      this.convert = new PathConversion();
+      this.convert = new PathConversion(schema);
     }
 
     @Override
@@ -135,7 +136,7 @@ class FileSystemPartitionIterator implements
 
   @SuppressWarnings("deprecation")
   FileSystemPartitionIterator(
-      FileSystem fs, Path root, PartitionStrategy strategy,
+      FileSystem fs, Path root, PartitionStrategy strategy, Schema schema,
       final Constraints constraints)
       throws IOException {
     Preconditions.checkArgument(fs.isDirectory(root));
@@ -144,7 +145,7 @@ class FileSystemPartitionIterator implements
     this.iterator = Iterators.filter(
         Iterators.transform(
             new FileSystemIterator(strategy.getFieldPartitioners().size()),
-            new MakeKey(strategy)),
+            new MakeKey(strategy, schema)),
         new KeyPredicate(constraints.toKeyPredicate()));
   }
 

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemView.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemView.java
@@ -150,10 +150,11 @@ class FileSystemView<E> extends AbstractRefinableView<E> implements InputFormatA
   }
 
   private FileSystemPartitionIterator partitionIterator() {
+    DatasetDescriptor descriptor = dataset.getDescriptor();
     try {
       return new FileSystemPartitionIterator(
-          fs, root,
-          dataset.getDescriptor().getPartitionStrategy(), constraints);
+          fs, root, descriptor.getPartitionStrategy(), descriptor.getSchema(),
+          constraints);
     } catch (IOException ex) {
       throw new DatasetException("Cannot list partitions in view:" + this, ex);
     }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/PartitionedDatasetWriter.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/PartitionedDatasetWriter.java
@@ -190,7 +190,8 @@ class PartitionedDatasetWriter<E> extends AbstractDatasetWriter<E> {
 
     public DatasetWriterCacheLoader(FileSystemView<E> view) {
       this.view = view;
-      this.convert = new PathConversion();
+      this.convert = new PathConversion(
+          view.getDataset().getDescriptor().getSchema());
     }
 
     @Override

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/PathConversion.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/PathConversion.java
@@ -16,7 +16,9 @@
 
 package org.kitesdk.data.spi.filesystem;
 
+import org.apache.avro.Schema;
 import org.kitesdk.data.spi.FieldPartitioner;
+import org.kitesdk.data.spi.SchemaUtil;
 import org.kitesdk.data.spi.partition.DayOfMonthFieldPartitioner;
 import org.kitesdk.data.spi.partition.HourFieldPartitioner;
 import org.kitesdk.data.spi.partition.MinuteFieldPartitioner;
@@ -37,6 +39,12 @@ import java.util.List;
 import java.util.Map;
 
 public class PathConversion {
+
+  private final Schema schema;
+
+  public PathConversion(Schema schema) {
+    this.schema = schema;
+  }
 
   public StorageKey toKey(Path fromPath, StorageKey storage) {
     final List<FieldPartitioner> partitioners =
@@ -100,7 +108,8 @@ public class PathConversion {
 
   public <T> T valueForDirname(FieldPartitioner<?, T> field, String name) {
     // this could check that the field name matches the directory name
-    return Conversions.convert(valueStringForDirname(name), field.getType());
+    return Conversions.convert(valueStringForDirname(name),
+        SchemaUtil.getPartitionType(field, schema));
   }
 
   public String valueStringForDirname(String name) {

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemPartitionIterator.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemPartitionIterator.java
@@ -19,6 +19,7 @@ package org.kitesdk.data.spi.filesystem;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import javax.annotation.Nullable;
+import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -65,6 +66,11 @@ public class TestFileSystemPartitionIterator extends MiniDFSTest {
       SchemaBuilder.record("Event").fields()
           .requiredLong("timestamp")
           .endRecord(), strategy);
+
+  private static final Schema schema = SchemaBuilder.record("Event").fields()
+      .requiredLong("id")
+      .requiredLong("timestamp")
+      .endRecord();
 
   @BeforeClass
   public static void createExpectedKeys() {
@@ -120,7 +126,7 @@ public class TestFileSystemPartitionIterator extends MiniDFSTest {
   @Test
   public void testUnbounded() throws Exception {
     Iterable<StorageKey> partitions = firsts(new FileSystemPartitionIterator(
-        fileSystem, testDirectory, strategy, emptyConstraints));
+        fileSystem, testDirectory, strategy, schema, emptyConstraints));
 
     assertIterableEquals(keys, partitions);
   }
@@ -133,7 +139,7 @@ public class TestFileSystemPartitionIterator extends MiniDFSTest {
   @Test
   public void testFrom() throws Exception {
     Iterable<StorageKey> partitions = firsts(new FileSystemPartitionIterator(
-        fileSystem, testDirectory, strategy,
+        fileSystem, testDirectory, strategy, schema,
         emptyConstraints.from("timestamp", oct_24_2013)));
     assertIterableEquals(keys.subList(16, 24), partitions);
   }
@@ -141,7 +147,7 @@ public class TestFileSystemPartitionIterator extends MiniDFSTest {
   @Test
   public void testAfter() throws Exception {
     Iterable<StorageKey> partitions = firsts(new FileSystemPartitionIterator(
-        fileSystem, testDirectory, strategy,
+        fileSystem, testDirectory, strategy, schema,
         emptyConstraints.fromAfter("timestamp", oct_24_2013_end)));
     assertIterableEquals(keys.subList(17, 24), partitions);
   }
@@ -149,7 +155,7 @@ public class TestFileSystemPartitionIterator extends MiniDFSTest {
   @Test
   public void testTo() throws Exception {
     Iterable<StorageKey> partitions = firsts(new FileSystemPartitionIterator(
-        fileSystem, testDirectory, strategy,
+        fileSystem, testDirectory, strategy, schema,
         emptyConstraints.to("timestamp", oct_25_2012)));
     assertIterableEquals(keys.subList(0, 6), partitions);
   }
@@ -157,7 +163,7 @@ public class TestFileSystemPartitionIterator extends MiniDFSTest {
   @Test
   public void testBefore() throws Exception {
     Iterable <StorageKey> partitions = firsts(new FileSystemPartitionIterator(
-        fileSystem, testDirectory, strategy,
+        fileSystem, testDirectory, strategy, schema,
         emptyConstraints.toBefore("timestamp", oct_25_2012)));
     assertIterableEquals(keys.subList(0, 5), partitions);
   }
@@ -165,7 +171,7 @@ public class TestFileSystemPartitionIterator extends MiniDFSTest {
   @Test
   public void testWith() throws Exception {
     Iterable<StorageKey> partitions = firsts(new FileSystemPartitionIterator(
-        fileSystem, testDirectory, strategy,
+        fileSystem, testDirectory, strategy, schema,
         emptyConstraints.with("timestamp", oct_24_2013)));
     assertIterableEquals(keys.subList(16, 17), partitions);
   }
@@ -173,7 +179,7 @@ public class TestFileSystemPartitionIterator extends MiniDFSTest {
   @Test
   public void testDayRange() throws Exception {
     Iterable<StorageKey> partitions = firsts(new FileSystemPartitionIterator(
-        fileSystem, testDirectory, strategy,
+        fileSystem, testDirectory, strategy, schema,
         emptyConstraints.from("timestamp", oct_24_2013).to("timestamp", oct_24_2013_end)));
     assertIterableEquals(keys.subList(16, 17), partitions);
   }
@@ -181,7 +187,7 @@ public class TestFileSystemPartitionIterator extends MiniDFSTest {
   @Test
   public void testLargerRange() throws Exception {
     Iterable<StorageKey> partitions = firsts(new FileSystemPartitionIterator(
-        fileSystem, testDirectory, strategy,
+        fileSystem, testDirectory, strategy, schema,
         emptyConstraints.from("timestamp", oct_25_2012).to("timestamp", oct_24_2013)));
     assertIterableEquals(keys.subList(5, 17), partitions);
   }

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemPartitionIteratorTolerance.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemPartitionIteratorTolerance.java
@@ -19,6 +19,7 @@ package org.kitesdk.data.spi.filesystem;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import javax.annotation.Nullable;
+import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -64,6 +65,11 @@ public class TestFileSystemPartitionIteratorTolerance extends MiniDFSTest {
       SchemaBuilder.record("Event").fields()
           .requiredLong("timestamp")
           .endRecord(), strategy);
+
+  private static final Schema schema = SchemaBuilder.record("Event").fields()
+      .requiredLong("id")
+      .requiredLong("timestamp")
+      .endRecord();
 
   @BeforeClass
   public static void createExpectedKeys() {
@@ -152,7 +158,7 @@ public class TestFileSystemPartitionIteratorTolerance extends MiniDFSTest {
   @Test
   public void testUnbounded() throws Exception {
     Iterable<StorageKey> partitions = firsts(new FileSystemPartitionIterator(
-        fileSystem, testDirectory, strategy, emptyConstraints));
+        fileSystem, testDirectory, strategy, schema, emptyConstraints));
 
     assertIterableEquals(keys, partitions);
   }
@@ -165,7 +171,7 @@ public class TestFileSystemPartitionIteratorTolerance extends MiniDFSTest {
   @Test
   public void testFrom() throws Exception {
     Iterable<StorageKey> partitions = firsts(new FileSystemPartitionIterator(
-        fileSystem, testDirectory, strategy,
+        fileSystem, testDirectory, strategy, schema,
         emptyConstraints.from("timestamp", oct_24_2013)));
     assertIterableEquals(keys.subList(16, 24), partitions);
   }
@@ -173,7 +179,7 @@ public class TestFileSystemPartitionIteratorTolerance extends MiniDFSTest {
   @Test
   public void testAfter() throws Exception {
     Iterable<StorageKey> partitions = firsts(new FileSystemPartitionIterator(
-        fileSystem, testDirectory, strategy,
+        fileSystem, testDirectory, strategy, schema,
         emptyConstraints.fromAfter("timestamp", oct_24_2013_end)));
     assertIterableEquals(keys.subList(17, 24), partitions);
   }
@@ -181,7 +187,7 @@ public class TestFileSystemPartitionIteratorTolerance extends MiniDFSTest {
   @Test
   public void testTo() throws Exception {
     Iterable<StorageKey> partitions = firsts(new FileSystemPartitionIterator(
-        fileSystem, testDirectory, strategy,
+        fileSystem, testDirectory, strategy, schema,
         emptyConstraints.to("timestamp", oct_25_2012)));
     assertIterableEquals(keys.subList(0, 6), partitions);
   }
@@ -189,7 +195,7 @@ public class TestFileSystemPartitionIteratorTolerance extends MiniDFSTest {
   @Test
   public void testBefore() throws Exception {
     Iterable <StorageKey> partitions = firsts(new FileSystemPartitionIterator(
-        fileSystem, testDirectory, strategy,
+        fileSystem, testDirectory, strategy, schema,
         emptyConstraints.toBefore("timestamp", oct_25_2012)));
     assertIterableEquals(keys.subList(0, 5), partitions);
   }
@@ -197,7 +203,7 @@ public class TestFileSystemPartitionIteratorTolerance extends MiniDFSTest {
   @Test
   public void testWith() throws Exception {
     Iterable<StorageKey> partitions = firsts(new FileSystemPartitionIterator(
-        fileSystem, testDirectory, strategy,
+        fileSystem, testDirectory, strategy, schema,
         emptyConstraints.with("timestamp", oct_24_2013)));
     assertIterableEquals(keys.subList(16, 17), partitions);
   }
@@ -205,7 +211,7 @@ public class TestFileSystemPartitionIteratorTolerance extends MiniDFSTest {
   @Test
   public void testDayRange() throws Exception {
     Iterable<StorageKey> partitions = firsts(new FileSystemPartitionIterator(
-        fileSystem, testDirectory, strategy,
+        fileSystem, testDirectory, strategy, schema,
         emptyConstraints.from("timestamp", oct_24_2013).to("timestamp", oct_24_2013_end)));
     assertIterableEquals(keys.subList(16, 17), partitions);
   }
@@ -213,7 +219,7 @@ public class TestFileSystemPartitionIteratorTolerance extends MiniDFSTest {
   @Test
   public void testLargerRange() throws Exception {
     Iterable <StorageKey> partitions = firsts(new FileSystemPartitionIterator(
-        fileSystem, testDirectory, strategy,
+        fileSystem, testDirectory, strategy, schema,
         emptyConstraints.from("timestamp", oct_25_2012).to("timestamp", oct_24_2013)));
     assertIterableEquals(keys.subList(5, 17), partitions);
   }


### PR DESCRIPTION
The conversion from path to StorageKey was incorrectly using the
FieldPartitioner#getType() method. The fix is to use
SchemaUtil.getPartitionType(), which will use the type from the schema
for identity partitioners rather than Object.class which results in no
conversion.

Most of the changes are to add a Schema to the PathConversion class and
update its tests.
