### PR TITLE
CDK-684: Fix CLI command name in help messages.

### DIFF
--- a/kite-tools/src/main/java/org/kitesdk/cli/Help.java
+++ b/kite-tools/src/main/java/org/kitesdk/cli/Help.java
@@ -29,10 +29,15 @@ public class Help implements Command {
 
   private final JCommander jc;
   private final Logger console;
+  private String programName;
 
   public Help(JCommander jc, Logger console) {
     this.jc = jc;
     this.console = console;
+  }
+
+  public void setProgramName(String programName) {
+    this.programName = programName;
   }
 
   @Override
@@ -42,7 +47,7 @@ public class Help implements Command {
     if (helpCommands.isEmpty()) {
       console.info(
           "\nUsage: {} [options] [command] [command options]",
-          Main.PROGRAM_NAME);
+          programName);
       console.info("\n  Options:\n");
       for (ParameterDescription param : jc.getParameters()) {
         hasRequired = printOption(console, param) || hasRequired;
@@ -57,9 +62,9 @@ public class Help implements Command {
       }
       console.info("\n  Examples:");
       console.info("\n    # print information for create\n    {} help create",
-          Main.PROGRAM_NAME);
+          programName);
       console.info("\n  See '{} help <command>' for more information on a " +
-          "specific command.", Main.PROGRAM_NAME);
+          "specific command.", programName);
 
     } else {
       for (String cmd : helpCommands) {
@@ -71,7 +76,7 @@ public class Help implements Command {
 
         console.info("\nUsage: {} [general options] {} {} [command options]",
             new Object[] {
-                Main.PROGRAM_NAME, cmd,
+                programName, cmd,
                 commander.getMainParameterDescription()});
         console.info("\n  Description:");
         console.info("\n    {}", jc.getCommandDescription(cmd));
@@ -93,7 +98,7 @@ public class Help implements Command {
               console.info("\n    {}", example);
             } else {
               console.info("    {} {} {}",
-                  new Object[] {Main.PROGRAM_NAME, cmd, example});
+                  new Object[] {programName, cmd, example});
             }
           }
         }

--- a/kite-tools/src/main/java/org/kitesdk/cli/Main.java
+++ b/kite-tools/src/main/java/org/kitesdk/cli/Main.java
@@ -32,7 +32,6 @@ import org.kitesdk.cli.commands.CreateDatasetCommand;
 import org.kitesdk.cli.commands.CreatePartitionStrategyCommand;
 import org.kitesdk.cli.commands.DeleteDatasetCommand;
 import com.google.common.collect.ImmutableSet;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 import java.util.Set;
