### PR TITLE
CDK-787: Fix Hive backward-compatibility check.

### DIFF
--- a/kite-data/kite-data-hive/src/main/java/org/kitesdk/data/spi/hive/HiveManagedMetadataProvider.java
+++ b/kite-data/kite-data-hive/src/main/java/org/kitesdk/data/spi/hive/HiveManagedMetadataProvider.java
@@ -46,7 +46,9 @@ class HiveManagedMetadataProvider extends HiveAbstractMetadataProvider {
         // the requested dataset already exists
         throw new DatasetExistsException(
             "Metadata already exists for dataset: " + namespace + "." + name);
-      } else {
+      } else if (location != null) {
+        // if the location was set and matches an existing dataset, then this
+        // dataset is replacing the existing and using its data
         DatasetDescriptor loaded = load(resolved, name);
         // replacing old default.name table
         LOG.warn("Creating table managed table {}.{}: replaces default.{}",


### PR DESCRIPTION
For backward-compatibility with pre-namespaces datasets, Hive dataset
creation checked whether or not a new dataset was replacing an existing
one in the default namespace. If it is, then the schema for the new
dataset is validated to ensure it can read existing data.

The problem was that this check used resolveNamespace, which returns the
default namespace as a match if either the location is null or the
location matches. But the location is almost always null, so this
prevented any table from being created when there is a duplicate name in
the default db. The fix is to consider only new tables that point to a
location matching the existing default table to match for this
validation.
