### PR TITLE
CDK-653: Add DefaultConfiguration.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/DefaultConfiguration.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/DefaultConfiguration.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data.spi;
+
+import org.apache.hadoop.conf.Configuration;
+
+/**
+ * Manages a default Hadoop {@link Configuration}.
+ * <p>
+ * Implementations that are built on Hadoop need to be passed options via a
+ * {@code Configuration} that is based on the environment, but could be changed
+ * by command-line options. This class allows both patterns. The {@link #get()}
+ * method will return a {@code Configuration} based on the environment by
+ * default, which can be updated and changed using {@link #set(Configuration)}.
+ * <p>
+ * Note that the {@code Configuration} managed by this class is global and must
+ * only be used for unchanging configuration options, like the URI for HDFS.
+ */
+public class DefaultConfiguration {
+
+  // initialize the default configuration from the environment
+  private static Configuration conf = new Configuration();
+
+  /**
+   * Get a copy of the default Hadoop {@link Configuration}.
+   * <p>
+   * The {@code Configuration} returned by this method can be changed without
+   * changing the global {@code Configuration}.
+   *
+   * @return A {@code Configuration} based on the environment or set by
+   *          {@link #set(Configuration)}
+   */
+  public static Configuration get() {
+    return new Configuration(conf);
+  }
+
+  /**
+   * Set the default Hadoop {@link Configuration}.
+   */
+  public static void set(Configuration conf) {
+    DefaultConfiguration.conf = conf;
+  }
+}

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestDefaultConfigurationFileSystem.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestDefaultConfigurationFileSystem.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2013 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data.spi.filesystem;
+
+import java.net.URI;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.kitesdk.data.DatasetDescriptor;
+import org.kitesdk.data.DatasetIOException;
+import org.kitesdk.data.Datasets;
+import org.kitesdk.data.MiniDFSTest;
+import org.kitesdk.data.spi.DatasetRepository;
+import org.kitesdk.data.spi.DefaultConfiguration;
+
+public class TestDefaultConfigurationFileSystem extends MiniDFSTest {
+
+  private static final DatasetRepository repo =
+      new FileSystemDatasetRepository.Builder()
+          .configuration(getConfiguration()) // explicitly use the DFS config
+          .rootDirectory(URI.create("hdfs:/tmp/datasets"))
+              .build();
+
+  @Before
+  public void createStringsDataset() throws Exception {
+    // create a dataset in HDFS
+    repo.delete("ns", "strings");
+    repo.create("ns", "strings", new DatasetDescriptor.Builder()
+        .schemaLiteral("\"string\"")
+        .build());
+  }
+
+  @After
+  public void removeStringsDataset() {
+    repo.delete("ns", "strings");
+  }
+
+  @Test
+  public void testFindsHDFS() throws Exception {
+    // set the default configuration that the loader will use
+    Configuration existing = DefaultConfiguration.get();
+    DefaultConfiguration.set(getConfiguration());
+
+    FileSystemDataset<GenericRecord> dataset =
+        Datasets.load("dataset:hdfs:/tmp/datasets/ns/strings");
+    Assert.assertNotNull("Dataset should be found", dataset);
+    Assert.assertEquals("Dataset should be located in HDFS",
+        "hdfs", dataset.getFileSystem().getUri().getScheme());
+
+    // replace the original config so the other tests are not affected
+    DefaultConfiguration.set(existing);
+  }
+
+  @Test(expected=DatasetIOException.class)
+  public void testCannotFindHDFS() throws Exception {
+    // do not set the default configuration that the loader will use
+    Datasets.load("dataset:hdfs:/tmp/datasets/ns/strings");
+  }
+}

--- a/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/impl/Loader.java
+++ b/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/impl/Loader.java
@@ -17,6 +17,7 @@ package org.kitesdk.data.hbase.impl;
 
 import org.kitesdk.data.hbase.HBaseDatasetRepository;
 import org.kitesdk.data.spi.DatasetRepository;
+import org.kitesdk.data.spi.DefaultConfiguration;
 import org.kitesdk.data.spi.Loadable;
 import org.kitesdk.data.spi.OptionBuilder;
 import org.kitesdk.data.spi.Registration;
