### PR TITLE
CDK-666: Fix for sporadic Hive test failures

### DIFF
--- a/kite-data/kite-data-core/src/test/resources/hive-site.xml
+++ b/kite-data/kite-data-core/src/test/resources/hive-site.xml
@@ -19,4 +19,8 @@
     <name>hive.metastore.warehouse.dir</name>
     <value>/tmp/test/user/hive/warehouse</value>
   </property>
+  <property>
+    <name>javax.jdo.option.ConnectionURL</name>
+    <value>jdbc:derby:;databaseName=target/metastore_db;create=true</value>
+  </property>
 </configuration>

--- a/kite-data/kite-data-hive/src/main/java/org/kitesdk/data/spi/hive/MetaStoreUtil.java
+++ b/kite-data/kite-data-hive/src/main/java/org/kitesdk/data/spi/hive/MetaStoreUtil.java
@@ -330,4 +330,26 @@ public class MetaStoreUtil {
           "Exception communicating with the Hive MetaStore", e);
     }
   }
+
+  public void dropDatabse(final String name, final boolean deleteData) {
+    ClientAction<Void> drop =
+        new ClientAction<Void>() {
+
+        @Override
+        public Void call() throws TException {
+          client.dropDatabase(name, deleteData, true);
+          return null;
+        }
+      };
+
+    try {
+      doWithRetry(drop);
+    } catch (NoSuchObjectException e) {
+    } catch (MetaException e) {
+      throw new DatasetOperationException("Hive MetaStore exception", e);
+    } catch (TException e) {
+      throw new DatasetOperationException(
+          "Exception communicating with the Hive MetaStore", e);
+    }
+  }
 }

--- a/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestHiveDatasetURIs.java
+++ b/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestHiveDatasetURIs.java
@@ -18,7 +18,9 @@ package org.kitesdk.data.spi.hive;
 
 import java.net.URI;
 import org.apache.hadoop.fs.Path;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kitesdk.data.Dataset;
@@ -48,6 +50,17 @@ public class TestHiveDatasetURIs extends MiniDFSTest {
     descriptor = new DatasetDescriptor.Builder()
         .schemaUri("resource:schema/user.avsc")
         .build();
+  }
+
+  @Before
+  @After
+  public void cleanHive() {
+    // ensures all tables are removed
+    MetaStoreUtil metastore = new MetaStoreUtil(getConfiguration());
+    metastore.dropDatabse("ns", true);
+    for (String table : metastore.getAllTables("default")) {
+      metastore.dropTable("default", table);
+    }
   }
 
   @Test

--- a/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestHiveDatasetURIsWithDefaultConfiguration.java
+++ b/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestHiveDatasetURIsWithDefaultConfiguration.java
@@ -20,8 +20,10 @@ import java.net.URI;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kitesdk.data.Dataset;
@@ -55,6 +57,17 @@ public class TestHiveDatasetURIsWithDefaultConfiguration extends MiniDFSTest {
   @AfterClass
   public static void resetDefaultConfiguration() {
     DefaultConfiguration.set(existing);
+  }
+
+  @Before
+  @After
+  public void cleanHive() {
+    // ensures all tables are removed
+    MetaStoreUtil metastore = new MetaStoreUtil(getConfiguration());
+    metastore.dropDatabse("ns", true);
+    for (String table : metastore.getAllTables("default")) {
+      metastore.dropTable("default", table);
+    }
   }
 
   @Test

--- a/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestHivePartitioning.java
+++ b/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestHivePartitioning.java
@@ -19,14 +19,28 @@ import java.util.List;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.PartitionStrategy;
 import org.kitesdk.data.spi.DatasetRepositories;
 import org.kitesdk.data.spi.DatasetRepository;
+import org.kitesdk.data.spi.DefaultConfiguration;
 
 public class TestHivePartitioning {
+
+  @Before
+  @After
+  public void cleanHive() {
+    // ensures all tables are removed
+    MetaStoreUtil metastore = new MetaStoreUtil(DefaultConfiguration.get());
+    metastore.dropDatabse("ns", true);
+    for (String table : metastore.getAllTables("default")) {
+      metastore.dropTable("default", table);
+    }
+  }
 
   private static final Schema schema = SchemaBuilder.record("Record").fields()
       .requiredLong("timestamp")


### PR DESCRIPTION
- Adds a config to put the metastore_db directory under target/
- Adds code to drop tables and namespaces before and after tests
