### PR TITLE
CDK-619: Implemented read/write support for Pig

### DIFF
--- a/kite-data/kite-data-pig/pom.xml
+++ b/kite-data/kite-data-pig/pom.xml
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Copyright 2013 Cloudera Inc.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~ http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>kite-data-pig</artifactId>
+
+  <parent>
+    <groupId>org.kitesdk</groupId>
+    <artifactId>kite-data</artifactId>
+    <version>0.16.1-SNAPSHOT</version>
+  </parent>
+
+  <name>Kite Data Pig Module</name>
+  <description>
+    The Kite Data Pig module provides Pig support for working with Kite datasets.
+  </description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemProperties>
+            <property>
+              <!-- Make sure derby.log goes to target/ subdir
+                   when running tests involving Hive -->
+              <name>derby.stream.error.file</name>
+              <value>target/derby.log</value>
+            </property>
+          </systemProperties>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <reportSets>
+          <reportSet>
+            <inherited>false</inherited>
+            <reports>
+              <report>index</report>
+              <report>summary</report>
+              <report>dependency-info</report>
+              <report>dependencies</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </reporting>
+
+  <dependencies>
+    <!-- Kite -->
+    <dependency>
+      <groupId>org.kitesdk</groupId>
+      <artifactId>kite-data-core</artifactId>
+      <version>0.16.1-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.kitesdk</groupId>
+      <artifactId>kite-data-mapreduce</artifactId>
+      <version>0.16.1-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.kitesdk</groupId>
+      <artifactId>kite-data-hcatalog</artifactId>
+      <version>0.16.1-SNAPSHOT</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.kitesdk</groupId>
+      <artifactId>kite-data-hbase</artifactId>
+      <version>0.16.1-SNAPSHOT</version>
+      <optional>true</optional>
+    </dependency>
+
+    <!-- Hadoop -->
+
+    <dependency>
+      <groupId>org.kitesdk</groupId>
+      <artifactId>${artifact.hadoop-deps}</artifactId>
+      <type>pom</type>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kitesdk</groupId>
+      <artifactId>${artifact.hbase-deps}</artifactId>
+      <type>pom</type>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kitesdk</groupId>
+      <artifactId>kite-hadoop-compatibility</artifactId>
+    </dependency>
+
+    <!-- Pig -->
+    <dependency>
+      <groupId>org.apache.pig</groupId>
+      <artifactId>pig</artifactId>
+      <version>0.12.0</version>
+      <classifier>h2</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.pig</groupId>
+      <artifactId>piggybank</artifactId>
+      <version>0.12.0</version>
+    </dependency>
+
+    <!-- Formats -->
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+    </dependency>
+
+    <!-- These should be compile-dependencies of kite-data-hcatalog
+         But, hive-exec includes classes from other modules at Hive-specific
+         versions, including avro's Schema. This causes errors in this and
+         other modules, so these are marked provided.
+         -->
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-exec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-serde</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Test Dependencies -->
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kitesdk</groupId>
+      <artifactId>kite-data-core</artifactId>
+      <version>0.16.1-SNAPSHOT</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kitesdk</groupId>
+      <artifactId>kite-data-hbase</artifactId>
+      <version>0.16.1-SNAPSHOT</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kitesdk</groupId>
+      <artifactId>${artifact.hadoop-test-deps}</artifactId>
+      <type>pom</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kitesdk</groupId>
+      <artifactId>${artifact.hbase-test-deps}</artifactId>
+      <type>pom</type>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- fix hbase/hive thrift version conflict -->
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <version>0.9.0</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/kite-data/kite-data-pig/src/main/java/org/kitesdk/data/pig/KiteStorage.java
+++ b/kite-data/kite-data-pig/src/main/java/org/kitesdk/data/pig/KiteStorage.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2014 Cloudera, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data.pig;
+
+import java.io.IOException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.OutputFormat;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.pig.Expression;
+import org.apache.pig.LoadFunc;
+import org.apache.pig.LoadMetadata;
+import org.apache.pig.ResourceSchema;
+import org.apache.pig.ResourceStatistics;
+import org.apache.pig.StoreFuncInterface;
+import org.apache.pig.backend.hadoop.executionengine.mapReduceLayer.PigSplit;
+import org.apache.pig.data.Tuple;
+import org.apache.pig.impl.util.avro.AvroStorageDataConversionUtilities;
+import org.apache.pig.impl.util.avro.AvroTupleWrapper;
+import org.apache.pig.piggybank.storage.avro.AvroSchema2Pig;
+import org.apache.pig.piggybank.storage.avro.PigSchema2Avro;
+import org.kitesdk.data.DatasetException;
+import org.kitesdk.data.Datasets;
+import org.kitesdk.data.View;
+import org.kitesdk.data.mapreduce.DatasetKeyInputFormat;
+import org.kitesdk.data.mapreduce.DatasetKeyOutputFormat;
+import org.kitesdk.data.spi.SchemaValidationUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class KiteStorage extends LoadFunc implements StoreFuncInterface, LoadMetadata {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KiteStorage.class);
+
+  private View<GenericRecord> inputDataset = null;
+  private View<GenericRecord> outputDataset = null;
+  private RecordReader<GenericRecord, Void> recordReader = null;
+  private RecordWriter<GenericRecord, Void> recordWriter = null;
+  private Job job = null;
+  private Schema outputSchema = null;
+
+  @Override
+  public void setLocation(String location, Job job) throws IOException {
+    inputDataset = Datasets.load(fixLocation(location));
+    DatasetKeyInputFormat.configure(job).readFrom(inputDataset);
+    this.job = job;
+  }
+
+  @Override
+  public InputFormat getInputFormat() throws IOException {
+    DatasetKeyInputFormat<GenericRecord> input = new DatasetKeyInputFormat<GenericRecord>();
+    input.setConf(job.getConfiguration());
+    return input;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public void prepareToRead(RecordReader reader, PigSplit split) throws IOException {
+    recordReader = reader;
+  }
+
+  @Override
+  public Tuple getNext() throws IOException {
+    try {
+      if (!recordReader.nextKeyValue()) {
+        return null;
+      }
+      GenericRecord record = recordReader.getCurrentKey();
+      return new AvroTupleWrapper<GenericRecord>(record);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      return null;
+    }
+  }
+
+  @Override
+  public String relToAbsPathForStoreLocation(String location, Path curDir) throws IOException {
+    return relativeToAbsolutePath(location, curDir);
+  }
+
+  @Override
+  public String relativeToAbsolutePath(String location, Path curDir) throws IOException {
+    String[] parts = location.split(":", 2);
+    if (parts[1].charAt(0) != '/') {
+      return parts[0] + ":/" + parts[1];
+    }
+
+    return location;
+  }
+
+  @Override
+  public OutputFormat getOutputFormat() throws IOException {
+    return new DatasetKeyOutputFormat<GenericRecord>();
+  }
+
+  @Override
+  public void setStoreLocation(String location, Job job) throws IOException {
+    outputDataset = Datasets.load(fixLocation(location));
+    validateSchema(outputDataset.getDataset().getDescriptor().getSchema());
+    DatasetKeyOutputFormat.configure(job).writeTo(outputDataset);
+    this.job = job;
+  }
+
+  private void validateSchema(Schema datasetSchema) {
+    if (outputSchema == null) {
+      return;
+    }
+
+    if (!SchemaValidationUtil.canRead(outputSchema, datasetSchema)) {
+      throw new DatasetException(
+          String.format("Trying to write with incompatible schema. Output "
+              + "schema:%n%n%s%n%n is incompatible with dataset schema:"
+              + "%n%n%s", outputSchema.toString(true),
+              datasetSchema.toString(true)));
+    }
+  }
+
+  @Override
+  public void checkSchema(ResourceSchema s) throws IOException {
+    outputSchema = PigSchema2Avro.convert(s, false);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public void prepareToWrite(RecordWriter writer) throws IOException {
+    recordWriter = writer;
+  }
+
+  @Override
+  public void putNext(Tuple t) throws IOException {
+    try {
+      GenericData.Record record = AvroStorageDataConversionUtilities.packIntoAvro(t,
+          outputDataset.getDataset().getDescriptor().getSchema());
+      recordWriter.write(record, null);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  @Override
+  public void setStoreFuncUDFContextSignature(String signature) {
+  }
+
+  @Override
+  public void cleanupOnFailure(String location, Job job) throws IOException {
+  }
+
+  @Override
+  public void cleanupOnSuccess(String location, Job job) throws IOException {
+  }
+
+  @Override
+  public ResourceSchema getSchema(String location, Job job) throws IOException {
+    View<GenericRecord> view = Datasets.load(fixLocation(location));
+    return AvroSchema2Pig.convert(view.getDataset().getDescriptor().getSchema());
+  }
+
+  @Override
+  public ResourceStatistics getStatistics(String location, Job job) throws IOException {
+    return null;
+  }
+
+  @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "PZLA_PREFER_ZERO_LENGTH_ARRAYS")
+  @Override
+  public String[] getPartitionKeys(String location, Job job) throws IOException {
+    return null;
+  }
+
+  @Override
+  public void setPartitionFilter(Expression partitionFilter) throws IOException {
+  }
+
+  public static String fixLocation(String location) {
+    String[] parts = location.split(":", 2);
+    if (parts[1].charAt(0) == '/') {
+      return parts[0] + ":" + parts[1].substring(1);
+    }
+    return location;
+  }
+}

--- a/kite-data/kite-data-pig/src/main/java/org/kitesdk/data/pig/KiteStorage.java
+++ b/kite-data/kite-data-pig/src/main/java/org/kitesdk/data/pig/KiteStorage.java
@@ -100,9 +100,13 @@ public class KiteStorage extends LoadFunc implements StoreFuncInterface, LoadMet
 
   @Override
   public String relativeToAbsolutePath(String location, Path curDir) throws IOException {
-    String[] parts = location.split(":", 2);
-    if (parts[1].charAt(0) != '/') {
-      return parts[0] + ":/" + parts[1];
+    int colon = location.indexOf(':');
+    if (colon != -1) {
+      String scheme = location.substring(0, colon);
+      String path = location.substring(colon+1);
+      if (path.charAt(0) != '/') {
+        return scheme + ":/" + path;
+      }
     }
 
     return location;
@@ -180,7 +184,8 @@ public class KiteStorage extends LoadFunc implements StoreFuncInterface, LoadMet
     return null;
   }
 
-  @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "PZLA_PREFER_ZERO_LENGTH_ARRAYS")
+  @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="PZLA_PREFER_ZERO_LENGTH_ARRAYS",
+      justification="The Pig API states: 'Implementations should return null to indicate that there are no partition keys'")
   @Override
   public String[] getPartitionKeys(String location, Job job) throws IOException {
     return null;
@@ -191,9 +196,13 @@ public class KiteStorage extends LoadFunc implements StoreFuncInterface, LoadMet
   }
 
   public static String fixLocation(String location) {
-    String[] parts = location.split(":", 2);
-    if (parts[1].charAt(0) == '/') {
-      return parts[0] + ":" + parts[1].substring(1);
+    int colon = location.indexOf(':');
+    if (colon != -1) {
+      String scheme = location.substring(0, colon);
+      String path = location.substring(colon+1);
+      if (path.charAt(0) == '/') {
+        return scheme + ":" + path.substring(1);
+      }
     }
     return location;
   }

--- a/kite-data/kite-data-pig/src/test/java/org/kitesdk/data/pig/TestKiteStorage.java
+++ b/kite-data/kite-data-pig/src/test/java/org/kitesdk/data/pig/TestKiteStorage.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2014 Cloudera, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kitesdk.data.pig;
+
+import java.io.File;
+import java.io.IOException;
+import org.apache.avro.generic.GenericData;
+import org.apache.pig.ExecType;
+import org.apache.pig.PigServer;
+import org.apache.pig.backend.executionengine.ExecException;
+import org.apache.pig.backend.executionengine.ExecJob;
+import org.apache.pig.backend.executionengine.ExecJob.JOB_STATUS;
+import org.apache.pig.impl.io.FileLocalizer;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertTrue;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.kitesdk.data.Dataset;
+import org.kitesdk.data.DatasetDescriptor;
+import org.kitesdk.data.Datasets;
+import static org.kitesdk.data.spi.filesystem.DatasetTestUtilities.USER_SCHEMA;
+import static org.kitesdk.data.spi.filesystem.DatasetTestUtilities.checkTestUsers;
+import static org.kitesdk.data.spi.filesystem.DatasetTestUtilities.writeTestUsers;
+
+public class TestKiteStorage {
+
+  private static PigServer pigServerLocal = null;
+  private static String outbasedir;
+  private static final String TMP_DIR = System.getProperty("buildDirectory") + "/tmp/pig";
+
+  // Adapted from Apache Pig (contrib/piggybank/java/src/test/java/org/apache/pig/piggybank/test/storage/avro/TestAvroStorage.java)
+  @BeforeClass
+  public static void setup() throws ExecException, IOException {
+    pigServerLocal = new PigServer(ExecType.LOCAL);
+    pigServerLocal.getPigContext().getProperties().setProperty("pig.temp.dir", TMP_DIR);
+    outbasedir = FileLocalizer.getTemporaryPath(pigServerLocal.getPigContext()).toString() + "/TestKiteStorage/";
+    deleteDirectory(new File(outbasedir));
+  }
+
+  // Adapted from Apache Pig (contrib/piggybank/java/src/test/java/org/apache/pig/piggybank/test/storage/avro/TestAvroStorage.java)
+  @AfterClass
+  public static void teardown() {
+    if (pigServerLocal != null) {
+      pigServerLocal.shutdown();
+    }
+  }
+
+  @Test
+  public void testGeneric() throws IOException {
+    String inUri = createUri("in");
+    if (Datasets.exists(inUri)) {
+      Datasets.delete(inUri);
+    }
+    Dataset<GenericData.Record> inputDataset = Datasets.create(inUri,
+        new DatasetDescriptor.Builder().schema(USER_SCHEMA).build(),
+        GenericData.Record.class);
+
+    String outUri = createUri("out");
+    if (Datasets.exists(outUri)) {
+      Datasets.delete(outUri);
+    }
+    Dataset<GenericData.Record> outputDataset = Datasets.create(outUri,
+        new DatasetDescriptor.Builder().schema(USER_SCHEMA).build(),
+        GenericData.Record.class);
+
+    // write two files, each of 5 records
+    writeTestUsers(inputDataset, 5, 0);
+    writeTestUsers(inputDataset, 5, 5);
+
+    String[] queries = {
+      " in = LOAD '" + inUri
+      + "' USING org.kitesdk.data.pig.KiteStorage;",
+      " STORE in INTO '" + outUri
+      + "' USING org.kitesdk.data.pig.KiteStorage;"
+    };
+    TestKiteStorage.this.testKiteStorage(queries);
+
+    checkTestUsers(outputDataset, 10);
+  }
+
+  @Ignore("Fails due to double creating of the temp repository by DatasetKeyOutputFormat")
+  @Test
+  public void testMultipleOutputs() throws IOException {
+    String inUri = createUri("in");
+    if (Datasets.exists(inUri)) {
+      Datasets.delete(inUri);
+    }
+    Dataset<GenericData.Record> inputDataset = Datasets.create(inUri,
+        new DatasetDescriptor.Builder().schema(USER_SCHEMA).build(),
+        GenericData.Record.class);
+
+    String outUri1 = createUri("out-1");
+    if (Datasets.exists(outUri1)) {
+      Datasets.delete(outUri1);
+    }
+    Dataset<GenericData.Record> outputDataset1 = Datasets.create(outUri1,
+        new DatasetDescriptor.Builder().schema(USER_SCHEMA).build(),
+        GenericData.Record.class);
+
+    String outUri2 = createUri("out-2");
+    if (Datasets.exists(outUri2)) {
+      Datasets.delete(outUri2);
+    }
+    Dataset<GenericData.Record> outputDataset2 = Datasets.create(outUri2,
+        new DatasetDescriptor.Builder().schema(USER_SCHEMA).build(),
+        GenericData.Record.class);
+
+    // write two files, each of 5 records
+    writeTestUsers(inputDataset, 5, 0);
+    writeTestUsers(inputDataset, 5, 5);
+
+    String[] queries = {
+      " in = LOAD '" + inUri
+      + "' USING org.kitesdk.data.pig.KiteStorage;",
+      " STORE in INTO '" + outUri1
+      + "' USING org.kitesdk.data.pig.KiteStorage;",
+      " STORE in INTO '" + outUri2
+      + "' USING org.kitesdk.data.pig.KiteStorage;"
+    };
+    TestKiteStorage.this.testKiteStorage(queries);
+
+    checkTestUsers(outputDataset1, 10);
+    checkTestUsers(outputDataset2, 10);
+  }
+
+  // Adapted from Apache Pig (contrib/piggybank/java/src/test/java/org/apache/pig/piggybank/test/storage/avro/TestAvroStorage.java)
+  private void testKiteStorage(String... queries) throws IOException {
+    testKiteStorage(false, queries);
+  }
+
+  // Adapted from Apache Pig (contrib/piggybank/java/src/test/java/org/apache/pig/piggybank/test/storage/avro/TestAvroStorage.java)
+  private void testKiteStorage(boolean expectedToFail, String... queries) throws IOException {
+    pigServerLocal.setBatchOn();
+    for (String query : queries) {
+      if (query != null && query.length() > 0) {
+        pigServerLocal.registerQuery(query);
+      }
+    }
+    int numOfFailedJobs = 0;
+    for (ExecJob job : pigServerLocal.executeBatch()) {
+      if (job.getStatus().equals(JOB_STATUS.FAILED)) {
+        numOfFailedJobs++;
+      }
+    }
+    if (expectedToFail) {
+      assertTrue("There was no failed job!", numOfFailedJobs > 0);
+    } else {
+      assertTrue("There was a failed job!", numOfFailedJobs == 0);
+    }
+  }
+
+  // Adapted from Apache Pig (contrib/piggybank/java/src/test/java/org/apache/pig/piggybank/test/storage/avro/TestAvroStorage.java)
+  private static void deleteDirectory(File path) {
+    if (path.exists()) {
+      File[] files = path.listFiles();
+      for (File file : files) {
+        if (file.isDirectory()) {
+          deleteDirectory(file);
+        }
+        file.delete();
+      }
+    }
+  }
+
+  private String createUri(String dataset) {
+    return "dataset:file:" + TMP_DIR + "/" + dataset;
+  }
+
+}

--- a/kite-data/pom.xml
+++ b/kite-data/pom.xml
@@ -30,6 +30,7 @@
     <module>kite-data-hbase</module>
     <module>kite-data-mapreduce</module>
     <module>kite-data-spark</module>
+    <module>kite-data-pig</module>
   </modules>
 
   <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,9 @@
 
   <inceptionYear>2013</inceptionYear>
   <url>${url.project}</url>
+  <organization>
+    <name>Cloudera, Inc</name>
+  </organization>
 
   <developers>
     <developer>
@@ -513,6 +516,9 @@
             <!-- https://issues.apache.org/jira/browse/ZOOKEEPER-1661-->
             <!-- https://issues.apache.org/jira/browse/ZOOKEEPER-1476-->
             <argLine>-Xmx512m -XX:MaxPermSize=128m -Djava.net.preferIPv4Stack=true</argLine> <!-- 512MB needed for HBase 2 -->
+            <systemPropertyVariables>
+              <buildDirectory>${project.build.directory}</buildDirectory>
+            </systemPropertyVariables>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
     * The patch still needs to move the pig dependencies under
       dependency management in the parent pom.
     * This needs more tests, in particular on error handling.