### PR TITLE
CDK-657: Fix URI qualification in descriptor.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetDescriptor.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetDescriptor.java
@@ -965,7 +965,12 @@ public class DatasetDescriptor {
       if (RESOURCE_URI_SCHEME.equals(location.getScheme())) {
         return null;
       } else {
-        return new Path(location).makeQualified(defaultFS, new Path("/")).toUri();
+        boolean useDefault = defaultFS.getScheme().equals(location.getScheme());
+        // work around a bug in Path where the authority for a different scheme
+        // will be used for the location.
+        return new Path(location)
+            .makeQualified(useDefault ? defaultFS : location, new Path("/"))
+            .toUri();
       }
     }
 


### PR DESCRIPTION
When makeQualified is called on a file URI and the default FS is a HDFS
URI, the authority section from the HDFS URI is incorrectly copied to
the file path. This catches the situation where the default FS scheme
and the location scheme do not match, so the default isn't useful, and
uses the location URI as the default to avoid this bug.
