### PR TITLE
Properties get lost after a copy

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetDescriptor.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetDescriptor.java
@@ -355,6 +355,8 @@ public class DatasetDescriptor {
       this.format = descriptor.getFormat();
       this.properties = Maps.newHashMap(descriptor.properties);
       this.location = descriptor.getLocation();
+      this.columnMapping = descriptor.getColumnMapping();
+      this.compressionType = descriptor.getCompressionType();
 
       if (descriptor.isPartitioned()) {
         this.partitionStrategy = descriptor.getPartitionStrategy();


### PR DESCRIPTION
CDK-654: Compression type and column mapping info get lost after DatasetDescriptor copy
https://issues.cloudera.org/browse/CDK-654
