### PR TITLE
Throw descriptive exception when JDK is not installed.

### DIFF
--- a/kite-morphlines/kite-morphlines-core/src/main/java/org/kitesdk/morphline/scriptengine/java/JavaCompiler.java
+++ b/kite-morphlines/kite-morphlines-core/src/main/java/org/kitesdk/morphline/scriptengine/java/JavaCompiler.java
@@ -51,6 +51,9 @@ class JavaCompiler {
 
 	public JavaCompiler() {
 		tool = ToolProvider.getSystemJavaCompiler();
+		if (tool == null) {
+			throw new RuntimeException("Could not get Java compiler. Please, ensure that JDK is used instead of JRE.");
+		}
 		stdManager = tool.getStandardFileManager(null, null, null);
 	}
 


### PR DESCRIPTION
Throw a descriptive exception (instead of NullPointerException) when JRE is used
instead of JRE.