@@ -48,7 +49,7 @@ public class Loader implements Loadable {
         new OptionBuilder<DatasetRepository>() {
           @Override
           public DatasetRepository getFromOptions(Map<String, String> options) {
-            Configuration conf = HBaseConfiguration.create();
+            Configuration conf = HBaseConfiguration.create(DefaultConfiguration.get());
             String[] hostsAndPort = parseHostsAndPort(options.get("zk"));
             conf.set(HConstants.ZOOKEEPER_QUORUM, hostsAndPort[0]);
             String port = hostsAndPort[1];

--- a/kite-data/kite-data-hcatalog/src/main/java/org/kitesdk/data/spi/hive/MetaStoreUtil.java
+++ b/kite-data/kite-data-hcatalog/src/main/java/org/kitesdk/data/spi/hive/MetaStoreUtil.java
@@ -15,10 +15,8 @@
  */
 package org.kitesdk.data.spi.hive;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
-import javax.annotation.Nullable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;

--- a/kite-data/kite-data-hcatalog/src/test/java/org/kitesdk/data/spi/hive/TestHiveDatasetURIsWithDefaultConfiguration.java
+++ b/kite-data/kite-data-hcatalog/src/test/java/org/kitesdk/data/spi/hive/TestHiveDatasetURIsWithDefaultConfiguration.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2013 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data.spi.hive;
+
+import java.net.URI;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kitesdk.data.Dataset;
+import org.kitesdk.data.DatasetDescriptor;
+import org.kitesdk.data.DatasetNotFoundException;
+import org.kitesdk.data.Datasets;
+import org.kitesdk.data.MiniDFSTest;
+import org.kitesdk.data.TestHelpers;
+import org.kitesdk.data.spi.DatasetRepositories;
+import org.kitesdk.data.spi.DatasetRepository;
+import org.kitesdk.data.spi.DefaultConfiguration;
+import org.kitesdk.data.spi.filesystem.FileSystemDataset;
+
+public class TestHiveDatasetURIsWithDefaultConfiguration extends MiniDFSTest {
+
+  private static Configuration existing;
+  private static String hdfsAuth;
+  private static DatasetDescriptor descriptor;
+
+  @BeforeClass
+  public static void createRepositoryAndTestDatasets() throws Exception {
+    // set the default configuration so that HDFS is found
+    existing = DefaultConfiguration.get();
+    DefaultConfiguration.set(getConfiguration());
+    hdfsAuth = getDFS().getUri().getAuthority();
+    descriptor = new DatasetDescriptor.Builder()
+        .schemaUri("resource:schema/user.avsc")
+        .build();
+  }
+
+  @AfterClass
+  public static void resetDefaultConfiguration() {
+    DefaultConfiguration.set(existing);
+  }
+
+  @Test
+  public void testExternal() {
+    DatasetRepository repo = DatasetRepositories.repositoryFor("repo:hive:/tmp/data");
+    repo.delete("ns", "test");
+    repo.create("ns", "test", descriptor);
+
+    Dataset<GenericRecord> ds = Datasets.load("dataset:hive:/tmp/data/ns/test");
+
+    Assert.assertNotNull("Should load dataset", ds);
+    Assert.assertTrue(ds instanceof FileSystemDataset);
+    Assert.assertEquals("Locations should match",
+        URI.create("hdfs://" + hdfsAuth + "/tmp/data/ns/test"),
+        ds.getDescriptor().getLocation());
+    Assert.assertEquals("Descriptors should match",
+        repo.load("ns", "test").getDescriptor(), ds.getDescriptor());
+
+    repo.delete("ns", "test");
+  }
+
+  @Test
+  public void testExternalRoot() {
+    DatasetRepository repo = DatasetRepositories.repositoryFor("repo:hive:/");
+    repo.delete("ns", "test");
+    repo.create("ns", "test", descriptor);
+
+    Dataset<GenericRecord> ds = Datasets.load("dataset:hive:/ns/test");
+
+    Assert.assertNotNull("Should load dataset", ds);
+    Assert.assertTrue(ds instanceof FileSystemDataset);
+    Assert.assertEquals("Locations should match",
+        URI.create("hdfs://" + hdfsAuth + "/ns/test"),
+        ds.getDescriptor().getLocation());
+    Assert.assertEquals("Descriptors should match",
+        repo.load("ns", "test").getDescriptor(), ds.getDescriptor());
+
+    repo.delete("ns", "test");
+  }
+
+  @Test
+  public void testExternalRelative() {
+    DatasetRepository repo = DatasetRepositories.repositoryFor("repo:hive:data");
+    repo.delete("ns", "test");
+    repo.create("ns", "test", descriptor);
+
+    Dataset<GenericRecord> ds = Datasets.load("dataset:hive:data/ns/test");
+
+    Assert.assertNotNull("Should load dataset", ds);
+    Assert.assertTrue(ds instanceof FileSystemDataset);
+    Path cwd = getDFS().makeQualified(new Path("."));
+    Assert.assertEquals("Locations should match",
+        new Path(cwd, "data/ns/test").toUri(), ds.getDescriptor().getLocation());
+    Assert.assertEquals("Descriptors should match",
+        repo.load("ns", "test").getDescriptor(), ds.getDescriptor());
+
+    repo.delete("ns", "test");
+  }
+
+  @Test
+  public void testManaged() {
+    DatasetRepository repo = DatasetRepositories.repositoryFor("repo:hive");
+    repo.delete("ns", "test");
+    repo.create("ns", "test", descriptor);
+
+    Dataset<GenericRecord> ds = Datasets.load("dataset:hive?dataset=test&namespace=ns");
+
+    Assert.assertNotNull("Should load dataset", ds);
+    Assert.assertTrue(ds instanceof FileSystemDataset);
+    Assert.assertEquals("Descriptors should match",
+        repo.load("ns", "test").getDescriptor(), ds.getDescriptor());
+
+    repo.delete("ns", "test");
+  }
+
+  @Test
+  public void testMissingDataset() {
+    TestHelpers.assertThrows("Should not find dataset: no such dataset",
+        DatasetNotFoundException.class, new Runnable() {
+      @Override
+      public void run() {
+        Datasets.load("dataset:hive:/tmp/data/ns/nosuchdataset");
+      }
+    });
+  }
+
+  @Test
+  public void testMissingRepository() {
+    TestHelpers.assertThrows("Should not find dataset: unknown storage scheme",
+        DatasetNotFoundException.class, new Runnable() {
+          @Override
+          public void run() {
+            Datasets.load("dataset:unknown:/tmp/data/ns/test");
+          }
+        });
+  }
+}


### PR DESCRIPTION
This adds DefaultConfiguration, which is a single place to get the
environment Hadoop configuration. Previously, the Loader classes would
call new Configuration() to inspect the environment and get defaults,
like the HDFS location. Now, the loaders call DefaultConfiguration.get()
instead that returns a consistent Configuration to all callers.

There is also a DefaultConfiguration.set(Configuration) method that can
replace the default Configuration based on just the environment. This
should only be used to replace the environment config with a more
accurate global configuration. For example, one configured with CLI
options by ToolRunner or via other configuration methods that apply
globally to the process.
