### PR TITLE
CDK-639: Qualify DatasetDescriptor schema paths.

### DIFF
--- a/kite-data/kite-data-hcatalog/src/main/java/org/kitesdk/data/spi/hive/HiveManagedMetadataProvider.java
+++ b/kite-data/kite-data-hcatalog/src/main/java/org/kitesdk/data/spi/hive/HiveManagedMetadataProvider.java
@@ -66,12 +66,8 @@ class HiveManagedMetadataProvider extends HiveAbstractMetadataProvider {
     // load the created table to get the data location
     final Table newTable = getMetaStoreUtil().getTable(namespace, name);
 
-    try {
-      return new DatasetDescriptor.Builder(descriptor)
-          .location(newTable.getSd().getLocation())
-          .build();
-    } catch (URISyntaxException e) {
-      throw new DatasetException(e);
-    }
+    return new DatasetDescriptor.Builder(descriptor)
+        .location(newTable.getSd().getLocation())
+        .build();
   }
 }


### PR DESCRIPTION
This uses the schema URI rather than schema URL where possible and adds
an accessor for the URI. This also replaces new URI(...) with URI.create
and eliminates the URISyntaxExceptions that were thrown.

I've tested this on the CDH5.1 quickstart VM and it's working with both Hive and Impala.
