### PR TITLE
CDK-600: Add mapred.reducer.new-api to OutputFormat.

### DIFF
--- a/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/DatasetKeyOutputFormat.java
+++ b/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/DatasetKeyOutputFormat.java
@@ -75,11 +75,13 @@ public class DatasetKeyOutputFormat<E> extends OutputFormat<E, Void> {
     private final Configuration conf;
 
     private ConfigBuilder(Job job) {
-      this.conf = Hadoop.JobContext.getConfiguration.invoke(job);
+      this(Hadoop.JobContext.getConfiguration.<Configuration>invoke(job));
     }
 
     private ConfigBuilder(Configuration conf) {
       this.conf = conf;
+      // always use the new API for OutputCommitters, even for 0 reducers
+      conf.setBoolean("mapred.reducer.new-api", true);
     }
 
     /**


### PR DESCRIPTION
When the number of reducers is 0 in some Hadoop versions, the new API is
not used. The output format relies on the new API to run its
OutputCommitter correctly, so this forces the property to true.
