### PR TITLE
CDK-651: Throw exception if Hive cannot find the MetaStore.

### DIFF
--- a/kite-data/kite-data-crunch/src/test/resources/hadoop-site.xml
+++ b/kite-data/kite-data-crunch/src/test/resources/hadoop-site.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013 Cloudera Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+  <property>
+    <name>kite.allow.test-metastore</name>
+    <value>true</value>
+  </property>
+</configuration>

--- a/kite-data/kite-data-hcatalog/src/test/resources/hadoop-site.xml
+++ b/kite-data/kite-data-hcatalog/src/test/resources/hadoop-site.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013 Cloudera Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+  <property>
+    <name>kite.allow.test-metastore</name>
+    <value>true</value>
+  </property>
+</configuration>

--- a/kite-tools/src/test/resources/hadoop-site.xml
+++ b/kite-tools/src/test/resources/hadoop-site.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2013 Cloudera Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+  <property>
+    <name>kite.allow.test-metastore</name>
+    <value>true</value>
+  </property>
+</configuration>


### PR DESCRIPTION
Previously, Hive would connect to the local MetaStore, which should only
be used for testing. Now, the Hive integration will throw an exception
if it cannot connect to the real MetaStore. To test, this uses a new
property, kite.allow.test-metastore, to avoid the exception.
