### PR TITLE
CDK-759: Update kite-tools links after relocation.

### DIFF
--- a/src/site/markdown/dependencies.md.vm
+++ b/src/site/markdown/dependencies.md.vm
@@ -176,5 +176,5 @@ $h2 Kite Morphlines Modules
 $h2 Kite Tools Modules
 
 * Kite Tools
- [Dependency Information](kite-tools/dependency-info.html),
- [Dependencies](kite-tools/dependencies.html)
+ [Dependency Information](kite-tools-parent/kite-tools/dependency-info.html),
+ [Dependencies](kite-tools-parent/kite-tools/dependencies.html)

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -30,7 +30,7 @@ goals for packaging, deploying, and running distributed applications.
 and skills necessary to build and change Hadoop
 ETL stream processing applications that extract, transform and load data into Apache
 Solr, Enterprise Data Warehouses, HDFS, HBase or Analytic Online Dashboards.
-* [__Kite Tools__](kite-tools/index.html) The tools module provides command-line tools and
+* [__Kite Tools__](kite-tools-parent/index.html) The tools module provides command-line tools and
 APIs for performing common tasks with Kite.
 
 There is also __example code__ demonstrating how to use the Kite SDK in a separate GitHub

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -73,7 +73,7 @@
       <item name="Kite Data" href="kite-data/index.html"/>
       <item name="Kite Maven Plugin" href="kite-maven-plugin/index.html"/>
       <item name="Kite Morphlines" href="kite-morphlines/index.html"/>
-      <item name="Kite Tools" href="kite-tools/index.html"/>
+      <item name="Kite Tools" href="kite-tools-parent/index.html"/>
     </menu>
 
     <menu name="Contribute" inherit="bottom">


### PR DESCRIPTION
This updates all of the links to the kite tools project, either
replacing the stale link with a link to the parent module (for the
generic docs) or linking directly to the runtime project's information
(for the relevant dependency info).
