### PR TITLE
CDK-717. Fix javadoc warnings, and add missing @since tags.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/Dataset.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/Dataset.java
@@ -57,6 +57,8 @@ public interface Dataset<E> extends RefinableView<E> {
   /**
    * Get the namespace that contains this {@code Dataset}. A namespace is a
    * string that identifies a logical group of datasets.
+   *
+   * @since 0.17.0
    */
   String getNamespace();
 

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetOperationException.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetOperationException.java
@@ -19,6 +19,8 @@ package org.kitesdk.data;
 /**
  * {@link DatasetException} thrown when an implementation-specific step fails
  * and prevents a dataset operation from completing successfully.
+ *
+ * @since 0.17.0
  */
 public class DatasetOperationException extends DatasetException {
   public DatasetOperationException(String message, Throwable t) {

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/PartitionStrategy.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/PartitionStrategy.java
@@ -48,8 +48,7 @@ import org.slf4j.LoggerFactory;
  * The strategy used to determine how a dataset is partitioned.
  * </p>
  * <p>
- * A {@code PartitionStrategy} is configured with one or more
- * {@link FieldPartitioner}s upon creation. When a {@link Dataset} is configured
+ * When a {@link Dataset} is configured
  * with a partition strategy, that data is considered partitioned. Any entities
  * written to a partitioned dataset are evaluated with its
  * {@code PartitionStrategy} to determine which partition to write to.
@@ -58,7 +57,6 @@ import org.slf4j.LoggerFactory;
  * You should use the inner {@link Builder} to create new instances.
  * </p>
  * 
- * @see FieldPartitioner
  * @see DatasetDescriptor
  * @see Dataset
  */
@@ -96,7 +94,9 @@ public class PartitionStrategy {
    * {@link FieldPartitioner}s are returned in the same order they are used
    * during partition selection.
    * </p>
+   * @deprecated will be removed in 0.18.0
    */
+  @Deprecated
   public List<FieldPartitioner> getFieldPartitioners() {
     return fieldPartitioners;
   }
@@ -105,7 +105,9 @@ public class PartitionStrategy {
    * Get a partitioner by partition name.
    * @return a FieldPartitioner with the given partition name
    * @since 0.15.0
+   * @deprecated will be removed in 0.18.0
    */
+  @Deprecated
   public FieldPartitioner getPartitioner(String name) {
     return partitionerMap.get(name);
   }
@@ -114,7 +116,9 @@ public class PartitionStrategy {
    * Check if a partitioner for the partition name exists.
    * @return {@code true} if this strategy has a partitioner for the name
    * @since 0.15.0
+   * @deprecated will be removed in 0.18.0
    */
+  @Deprecated
   public boolean hasPartitioner(String name) {
     return partitionerMap.containsKey(name);
   }

--- a/kite-data/kite-data-crunch/src/main/java/org/kitesdk/data/crunch/CrunchDatasets.java
+++ b/kite-data/kite-data-crunch/src/main/java/org/kitesdk/data/crunch/CrunchDatasets.java
@@ -181,7 +181,7 @@ public class CrunchDatasets {
    * @param numWriters the number of writers that should be used
    * @param <E> the type of entities in the collection and underlying dataset
    * @return an equivalent collection of entities partitioned for the view
-   * @see {@link #partition(PCollection, View)}
+   * @see #partition(PCollection, View)
    *
    * @since 0.16.0
    */
@@ -206,7 +206,7 @@ public class CrunchDatasets {
    * @param numWriters the number of writers that should be used
    * @param <E> the type of entities in the collection and underlying dataset
    * @return an equivalent collection of entities partitioned for the view
-   * @see {@link #partition(PCollection, Dataset)}
+   * @see #partition(PCollection, Dataset)
    *
    * @since 0.16.0
    */
@@ -302,7 +302,7 @@ public class CrunchDatasets {
       this.strategy = strategy;
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "deprecation"})
     public <E> AvroStorageKey reuseFor(E entity, EntityAccessor<E> accessor) {
       List<FieldPartitioner> partitioners = strategy.getFieldPartitioners();
 

--- a/kite-data/kite-data-hive/src/main/java/org/kitesdk/data/spi/hive/HiveUtils.java
+++ b/kite-data/kite-data-hive/src/main/java/org/kitesdk/data/spi/hive/HiveUtils.java
@@ -342,6 +342,7 @@ class HiveUtils {
     return new Path(root, new Path(namespace, name.replace('.', Path.SEPARATOR_CHAR)));
   }
 
+  @SuppressWarnings("deprecation")
   static List<FieldSchema> partitionColumns(PartitionStrategy strategy, Schema schema) {
     List<FieldSchema> columns = Lists.newArrayList();
     for (FieldPartitioner<?, ?> fp : strategy.getFieldPartitioners()) {


### PR DESCRIPTION
Deprecate some methods that leak FieldPartitioner, which has since moved
to the SPI.
