### PR TITLE
CDK-694: Change behavior of a null namespace to use the default

### DIFF
--- a/kite-data/kite-data-flume/src/main/java/org/kitesdk/data/flume/Log4jAppender.java
+++ b/kite-data/kite-data-flume/src/main/java/org/kitesdk/data/flume/Log4jAppender.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.flume.FlumeException;
 import org.kitesdk.data.Datasets;
-import org.kitesdk.data.URIBuilder;
 import org.kitesdk.data.spi.StorageKey;
 import org.kitesdk.data.spi.filesystem.PathConversion;
 
@@ -96,7 +95,12 @@ public class Log4jAppender extends org.apache.flume.clients.log4jappender.Log4jA
       // initialize here rather than in activateOptions to avoid initialization
       // cycle in Configuration and log4j
       try {
-        URI datasetUri = new URIBuilder(datasetRepositoryUri, datasetNamespace, datasetName).build();
+        URI datasetUri;
+        if (datasetNamespace == null) {
+          datasetUri = new org.kitesdk.data.spi.URIBuilder(datasetRepositoryUri, datasetName).build();
+        } else {
+          datasetUri = new org.kitesdk.data.spi.URIBuilder(datasetRepositoryUri, datasetNamespace, datasetName).build();
+        }
         Dataset<Object> dataset = Datasets.load(datasetUri, Object.class);
         if (dataset.getDescriptor().isPartitioned()) {
           partitionStrategy = dataset.getDescriptor().getPartitionStrategy();


### PR DESCRIPTION
- This is needed to maintain backwards compatibility with Kite Log4jAppender
  users. With out this, they have to update their configuration files which
  means our public API has broken.