@@ -65,7 +64,12 @@ public class Main extends Configured implements Tool {
   private boolean printVersion = false;
 
   @VisibleForTesting
-  static final String PROGRAM_NAME = "dataset";
+  @Parameter(names="--dollar-zero",
+      description="A way for the runtime path to be passed in", hidden=true)
+  String programName = DEFAULT_PROGRAM_NAME;
+
+  @VisibleForTesting
+  static final String DEFAULT_PROGRAM_NAME = "kite-dataset";
 
   private static Set<String> HELP_ARGS = ImmutableSet.of("-h", "-help", "--help", "help");
 
@@ -79,7 +83,7 @@ public class Main extends Configured implements Tool {
     this.console = console;
     this.jc = new JCommander(this);
     this.help = new Help(jc, console);
-    jc.setProgramName(PROGRAM_NAME);
+    jc.setProgramName(DEFAULT_PROGRAM_NAME);
     jc.addCommand("help", help, "-h", "-help", "--help");
     jc.addCommand("create", new CreateDatasetCommand(console));
     jc.addCommand("copy", new CopyCommand(console));
@@ -104,6 +108,7 @@ public class Main extends Configured implements Tool {
       console.error(e.getMessage());
       return 1;
     } catch (ParameterException e) {
+      help.setProgramName(programName);
       String cmd = jc.getParsedCommand();
       if (args.length == 1) { // i.e., just the command (missing required arguments)
         help.helpCommands.add(cmd);
@@ -122,8 +127,10 @@ public class Main extends Configured implements Tool {
       return 1;
     }
 
+    help.setProgramName(programName);
+
     if (printVersion) {
-      console.info("kite version \"{}\"", getVersion());
+      console.info("Kite version \"{}\"", getVersion());
       return 0;
     }
 

--- a/kite-tools/src/main/java/org/kitesdk/cli/commands/BaseCommand.java
+++ b/kite-tools/src/main/java/org/kitesdk/cli/commands/BaseCommand.java
@@ -31,7 +31,6 @@ import java.nio.charset.Charset;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.List;
-import org.apache.crunch.util.DistCache;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.ChecksumFileSystem;
@@ -40,7 +39,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
 import org.kitesdk.cli.Command;
-import org.kitesdk.compat.DynMethods;
 import org.kitesdk.data.spi.HadoopFileSystemURLStreamHandler;
 import org.slf4j.Logger;
 

--- a/kite-tools/src/main/sh/dataset.sh
+++ b/kite-tools/src/main/sh/dataset.sh
@@ -137,11 +137,11 @@ export HIVE_CONF_DIR
 export HIVE_HOME
 
 if [ -x "$HADOOP_COMMON_HOME/bin/hadoop" ]; then
-  exec ${HADOOP_COMMON_HOME}/bin/hadoop jar "$0" $flags "$@"
+  exec ${HADOOP_COMMON_HOME}/bin/hadoop jar "$0" $flags --dollar-zero "$0" "$@"
 else
   # TODO: Add a stand-alone hadoop bundle
   echo "Cannot find hadoop, attempting to run without it"
-  exec java $flags -jar "$0" "$@"
+  exec java $flags -jar "$0" --dollar-zero "$0" "$@"
 fi
 
 # jar contents follows

--- a/kite-tools/src/test/java/org/kitesdk/cli/TestMain.java
+++ b/kite-tools/src/test/java/org/kitesdk/cli/TestMain.java
@@ -91,7 +91,7 @@ public class TestMain {
     int rc = run();
     verify(console).info(
         contains("Usage: {} [options] [command] [command options]"),
-        eq(Main.PROGRAM_NAME));
+        eq(Main.DEFAULT_PROGRAM_NAME));
     assertEquals(1, rc);
   }
 
@@ -107,7 +107,7 @@ public class TestMain {
     int rc = run("help");
     verify(console).info(
         contains("Usage: {} [options] [command] [command options]"),
-        eq(Main.PROGRAM_NAME));
+        eq(Main.DEFAULT_PROGRAM_NAME));
     verify(console).info(contains("Options"));
     verify(console, times(2)).info(anyString(), any(Object[].class)); // -v, --version
     verify(console).info(contains("Commands"));
@@ -118,10 +118,10 @@ public class TestMain {
     verify(console).info(anyString(), eq("csv-schema"), anyString());
     verify(console).info(anyString(), eq("test"), eq("Test description"));
     verify(console).info(contains("Examples"));
-    verify(console).info(contains("{} help create"), eq(Main.PROGRAM_NAME));
+    verify(console).info(contains("{} help create"), eq(Main.DEFAULT_PROGRAM_NAME));
     verify(console).info(
         contains("See '{} help <command>' for more information"),
-        eq(Main.PROGRAM_NAME));
+        eq(Main.DEFAULT_PROGRAM_NAME));
     assertEquals(0, rc);
   }
 
@@ -130,14 +130,14 @@ public class TestMain {
     int rc = run("help", "test");
     verify(console).info(
         "\nUsage: {} [general options] {} {} [command options]",
-        new Object[]{ "dataset", "test", "<test dataset names>" });
+        new Object[]{ Main.DEFAULT_PROGRAM_NAME, "test", "<test dataset names>" });
     verify(console).info(contains("Description"));
     verify(console).info(anyString(), contains("Test description"));
     verify(console).info(contains("Command options"));
     verify(console).info(contains("Examples"));
     verify(console).info(anyString(), contains("# this is a comment"));
     verify(console).info(anyString(),
-        eq(new Object[] {Main.PROGRAM_NAME, "test", "test dataset-name"}));
+        eq(new Object[] {Main.DEFAULT_PROGRAM_NAME, "test", "test dataset-name"}));
     assertEquals(0, rc);
   }
 
@@ -146,21 +146,37 @@ public class TestMain {
     int rc = run("test", "--help");
     verify(console).info(
         "\nUsage: {} [general options] {} {} [command options]",
-        new Object[]{ "dataset", "test", "<test dataset names>" });
+        new Object[]{ Main.DEFAULT_PROGRAM_NAME, "test", "<test dataset names>" });
     verify(console).info(contains("Description"));
     verify(console).info(anyString(), contains("Test description"));
     verify(console).info(contains("Command options"));
     verify(console).info(contains("Examples"));
     verify(console).info(anyString(), contains("this is a comment"));
     verify(console).info(anyString(),
-        eq(new Object[] {Main.PROGRAM_NAME, "test", "test dataset-name"}));
+        eq(new Object[] {Main.DEFAULT_PROGRAM_NAME, "test", "test dataset-name"}));
+    assertEquals(0, rc);
+  }
+
+  @Test
+  public void testCommandHelpWithDollarZero() throws Exception {
+    int rc = run("--dollar-zero", "datasets", "test", "--help");
+    verify(console).info(
+        "\nUsage: {} [general options] {} {} [command options]",
+        new Object[]{ "datasets", "test", "<test dataset names>" });
+    verify(console).info(contains("Description"));
+    verify(console).info(anyString(), contains("Test description"));
+    verify(console).info(contains("Command options"));
+    verify(console).info(contains("Examples"));
+    verify(console).info(anyString(), contains("this is a comment"));
+    verify(console).info(anyString(),
+        eq(new Object[] {"datasets", "test", "test dataset-name"}));
     assertEquals(0, rc);
   }
 
   @Test
   public void testVersion() throws Exception {
     int rc = run("--version");
-    verify(console).info(contains("kite version"), anyString());
+    verify(console).info(contains("Kite version"), anyString());
     assertEquals(0, rc);
   }
 


### PR DESCRIPTION
This defaults the CLI command name to the current default, kite-dataset,
and also adds a --dollar-zero hidden option that gets set to $0 by the
wrapper script so that the command name is whatever was called.
