### PR TITLE
CDK-735: Fix Crunch dataset writes with provided partitioners.

### DIFF
--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/DatasetTestUtilities.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/DatasetTestUtilities.java
@@ -60,20 +60,20 @@ public class DatasetTestUtilities {
     }
   }
 
-  public static void writeTestUsers(Dataset<GenericData.Record> ds, int count) {
+  public static void writeTestUsers(View<GenericData.Record> ds, int count) {
     writeTestUsers(ds, count, 0);
   }
 
-  public static void writeTestUsers(Dataset<GenericData.Record> ds, int count, int start) {
+  public static void writeTestUsers(View<GenericData.Record> ds, int count, int start) {
     writeTestUsers(ds, count, start, "email");
   }
 
-  public static void writeTestUsers(Dataset<GenericData.Record> ds, int count, int start, String... fields) {
+  public static void writeTestUsers(View<GenericData.Record> view, int count, int start, String... fields) {
     DatasetWriter<GenericData.Record> writer = null;
     try {
-      writer = ds.newWriter();
+      writer = view.newWriter();
       for (int i = start; i < count + start; i++) {
-        GenericRecordBuilder recordBuilder = new GenericRecordBuilder(ds.getDescriptor
+        GenericRecordBuilder recordBuilder = new GenericRecordBuilder(view.getDataset().getDescriptor
             ().getSchema()).set("username", "test-" + i);
         for (String field : fields) {
           recordBuilder.set(field, field + "-" + i);


### PR DESCRIPTION
This updates DatasetKeyOutputFormat so that the view constraints are
used when writing to temporary datasets. That ensures that the values
provided by the target view are present so writes to the temporary
datasets don't fail. Fix and test contributed by Ryan Brush.

This also updates the partitioning methods in CrunchDatasets to fix the
CLI copy command when writing to a provided partition. In that case, the
mapper, GetStorageKey, needs the view constraints as well as the
partition strategy in order to create storage keys. The constraints are
serialized using the query map as a stand-in.
