### PR TITLE
Correct incompatible schema change test

### DIFF
--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemDatasetRepository.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemDatasetRepository.java
@@ -173,7 +173,8 @@ public class TestFileSystemDatasetRepository extends TestDatasetRepositories {
         .endRecord();
 
     try {
-      repo.update(NAMESPACE, NAME, new DatasetDescriptor.Builder().schema(testSchemaV2).build());
+      repo.update(NAMESPACE, NAME, new DatasetDescriptor.Builder(
+          dataset.getDescriptor()).schema(testSchemaV2).build());
       Assert.fail("Should fail due to incompatible update");
     } catch (ValidationException e) {
       // expected


### PR DESCRIPTION
Really minor nit, but TestFileSystemDatasetRepository#testUpdateFailsWithIncompatibleSchemaChange doesn't actually check anything with schema compatibility. Instead, the condition in the test passes because the DatasetDescriptor doesn't have a location filled in.

Nothing wrong in terms of actual functionality right now, but the test as it's written will fail to protect against regressions in schema compatibilities in the future. This commit makes the (tiny) change to fix this.
