### PR TITLE
CDK-799: Add support for escaped CSV settings.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVProperties.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVProperties.java
@@ -17,6 +17,7 @@
 package org.kitesdk.data.spi.filesystem;
 
 import javax.annotation.concurrent.Immutable;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.kitesdk.data.DatasetDescriptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -143,22 +144,17 @@ public class CSVProperties {
     }
 
     public Builder delimiter(String delimiter) {
-      // handle tab
-      if ("\\t".equals(delimiter)) {
-        this.delimiter = "\t";
-      } else {
-        this.delimiter = delimiter;
-      }
+      this.delimiter = StringEscapeUtils.unescapeJava(delimiter);
       return this;
     }
 
     public Builder quote(String quote) {
-      this.quote = quote;
+      this.quote = StringEscapeUtils.unescapeJava(quote);
       return this;
     }
 
     public Builder escape(String escape) {
-      this.escape = escape;
+      this.escape = StringEscapeUtils.unescapeJava(escape);
       return this;
     }
 

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestCSVProperties.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestCSVProperties.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2013 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data.spi.filesystem;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestCSVProperties {
+  @Test
+  public void testCSVProperitesBuilderDelimiter() {
+    Assert.assertEquals("Delimiter should be tab",
+        "\t",
+        new CSVProperties.Builder()
+            .delimiter("\\u0009")
+            .build().delimiter);
+    Assert.assertEquals("Delimiter should be tab",
+        "\t",
+        new CSVProperties.Builder()
+            .delimiter("\\t")
+            .build().delimiter);
+    Assert.assertEquals("Delimiter should be tab",
+        "\t",
+        new CSVProperties.Builder()
+            .delimiter("\t")
+            .build().delimiter);
+  }
+
+  @Test
+  public void testCSVProperitesBuilderEscape() {
+    Assert.assertEquals("Escape should be backslash",
+        "\\",
+        new CSVProperties.Builder()
+            .escape("\\u005c")
+            .build().escape);
+    Assert.assertEquals("Escape should be backslash",
+        "\\",
+        new CSVProperties.Builder()
+            .escape("\\\\")
+            .build().escape);
+    Assert.assertEquals("Escape should be backslash",
+        "\\",
+        new CSVProperties.Builder()
+            .escape("\\")
+            .build().escape);
+  }
+
+  @Test
+  public void testCSVProperitesBuilderQuote() {
+    Assert.assertEquals("Quote should be '",
+        "'",
+        new CSVProperties.Builder()
+            .quote("\\u0027")
+            .build().quote);
+    Assert.assertEquals("Quote should be '",
+        "'",
+        new CSVProperties.Builder()
+            .quote("\\'")
+            .build().quote);
+    Assert.assertEquals("Quote should be '",
+        "'",
+        new CSVProperties.Builder()
+            .quote("\'")
+            .build().quote);
+    Assert.assertEquals("Quote should be '",
+        "'",
+        new CSVProperties.Builder()
+            .quote("'")
+            .build().quote);
+  }
+}


### PR DESCRIPTION
This generalizes the support for escaped characters, like \t. It uses
unescapeJava to decode the quote, delimiter, and escape characters
passed into the builder (which is used by the CLI commands).

Once CDK-259 is merged and we update guava, we should use the guava
escape support.
