### PR TITLE
CDK-518: Add EntityAccessor to read entity fields.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/DataModelUtil.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/DataModelUtil.java
@@ -156,4 +156,9 @@ public class DataModelUtil {
 
     return null;
   }
+
+  public static <E> EntityAccessor<E> accessor(Class<E> type, Schema schema) {
+    return new EntityAccessor<E>(type, schema);
+  }
+
 }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/EntityAccessor.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/EntityAccessor.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2013 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data.spi;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.concurrent.Immutable;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+
+@Immutable
+public class EntityAccessor<E> {
+
+  private final Schema schema;
+  private final Class<E> type;
+  private final GenericData model;
+  private final Map<String, List<Schema.Field>> cache = Maps.newHashMap();
+
+  EntityAccessor(Class<E> type, Schema schema) {
+    this.type = DataModelUtil.resolveType(type, schema);
+    this.schema = DataModelUtil.getReaderSchema(this.type, schema);
+    this.model = DataModelUtil.getDataModelForType(this.type);
+  }
+
+  public Class<E> getType() {
+    return type;
+  }
+
+  public Schema getEntitySchema() {
+    return schema;
+  }
+
+  public Object get(E object, String name) {
+    List<Schema.Field> fields = cache.get(name);
+
+    Object value;
+    if (fields != null) {
+      value = get(object, fields);
+
+    } else {
+      value = object;
+      fields = Lists.newArrayList();
+      Schema nested = schema;
+      for (String level : SchemaUtil.NAME_SPLITTER.split(name)) {
+        // assume that the nested schemas are Records
+        // this is checked by SchemaUtil.fieldSchema(Schema, String)
+        Schema.Field field = nested.getField(level);
+        fields.add(field);
+        nested = field.schema();
+        value = model.getField(value, level, field.pos());
+      }
+      cache.put(name, fields);
+    }
+
+    return value;
+  }
+
+  public Object get(E object, Iterable<Schema.Field> fields) {
+    Object value = object;
+    for (Schema.Field level : fields) {
+      value = model.getField(value, level.name(), level.pos());
+    }
+    return value;
+  }
+}

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/FilteredRecordReader.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/FilteredRecordReader.java
@@ -26,9 +26,11 @@ public class FilteredRecordReader<E> extends RecordReader<E, Void> {
   private Predicate<E> predicate;
   private E current;
 
-  public FilteredRecordReader(RecordReader<E, Void> unfiltered, Constraints constraints) {
+  public FilteredRecordReader(RecordReader<E, Void> unfiltered,
+                              Constraints constraints,
+                              EntityAccessor<E> accessor) {
     this.unfiltered = unfiltered;
-    this.predicate = constraints.toEntityPredicate(); // TODO: optimize with storage key
+    this.predicate = constraints.toEntityPredicate(accessor); // TODO: optimize with storage key
   }
 
   @Override

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVFileReader.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVFileReader.java
@@ -21,9 +21,9 @@ import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.kitesdk.data.DatasetDescriptor;
-import org.kitesdk.data.DatasetReader;
 import org.kitesdk.data.DatasetReaderException;
 import org.kitesdk.data.spi.AbstractDatasetReader;
+import org.kitesdk.data.spi.EntityAccessor;
 import org.kitesdk.data.spi.ReaderWriterState;
 import com.google.common.base.Preconditions;
 import org.apache.avro.Schema;
@@ -31,7 +31,6 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.reflect.ReflectData;
-import org.apache.avro.specific.SpecificData;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -40,7 +39,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.NoSuchElementException;
-import org.kitesdk.data.spi.DataModelUtil;
 
 class CSVFileReader<E> extends AbstractDatasetReader<E> {
 
@@ -67,15 +65,14 @@ class CSVFileReader<E> extends AbstractDatasetReader<E> {
 
   @SuppressWarnings("unchecked")
   public CSVFileReader(FileSystem fileSystem, Path path,
-      DatasetDescriptor descriptor, Class<E> type) {
+      DatasetDescriptor descriptor, EntityAccessor<E> accessor) {
     this.fs = fileSystem;
     this.path = path;
-    this.schema = descriptor.getSchema();
-    this.recordClass = DataModelUtil.resolveType(type, schema);
+    this.schema = accessor.getEntitySchema();
+    this.recordClass = accessor.getType();
     this.state = ReaderWriterState.NEW;
     this.props = CSVProperties.fromDescriptor(descriptor);
 
-    Schema schema = descriptor.getSchema();
     Preconditions.checkArgument(Schema.Type.RECORD.equals(schema.getType()),
         "Schemas for CSV files must be records of primitive types");
 

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVInputFormat.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVInputFormat.java
@@ -28,17 +28,19 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 import org.kitesdk.compat.Hadoop;
 import org.kitesdk.data.DatasetDescriptor;
+import org.kitesdk.data.spi.DataModelUtil;
+import org.kitesdk.data.spi.EntityAccessor;
 
 class CSVInputFormat<E> extends FileInputFormat<E, Void> {
-  private DatasetDescriptor descriptor;
-  private Class<E> type;
+  private DatasetDescriptor descriptor = null;
+  private EntityAccessor<E> accessor = null;
 
   public void setDescriptor(DatasetDescriptor descriptor) {
     this.descriptor = descriptor;
   }
 
   public void setType(Class<E> type) {
-    this.type = type;
+    this.accessor = DataModelUtil.accessor(type, descriptor.getSchema());
   }
 
   @Override
@@ -59,7 +61,7 @@ class CSVInputFormat<E> extends FileInputFormat<E, Void> {
         .getConfiguration.invoke(context);
     Path path = ((FileSplit) split).getPath();
     CSVFileReader<E> reader = new CSVFileReader<E>(
-        path.getFileSystem(conf), path, descriptor, type);
+        path.getFileSystem(conf), path, descriptor, accessor);
     reader.initialize();
     return reader.asRecordReader();
   }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemView.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemView.java
@@ -79,8 +79,8 @@ class FileSystemView<E> extends AbstractRefinableView<E> implements InputFormatA
 
   @Override
   public DatasetReader<E> newReader() {
-    AbstractDatasetReader<E> reader = new MultiFileDatasetReader<E>(
-        fs, pathIterator(), dataset.getDescriptor(), constraints, type);
+    AbstractDatasetReader<E> reader = new MultiFileDatasetReader<E>(fs,
+        pathIterator(), dataset.getDescriptor(), constraints, getAccessor());
     reader.initialize();
     return reader;
   }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemViewKeyInputFormat.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemViewKeyInputFormat.java
@@ -134,7 +134,7 @@ class FileSystemViewKeyInputFormat<E> extends InputFormat<E, Void> {
     if (view != null) {
       // use the constraints to filter out entities from the reader
       return new FilteredRecordReader<E>(unfilteredRecordReader,
-          ((AbstractRefinableView) view).getConstraints());
+          ((AbstractRefinableView) view).getConstraints(), view.getAccessor());
     }
     return unfilteredRecordReader;
   }

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestCSVAppender.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestCSVAppender.java
@@ -27,6 +27,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.MiniDFSTest;
+import org.kitesdk.data.spi.DataModelUtil;
 
 public class TestCSVAppender extends MiniDFSTest {
   private static final Schema schema = SchemaBuilder
@@ -129,7 +130,8 @@ public class TestCSVAppender extends MiniDFSTest {
 
   public int count(FileSystem fs, Path path, DatasetDescriptor descriptor) {
     CSVFileReader<GenericRecord> reader = new CSVFileReader<GenericRecord>(
-            fs, path, descriptor, GenericRecord.class);
+        fs, path, descriptor,
+        DataModelUtil.accessor(GenericRecord.class, descriptor.getSchema()));
     int count = 0;
     reader.initialize();
     for (GenericRecord r : reader) {

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestCSVFileReader.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestCSVFileReader.java
@@ -33,6 +33,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
+import org.kitesdk.data.spi.DataModelUtil;
 
 public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
   /*
@@ -120,7 +121,7 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
         .schema(VALIDATOR_SCHEMA)
         .build();
     return new CSVFileReader<GenericData.Record>(localfs, validatorFile, desc,
-        GenericData.Record.class);
+        DataModelUtil.accessor(GenericData.Record.class, desc.getSchema()));
   }
 
   @Override
@@ -146,7 +147,8 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
     final DatasetDescriptor desc = new DatasetDescriptor.Builder()
         .schema(SchemaBuilder.array().items().stringType())
         .build();
-    new CSVFileReader<GenericData.Record>(localfs, csvFile, desc, GenericData.Record.class);
+    new CSVFileReader<GenericData.Record>(localfs, csvFile, desc,
+        DataModelUtil.accessor(GenericData.Record.class, desc.getSchema()));
   }
 
   @Test
@@ -156,7 +158,7 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
         .build();
     final CSVFileReader<GenericData.Record> reader =
         new CSVFileReader<GenericData.Record>(localfs, csvFile, desc,
-            GenericData.Record.class);
+            DataModelUtil.accessor(GenericData.Record.class, desc.getSchema()));
 
     reader.initialize();
     Assert.assertTrue(reader.hasNext());
@@ -192,7 +194,7 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
         .build();
     final CSVFileReader<GenericData.Record> reader =
         new CSVFileReader<GenericData.Record>(localfs, tsvFile, desc,
-            GenericData.Record.class);
+            DataModelUtil.accessor(GenericData.Record.class, desc.getSchema()));
 
     reader.initialize();
     Assert.assertTrue(reader.hasNext());
@@ -228,7 +230,7 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
         .build();
     final CSVFileReader<GenericData.Record> reader =
         new CSVFileReader<GenericData.Record>(localfs, tsvFile, desc,
-            GenericData.Record.class);
+            DataModelUtil.accessor(GenericData.Record.class, desc.getSchema()));
 
     reader.initialize();
     Assert.assertTrue(reader.hasNext());
@@ -262,7 +264,7 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
         .build();
     final CSVFileReader<GenericData.Record> reader =
         new CSVFileReader<GenericData.Record>(localfs, csvFile, desc,
-            GenericData.Record.class);
+            DataModelUtil.accessor(GenericData.Record.class, desc.getSchema()));
 
     reader.initialize();
     Assert.assertTrue(reader.hasNext());
@@ -297,7 +299,8 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
         .schema(BEAN_SCHEMA)
         .build();
     final CSVFileReader<TestBean> reader =
-        new CSVFileReader<TestBean>(localfs, csvFile, desc, TestBean.class);
+        new CSVFileReader<TestBean>(localfs, csvFile, desc,
+            DataModelUtil.accessor(TestBean.class, desc.getSchema()));
 
     reader.initialize();
     Assert.assertTrue(reader.hasNext());
@@ -308,11 +311,22 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
     Assert.assertEquals(false, bean.myBool);
 
     Assert.assertTrue(reader.hasNext());
-    bean = reader.next();
-    Assert.assertEquals("str,2", bean.myStr);
-    Assert.assertEquals((Integer) 0, bean.myInt);
-    Assert.assertEquals((Float) 4.0f, bean.myFloat);
-    Assert.assertEquals(true, bean.myBool);
+    TestHelpers.assertThrows("Should complain about missing default",
+        AvroRuntimeException.class, new Runnable() {
+          @Override
+          public void run() {
+            reader.next();
+          }
+        });
+//    The following fails with a missing default until Avro 1.7.6. This happens
+//    because the TestBean class's Schema doesn't have a default for myInt.
+//
+//    Assert.assertTrue(reader.hasNext());
+//    bean = reader.next();
+//    Assert.assertEquals("str,2", bean.myStr);
+//    Assert.assertEquals((Integer) 0, bean.myInt);
+//    Assert.assertEquals((Float) 4.0f, bean.myFloat);
+//    Assert.assertEquals(true, bean.myBool);
 
     Assert.assertTrue(reader.hasNext());
     TestHelpers.assertThrows("Should complain about missing default",
@@ -333,7 +347,7 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
         .build();
     final CSVFileReader<TestGenericRecord> reader =
         new CSVFileReader<TestGenericRecord>(localfs, csvFile, desc,
-        TestGenericRecord.class);
+        DataModelUtil.accessor(TestGenericRecord.class, desc.getSchema()));
 
     reader.initialize();
     Assert.assertTrue(reader.hasNext());

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestMultiFileDatasetReader.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestMultiFileDatasetReader.java
@@ -35,6 +35,8 @@ import static org.kitesdk.data.spi.filesystem.DatasetTestUtilities.*;
 import org.kitesdk.data.impl.Accessor;
 import org.apache.avro.generic.GenericData;
 import org.kitesdk.data.spi.Constraints;
+import org.kitesdk.data.spi.DataModelUtil;
+import org.kitesdk.data.spi.EntityAccessor;
 
 public class TestMultiFileDatasetReader extends TestDatasetReaders {
 
@@ -51,13 +53,15 @@ public class TestMultiFileDatasetReader extends TestDatasetReaders {
     };
   public static final DatasetDescriptor DESCRIPTOR = new DatasetDescriptor
       .Builder().schema(STRING_SCHEMA).build();
+  private static final EntityAccessor<Record> ACCESSOR =
+      DataModelUtil.accessor(Record.class, STRING_SCHEMA);
 
   @Override
   public DatasetReader newReader() throws IOException {
-    return new MultiFileDatasetReader<GenericData.Record>(
+    return new MultiFileDatasetReader<Record>(
         FileSystem.get(new Configuration()),
         Lists.newArrayList(TEST_FILE, TEST_FILE),
-        DESCRIPTOR, CONSTRAINTS, GenericData.Record.class);
+        DESCRIPTOR, CONSTRAINTS, ACCESSOR);
   }
 
   @Override
@@ -79,7 +83,7 @@ public class TestMultiFileDatasetReader extends TestDatasetReaders {
   @Test
   public void testEmptyPathList() throws IOException {
     MultiFileDatasetReader<Record> reader = new MultiFileDatasetReader<Record>(
-        fileSystem, Lists.<Path>newArrayList(), DESCRIPTOR, CONSTRAINTS, Record.class);
+        fileSystem, Lists.<Path>newArrayList(), DESCRIPTOR, CONSTRAINTS, ACCESSOR);
 
     checkReaderBehavior(reader, 0, VALIDATOR);
   }
@@ -87,36 +91,36 @@ public class TestMultiFileDatasetReader extends TestDatasetReaders {
   @Test
   public void testSingleFile() throws IOException {
     MultiFileDatasetReader<Record> reader = new MultiFileDatasetReader<Record>(
-        fileSystem, Lists.newArrayList(TEST_FILE), DESCRIPTOR, CONSTRAINTS, Record.class);
+        fileSystem, Lists.newArrayList(TEST_FILE), DESCRIPTOR, CONSTRAINTS, ACCESSOR);
 
     checkReaderBehavior(reader, 100, VALIDATOR);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test(expected = NullPointerException.class)
   public void testRequriesFileSystem() throws IOException {
     new MultiFileDatasetReader<Record>(
         null, Lists.newArrayList(TEST_FILE, TEST_FILE), DESCRIPTOR,
-        CONSTRAINTS, Record.class);
+        CONSTRAINTS, ACCESSOR);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test(expected = NullPointerException.class)
   public void testRequriesFiles() throws IOException {
     new MultiFileDatasetReader<Record>(
-        fileSystem, null, DESCRIPTOR, CONSTRAINTS, Record.class);
+        fileSystem, null, DESCRIPTOR, CONSTRAINTS, ACCESSOR);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test(expected = NullPointerException.class)
   public void testRequriesDescriptor() throws IOException {
     new MultiFileDatasetReader<Record>(
         fileSystem, Lists.newArrayList(TEST_FILE, TEST_FILE), null,
-        CONSTRAINTS, Record.class);
+        CONSTRAINTS, ACCESSOR);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testRejectsNullPaths() throws IOException {
     MultiFileDatasetReader<Record> reader = new MultiFileDatasetReader<Record>(
         fileSystem, Lists.newArrayList(null, TEST_FILE), DESCRIPTOR,
-        CONSTRAINTS, Record.class);
+        CONSTRAINTS, ACCESSOR);
     reader.initialize();
     reader.hasNext();
   }
@@ -129,7 +133,8 @@ public class TestMultiFileDatasetReader extends TestDatasetReaders {
         .build();
 
     MultiFileDatasetReader<Record> reader = new MultiFileDatasetReader<Record>(
-        fileSystem, Lists.newArrayList(TEST_FILE), descriptor, CONSTRAINTS, Record.class);
+        fileSystem, Lists.newArrayList(TEST_FILE), descriptor, CONSTRAINTS,
+        ACCESSOR);
 
     try {
       reader.initialize();
@@ -153,7 +158,7 @@ public class TestMultiFileDatasetReader extends TestDatasetReaders {
 
     MultiFileDatasetReader<Record> reader = new MultiFileDatasetReader<Record>(
         fileSystem, Lists.newArrayList(missingFile, TEST_FILE), DESCRIPTOR,
-        CONSTRAINTS, Record.class);
+        CONSTRAINTS, ACCESSOR);
 
     try {
       try {
@@ -191,7 +196,7 @@ public class TestMultiFileDatasetReader extends TestDatasetReaders {
     try {
       MultiFileDatasetReader<Record> reader = new MultiFileDatasetReader<Record>(
           fileSystem, Lists.newArrayList(emptyFile, TEST_FILE), DESCRIPTOR,
-          CONSTRAINTS, Record.class);
+          CONSTRAINTS, ACCESSOR);
 
       try {
         try {

--- a/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/DaoView.java
+++ b/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/DaoView.java
@@ -71,8 +71,8 @@ class DaoView<E> extends AbstractRefinableView<E> implements InputFormatAccessor
   @Override
   public DatasetReader<E> newReader() {
     final DatasetReader<E> wrappedReader = newEntityScanner();
-    final UnmodifiableIterator<E> filteredIterator =
-        Iterators.filter(wrappedReader.iterator(), constraints.toEntityPredicate());
+    final UnmodifiableIterator<E> filteredIterator = Iterators.filter(
+        wrappedReader.iterator(), constraints.toEntityPredicate(getAccessor()));
     AbstractDatasetReader<E> reader = new AbstractDatasetReader<E>() {
       @Override
       public void initialize() {
@@ -145,7 +145,7 @@ class DaoView<E> extends AbstractRefinableView<E> implements InputFormatAccessor
 
       @Override
       public void write(E entity) {
-        StorageKey key = partitionStratKey.reuseFor(entity);
+        StorageKey key = partitionStratKey.reuseFor(entity, getAccessor());
         if (!keyPredicate.apply(key)) {
           throw new IllegalArgumentException("View does not contain entity: " + entity);
         }

--- a/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/HBaseViewKeyInputFormat.java
+++ b/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/HBaseViewKeyInputFormat.java
@@ -36,7 +36,6 @@ import org.kitesdk.data.hbase.impl.BaseEntityScanner;
 import org.kitesdk.data.hbase.impl.Dao;
 import org.kitesdk.data.hbase.impl.EntityMapper;
 import org.kitesdk.data.spi.AbstractKeyRecordReaderWrapper;
-import org.kitesdk.data.spi.AbstractRefinableView;
 import org.kitesdk.data.spi.FilteredRecordReader;
 
 import static org.apache.hadoop.hbase.mapreduce.TableInputFormat.SCAN;
@@ -76,10 +75,10 @@ class HBaseViewKeyInputFormat<E> extends InputFormat<E, Void> {
     TableInputFormat delegate = getDelegate(conf);
     RecordReader<E, Void> unfilteredRecordReader = new HBaseRecordReaderWrapper<E>(
         delegate.createRecordReader(inputSplit, taskAttemptContext), entityMapper);
-    if (view != null && view instanceof AbstractRefinableView) {
+    if (view != null) {
       // use the constraints to filter out entities from the reader
       return new FilteredRecordReader<E>(unfilteredRecordReader,
-          ((AbstractRefinableView) view).getConstraints());
+          view.getConstraints(), view.getAccessor());
     }
     return unfilteredRecordReader;
   }

--- a/kite-data/kite-data-hbase/src/test/java/org/kitesdk/data/hbase/DaoViewTest.java
+++ b/kite-data/kite-data-hbase/src/test/java/org/kitesdk/data/hbase/DaoViewTest.java
@@ -71,13 +71,13 @@ public class DaoViewTest {
   }
 
   @Before
-  @SuppressWarnings("unchecked")
   public void setup() throws Exception {
     repo = new HBaseDatasetRepository.Builder().configuration(
         HBaseTestUtils.getConf()).build();
     DatasetDescriptor descriptor = new DatasetDescriptor.Builder()
         .schemaLiteral(testEntity).build();
-    ds = (DaoDataset) repo.create("default", tableName, descriptor);
+    ds = (DaoDataset<TestEntity>) repo.create(
+        "default", tableName, descriptor, TestEntity.class);
   }
 
   @After


### PR DESCRIPTION
Before this commit, there were serveral places that read record data.
Older code used PropertyDescriptor to get accessor methods and newer
code used ReflectData#getField and didn't use DataModelUtil. This adds
an EntityAccessor class that resolves an entity type against a Schema,
determines the correct GenericData model for reading, and accesses
record data. This is also a good place to expose the resolved entity
class, as well as the actual entity schema based on that class.

The EntityAccessor instance is Immutable and can be shared. It also has
support for reading nested fields that will be required by CDK-435.
Nested field names are separated by '.', for example, location.latitude.
Where possible, EntityAccessor should be shared because it caches the
sequence of fields to access nested data.
