### PR TITLE
CDK-634: Add Dataset creation to MR and Crunch.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/DescriptorUtil.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/DescriptorUtil.java
@@ -16,9 +16,28 @@
 
 package org.kitesdk.data.spi;
 
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
 import org.kitesdk.data.DatasetDescriptor;
 
 public class DescriptorUtil {
+
+  private static final String KITE_SCHEMA_URI = "kite.%s.schema-uri";
+  private static final String KITE_SCHEMA_LITERAL = "kite.%s.schema-literal";
+  private static final String KITE_STRATEGY = "kite.%s.partition-strategy";
+  private static final String KITE_MAPPING = "kite.%s.column-mapping";
+  private static final String KITE_FORMAT = "kite.%s.format";
+  private static final String KITE_COMPRESSION = "kite.%s.compression-type";
+  private static final String KITE_LOCATION = "kite.%s.location";
+  private static final String KITE_PROPERTIES = "kite.%s.properties";
+
+  private static Joiner.MapJoiner PROP_JOINER = Joiner.on(',').withKeyValueSeparator("=");
+  private static Splitter.MapSplitter PROP_SPLITTER = Splitter.on(',').withKeyValueSeparator("=");
 
   /**
    * Returns whether the value of the descriptor property is {@code true}.
@@ -33,5 +52,110 @@ public class DescriptorUtil {
       return Boolean.valueOf(descriptor.getProperty(property));
     }
     return false;
+  }
+
+  /**
+   * Builds a {@link DatasetDescriptor} from the properties set in the given
+   * {@link Configuration} that contain the context string.
+   * <p>
+   * The context string is used to build the property names that store the
+   * descriptor data. For example, "out" will use "kite.out.*" names.
+   *
+   * @param conf a Configuration
+   * @param context a String used to build descriptor property names
+   * @return a DatasetDescriptor
+   * @throws IOException if the Schema URI cannot be opened
+   */
+  public static DatasetDescriptor buildFromConfiguration(
+      Configuration conf, String context) throws IOException {
+    DatasetDescriptor.Builder builder = new DatasetDescriptor.Builder();
+
+    String schemaUri = get(conf, KITE_SCHEMA_URI, context);
+    if (schemaUri != null) {
+      builder.schemaUri(schemaUri);
+    } else {
+      String schemaLiteral = get(conf, KITE_SCHEMA_LITERAL, context);
+      Preconditions.checkNotNull(schemaLiteral,
+          "Missing schema: literal or URI is required");
+      builder.schemaLiteral(schemaLiteral);
+    }
+    String strategyLiteral = get(conf, KITE_STRATEGY, context);
+    if (strategyLiteral != null) {
+      builder.partitionStrategyLiteral(strategyLiteral);
+    }
+    String mappingLiteral = get(conf, KITE_MAPPING, context);
+    if (mappingLiteral != null) {
+      builder.columnMappingLiteral(mappingLiteral);
+    }
+    String outputFileFormat = get(conf, KITE_FORMAT, context);
+    if (outputFileFormat != null) {
+      builder.format(outputFileFormat);
+    }
+    String compressionType = get(conf, KITE_COMPRESSION, context);
+    if (compressionType != null) {
+      builder.compressionType(compressionType);
+    }
+    String location = get(conf, KITE_LOCATION, context);
+    if (location != null) {
+      builder.location(location);
+    }
+    String properties = get(conf, KITE_PROPERTIES, context);
+    if (properties != null && !properties.isEmpty()) {
+      Map<String, String> propMap = PROP_SPLITTER.split(properties);
+      for (Map.Entry<String, String> entry : propMap.entrySet()) {
+        builder.property(entry.getKey(), entry.getValue());
+      }
+    }
+
+    return builder.build();
+  }
+
+  /**
+   * Stores a {@link DatasetDescriptor} in properties in the given
+   * {@link Configuration} using a context string.
+   * <p>
+   * The context string is used to build the property names that will store the
+   * descriptor data. For example, "out" will produce "kite.out.*" names.
+   *
+   * @param descriptor a DatasetDescriptor to store
+   * @param conf a Configuration
+   * @param context a String used to build descriptor property names
+   */
+  public static void addToConfiguration(DatasetDescriptor descriptor,
+                                        String context, Configuration conf) {
+    if (descriptor.getSchemaUri() != null) {
+      set(conf, KITE_SCHEMA_URI, context, descriptor.getSchemaUri());
+    } else {
+      set(conf, KITE_SCHEMA_LITERAL, context, descriptor.getSchema());
+    }
+    if (descriptor.isPartitioned()) {
+      set(conf, KITE_STRATEGY, context, descriptor.getPartitionStrategy());
+    }
+    if (descriptor.isColumnMapped()) {
+      set(conf, KITE_MAPPING, context, descriptor.getColumnMapping());
+    }
+    set(conf, KITE_FORMAT, context, descriptor.getFormat().getName());
+    set(conf, KITE_COMPRESSION, context, descriptor.getCompressionType().getName());
+    set(conf, KITE_LOCATION, context, descriptor.getLocation());
+    set(conf, KITE_PROPERTIES, context, PROP_JOINER.join(propertiesAsMap(descriptor)));
+  }
+
+  private static Map<String, String> propertiesAsMap(DatasetDescriptor descriptor) {
+    ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
+    for (String property : descriptor.listProperties()) {
+      properties.put(property, descriptor.getProperty(property));
+    }
+    return properties.build();
+  }
+
+  private static String get(Configuration conf, String property, String context) {
+    return conf.get(String.format(property, context));
+  }
+
+  private static void set(Configuration conf, String property, String context,
+                          Object value) {
+    if (value != null) {
+      conf.set(String.format(property, context), value.toString());
+    }
   }
 }

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/TestDescriptorUtil.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/TestDescriptorUtil.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2013 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data.spi;
+
+import com.google.common.io.ByteStreams;
+import com.google.common.io.Resources;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+import org.kitesdk.data.ColumnMapping;
+import org.kitesdk.data.DatasetDescriptor;
+import org.kitesdk.data.PartitionStrategy;
+
+public class TestDescriptorUtil {
+  @Test
+  public void testRoundTripWithUri() throws IOException {
+    // copy the user avsc file to the local FS
+    File schemaFile = new File("target/user.avsc");
+    FileOutputStream out = new FileOutputStream(schemaFile);
+    ByteStreams.copy(Resources.getResource("schema/user.avsc").openStream(), out);
+    out.close();
+
+    DatasetDescriptor original = new DatasetDescriptor.Builder()
+        .schemaUri("file:" + schemaFile.getAbsolutePath())
+        .partitionStrategy(new PartitionStrategy.Builder()
+            .identity("email")
+            .build())
+        .columnMapping(new ColumnMapping.Builder()
+            .key("email")
+            .column("username", "u", "n")
+            .build())
+        .location("file:/tmp/datasets/ns/my_dataset")
+        .property("test.property", "value")
+        .build();
+
+    Configuration conf = new Configuration(false); // fresh config
+
+    DescriptorUtil.addToConfiguration(original, "context", conf);
+
+    Assert.assertNotNull("Should use kite.context.* properties",
+        conf.get("kite.context.schema-uri"));
+
+    DatasetDescriptor reconstructed = DescriptorUtil.buildFromConfiguration(
+        conf, "context");
+
+    Assert.assertEquals("Reconstructed configuration should match original",
+        original, reconstructed);
+  }
+
+  @Test
+  public void testRoundTripWithLiteral() throws IOException {
+    // resource URIs are not preserved because they depend on the classpath
+    DatasetDescriptor original = new DatasetDescriptor.Builder()
+        .schemaUri("resource:schema/user.avsc")
+        .partitionStrategy(new PartitionStrategy.Builder()
+            .identity("email")
+            .build())
+        .columnMapping(new ColumnMapping.Builder()
+            .key("email")
+            .column("username", "u", "n")
+            .build())
+        .location("file:/tmp/datasets/ns/my_dataset")
+        .property("test.property", "value")
+        .build();
+
+    Configuration conf = new Configuration(false); // fresh config
+
+    DescriptorUtil.addToConfiguration(original, "context", conf);
+
+    Assert.assertNotNull("Should use kite.context.* properties",
+        conf.get("kite.context.schema-literal"));
+
+    DatasetDescriptor reconstructed = DescriptorUtil.buildFromConfiguration(
+        conf, "context");
+
+    Assert.assertEquals("Reconstructed configuration should match original",
+        original, reconstructed);
+  }
+}

--- a/kite-data/kite-data-crunch/src/main/java/org/kitesdk/data/crunch/CrunchDatasets.java
+++ b/kite-data/kite-data-crunch/src/main/java/org/kitesdk/data/crunch/CrunchDatasets.java
@@ -135,6 +135,32 @@ public class CrunchDatasets {
   }
 
   /**
+   * Expose the {@link Dataset} or {@link View} represented by the given
+   * URI as a Crunch {@link Target}.
+   *
+   * @param uri the dataset or view URI
+   * @return a {@link Target} for the dataset or view
+   *
+   * @since 0.17.0
+   */
+  public static Target asTarget(String uri, DatasetDescriptor descriptor) {
+    return asTarget(URI.create(uri), descriptor);
+  }
+
+  /**
+   * Expose the {@link Dataset} or {@link View} represented by the given
+   * URI as a Crunch {@link Target}.
+   *
+   * @param uri the dataset or view URI
+   * @return a {@link Target} for the dataset or view
+   *
+   * @since 0.17.0
+   */
+  public static Target asTarget(URI uri, DatasetDescriptor descriptor) {
+    return new DatasetTarget<Object>(uri, descriptor);
+  }
+
+  /**
    * Partitions {@code collection} to be stored efficiently in {@code View}.
    * <p>
    * This restructures the parallel collection so that all of the entities that

--- a/kite-data/kite-data-crunch/src/main/java/org/kitesdk/data/crunch/DatasetTarget.java
+++ b/kite-data/kite-data-crunch/src/main/java/org/kitesdk/data/crunch/DatasetTarget.java
@@ -18,6 +18,7 @@ package org.kitesdk.data.crunch;
 import com.google.common.base.Preconditions;
 import java.net.URI;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.crunch.CrunchRuntimeException;
 import org.apache.crunch.SourceTarget;
 import org.apache.crunch.Target;
@@ -31,6 +32,7 @@ import org.apache.crunch.types.avro.AvroType;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.Job;
+import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.DatasetException;
 import org.kitesdk.data.DatasetNotFoundException;
 import org.kitesdk.data.Datasets;
@@ -58,10 +60,16 @@ class DatasetTarget<E> implements MapReduceTarget {
   }
 
   public DatasetTarget(URI uri) {
+    this(uri, null);
+  }
+
+  public DatasetTarget(URI uri, @Nullable DatasetDescriptor descriptor) {
     this.uri = uri;
     Configuration temp = emptyConf();
     // use appendTo since handleExisting checks for existing data
-    DatasetKeyOutputFormat.configure(temp).appendTo(uri);
+    DatasetKeyOutputFormat.configure(temp)
+        .appendTo(uri)
+        .withDescriptor(descriptor);
     this.formatBundle = outputBundle(temp);
   }
 

--- a/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/DatasetKeyInputFormat.java
+++ b/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/DatasetKeyInputFormat.java
@@ -129,6 +129,9 @@ public class DatasetKeyInputFormat<E> extends InputFormat<E, Void>
      * This Class is used to configure the input {@code Dataset}. If this class
      * cannot be found during job setup, the job will fail and throw a
      * {@link org.kitesdk.data.TypeNotFoundException}.
+     * <p>
+     * If not set, the output type will be
+     * {@link org.apache.avro.generic.GenericRecord}.
      *
      * @param type the entity Class that will be produced
      * @return this for method chaining
@@ -229,7 +232,8 @@ public class DatasetKeyInputFormat<E> extends InputFormat<E, Void>
   }
 
   @Override
-  @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR",
+  @edu.umd.cs.findbugs.annotations.SuppressWarnings(
+      value="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR",
       justification="Delegate set by setConf")
   public List<InputSplit> getSplits(JobContext jobContext) throws IOException,
       InterruptedException {
@@ -237,7 +241,8 @@ public class DatasetKeyInputFormat<E> extends InputFormat<E, Void>
   }
 
   @Override
-  @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR",
+  @edu.umd.cs.findbugs.annotations.SuppressWarnings(
+      value="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR",
       justification="Delegate set by setConf")
   public RecordReader<E, Void> createRecordReader(InputSplit inputSplit, TaskAttemptContext taskAttemptContext) throws IOException, InterruptedException {
     return delegate.createRecordReader(inputSplit, taskAttemptContext);

--- a/kite-hadoop-compatibility/src/main/java/org/kitesdk/compat/Hadoop.java
+++ b/kite-hadoop-compatibility/src/main/java/org/kitesdk/compat/Hadoop.java
@@ -37,11 +37,21 @@ public class Hadoop {
         new DynMethods.Builder("getConfiguration")
             .impl(org.apache.hadoop.mapreduce.JobContext.class)
             .build();
+
+    public static final DynMethods.UnboundMethod getJobID =
+        new DynMethods.Builder("getJobID")
+            .impl(org.apache.hadoop.mapreduce.JobContext.class)
+            .build();
   }
 
   public static class TaskAttemptContext {
     public static final DynMethods.UnboundMethod getConfiguration =
         new DynMethods.Builder("getConfiguration")
+            .impl(org.apache.hadoop.mapreduce.TaskAttemptContext.class)
+            .build();
+
+    public static final DynMethods.UnboundMethod getTaskAttemptID =
+        new DynMethods.Builder("getTaskAttemptID")
             .impl(org.apache.hadoop.mapreduce.TaskAttemptContext.class)
             .build();
   }


### PR DESCRIPTION
This adds an option to set a descriptor for the output URI, which is
used to create a Dataset if one doesn't already exist. For Datasets
that use the MergeOutputCommitter, the final Dataset is created in the
commitJob method and the NullOutputCommitter creates the dataset in the
setupJob method because tasks write directly to it.

This adds methods to store and retrieve a descriptor in a Configuration
to DescriptorUtil. These methods take a context String that is used to
build property names, so multiple descriptors can be stored in the same
Configuration.

Because the Descriptor can be stored in the Job Configuration, this no
longer relies on the job Dataset to serialize the descriptor to task
attempts. Task attemps no longer load the job Dataset to create the task
attempt Datasets.
