### PR TITLE
CDK-677: Add translation from Hive DDL to Schema.

### DIFF
--- a/kite-data/kite-data-hive/src/main/java/org/kitesdk/data/spi/hive/HiveSchemaConverter.java
+++ b/kite-data/kite-data-hive/src/main/java/org/kitesdk/data/spi/hive/HiveSchemaConverter.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright 2013 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data.spi.hive;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.avro.Schema;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
+import org.apache.hadoop.hive.serde2.typeinfo.UnionTypeInfo;
+import org.codehaus.jackson.node.NullNode;
+import org.kitesdk.compat.DynConstructors;
+import org.kitesdk.compat.DynMethods;
+import org.kitesdk.data.PartitionStrategy;
+import org.kitesdk.data.spi.FieldPartitioner;
+import org.kitesdk.data.spi.SchemaUtil;
+
+public class HiveSchemaConverter {
+
+  private static final DynMethods.StaticMethod primitiveTypeForName =
+      new DynMethods.Builder("getPrimitiveTypeInfo")
+          .impl(TypeInfoFactory.class, String.class)
+          .buildStatic();
+
+  private static final DynMethods.StaticMethod parseTypeInfo =
+      new DynMethods.Builder("getTypeInfoFromTypeString")
+          .impl(TypeInfoUtils.class, String.class)
+          .buildStatic();
+
+  private static Class<?> findTypeInfoClass(String className) {
+    try {
+      return new DynConstructors.Builder(TypeInfo.class)
+          .impl(className).buildChecked().getConstructedClass();
+    } catch (NoSuchMethodException e) {
+      return null;
+    }
+  }
+
+  // TypeInfo classes that may not be present at runtime
+  @VisibleForTesting
+  static final Class<?> charClass = findTypeInfoClass(
+      "org.apache.hadoop.hive.serde2.typeinfo.CharTypeInfo");
+  @VisibleForTesting
+  static final Class<?> varcharClass = findTypeInfoClass(
+      "org.apache.hadoop.hive.serde2.typeinfo.VarcharTypeInfo");
+  @VisibleForTesting
+  static final Class<?> decimalClass = findTypeInfoClass(
+      "org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo");
+
+  private static final ImmutableMap<String, Schema.Type> TYPEINFO_TO_TYPE =
+      ImmutableMap.<String, Schema.Type>builder()
+          .put("boolean", Schema.Type.BOOLEAN)
+          .put("tinyint", Schema.Type.INT)
+          .put("smallint", Schema.Type.INT)
+          .put("int", Schema.Type.INT)
+          .put("bigint", Schema.Type.LONG)
+          .put("float", Schema.Type.FLOAT)
+          .put("double", Schema.Type.DOUBLE)
+          .put("string", Schema.Type.STRING)
+          .put("binary", Schema.Type.BYTES)
+          .put("void", Schema.Type.NULL) // void columns are placeholders
+          .build();
+
+  static final ImmutableMap<Schema.Type, TypeInfo> TYPE_TO_TYPEINFO =
+      ImmutableMap.<Schema.Type, TypeInfo>builder()
+          .put(Schema.Type.BOOLEAN, primitiveTypeInfo("boolean"))
+          .put(Schema.Type.INT, primitiveTypeInfo("int"))
+          .put(Schema.Type.LONG, primitiveTypeInfo("bigint"))
+          .put(Schema.Type.FLOAT, primitiveTypeInfo("float"))
+          .put(Schema.Type.DOUBLE, primitiveTypeInfo("double"))
+          .put(Schema.Type.STRING, primitiveTypeInfo("string"))
+          .put(Schema.Type.ENUM, primitiveTypeInfo("string"))
+          .put(Schema.Type.BYTES, primitiveTypeInfo("binary"))
+          .put(Schema.Type.FIXED, primitiveTypeInfo("binary"))
+          .build();
+
+  private static final Schema NULL = Schema.create(Schema.Type.NULL);
+  @VisibleForTesting
+  static final NullNode NULL_DEFAULT = NullNode.getInstance();
+  @VisibleForTesting
+  static final Collection<String[]> NO_REQUIRED_FIELDS = ImmutableList.of();
+
+  private static TypeInfo primitiveTypeInfo(String type) {
+    return primitiveTypeForName.invoke(type);
+  }
+
+  public static TypeInfo parseTypeInfo(String type) {
+    return parseTypeInfo.invoke(type);
+  }
+
+  public static Schema convertTable(String table, Collection<FieldSchema> columns,
+                                    @Nullable PartitionStrategy strategy) {
+    ArrayList<String> fieldNames = Lists.newArrayList();
+    ArrayList<TypeInfo> fieldTypes = Lists.newArrayList();
+    LinkedList<String> start = Lists.newLinkedList();
+    Collection<String[]> requiredFields = requiredFields(strategy);
+
+    List<Schema.Field> fields = Lists.newArrayList();
+    for (FieldSchema column : columns) {
+      // pass null for the initial path to exclude the table name
+      TypeInfo type = parseTypeInfo(column.getType());
+      fieldNames.add(column.getName());
+      fieldTypes.add(type);
+      fields.add(convertField(start, column.getName(), type, requiredFields));
+    }
+
+    StructTypeInfo struct = new StructTypeInfo();
+    struct.setAllStructFieldNames(fieldNames);
+    struct.setAllStructFieldTypeInfos(fieldTypes);
+
+    Schema recordSchema = Schema.createRecord(table, doc(struct), null, false);
+    recordSchema.setFields(fields);
+
+    return recordSchema;
+  }
+
+  private static Schema convert(LinkedList<String> path, String name,
+                                StructTypeInfo type,
+                                Collection<String[]> required) {
+    List<String> names = type.getAllStructFieldNames();
+    List<TypeInfo> types = type.getAllStructFieldTypeInfos();
+    Preconditions.checkArgument(names.size() == types.size(),
+        "Cannot convert struct: %s names != %s types",
+        names.size(), types.size());
+
+    List<Schema.Field> fields = Lists.newArrayList();
+    for (int i = 0; i < names.size(); i += 1) {
+      path.addLast(name);
+      fields.add(convertField(path, names.get(i), types.get(i), required));
+      path.removeLast();
+    }
+
+    Schema recordSchema = Schema.createRecord(name, doc(type), null, false);
+    recordSchema.setFields(fields);
+
+    return recordSchema;
+  }
+
+  private static Schema.Field convertField(LinkedList<String> path, String name,
+                                           TypeInfo type,
+                                           Collection<String[]> required) {
+    // filter the required fields with the current name
+    Collection<String[]> matchingRequired = filterByStartsWith(required, path, name);
+
+    Schema schema = convert(path, name, type, matchingRequired);
+    boolean isOptional = (schema.getType() == Schema.Type.UNION);
+
+    if (!isOptional && matchingRequired.size() < 1) {
+      // not already an optional union and not required, make it optional.
+      // this doesn't complain if a required field is already optional because
+      // the minimum required fields are validated by DatasetDescriptor.
+      schema  = optional(schema);
+      isOptional = true;
+    }
+
+    return new Schema.Field(name, schema, doc(type),
+        isOptional ? NULL_DEFAULT : null);
+  }
+
+  @VisibleForTesting
+  static Schema convert(LinkedList<String> path, String name,
+                        TypeInfo type, Collection<String[]> required) {
+    switch (type.getCategory()) {
+      case PRIMITIVE:
+        if (type.getClass() == charClass || type.getClass() == varcharClass) {
+          // this is required because type name includes length
+          return Schema.create(Schema.Type.STRING);
+        }
+
+        String typeInfoName = type.getTypeName();
+        Preconditions.checkArgument(TYPEINFO_TO_TYPE.containsKey(typeInfoName),
+            "Cannot convert unsupported type: %s", typeInfoName);
+        return Schema.create(TYPEINFO_TO_TYPE.get(typeInfoName));
+
+      case LIST:
+        return Schema.createArray(optional(convert(path, name,
+            ((ListTypeInfo) type).getListElementTypeInfo(), required)));
+
+      case MAP:
+        MapTypeInfo mapType = (MapTypeInfo) type;
+        Preconditions.checkArgument(
+            "string".equals(mapType.getMapKeyTypeInfo().toString()),
+            "Non-String map key type: %s", mapType.getMapKeyTypeInfo());
+
+        return Schema.createMap(optional(convert(path, name,
+            mapType.getMapValueTypeInfo(), required)));
+
+      case STRUCT:
+        return convert(path, name, (StructTypeInfo) type, required);
+
+      case UNION:
+        List<TypeInfo> unionTypes = ((UnionTypeInfo) type)
+            .getAllUnionObjectTypeInfos();
+
+        // add NULL so all union types are optional
+        List<Schema> types = Lists.newArrayList(NULL);
+        for (int i = 0; i < unionTypes.size(); i += 1) {
+          // types within unions cannot be required
+          types.add(convert(
+              path, name + "_" + i, unionTypes.get(i), NO_REQUIRED_FIELDS));
+        }
+
+        return Schema.createUnion(types);
+
+      default:
+        throw new IllegalArgumentException(
+            "Unknown TypeInfo category: " + type.getCategory());
+    }
+  }
+
+  @VisibleForTesting
+  static Schema optional(Schema schema) {
+    return Schema.createUnion(Lists.newArrayList(NULL, schema));
+  }
+
+  private static String doc(TypeInfo type) {
+    if (type instanceof StructTypeInfo) {
+      // don't add struct<a:t1,b:t2> when fields a and b will have doc strings
+      return null;
+    }
+    return "Converted from '" + String.valueOf(type) + "'";
+  }
+
+  public static List<FieldSchema> convertSchema(Schema avroSchema) {
+    List<FieldSchema> columns = Lists.newArrayList();
+    if (Schema.Type.RECORD.equals(avroSchema.getType())) {
+      for (Schema.Field field : avroSchema.getFields()) {
+        columns.add(new FieldSchema(
+            field.name(), convert(field.schema()).getTypeName(), field.doc()));
+      }
+    } else {
+      columns.add(new FieldSchema(
+          "column", convert(avroSchema).getTypeName(), avroSchema.getDoc()));
+    }
+    return columns;
+  }
+
+  @VisibleForTesting
+  static TypeInfo convert(Schema schema) {
+    return SchemaUtil.visit(schema, new Converter());
+  }
+
+  private static class Converter extends SchemaUtil.SchemaVisitor<TypeInfo> {
+    public TypeInfo record(Schema record, List<String> names, List<TypeInfo> types) {
+      return TypeInfoFactory.getStructTypeInfo(names, types);
+    }
+
+    @Override
+    public TypeInfo union(Schema union, List<TypeInfo> options) {
+      // so no need to keep track of whether the avro type is nullable because
+      // all Hive types are nullable
+      List<TypeInfo> nonNullTypes = Lists.newArrayList();
+      for (TypeInfo type : options) {
+        if (type != null) {
+          nonNullTypes.add(type);
+        }
+      }
+
+      // handle a single field in the union
+      if (nonNullTypes.size() == 1) {
+        return nonNullTypes.get(0);
+      }
+
+      return TypeInfoFactory.getUnionTypeInfo(nonNullTypes);
+    }
+
+    @Override
+    public TypeInfo array(Schema array, TypeInfo element) {
+      return TypeInfoFactory.getListTypeInfo(element);
+    }
+
+    @Override
+    public TypeInfo map(Schema map, TypeInfo value) {
+      return TypeInfoFactory.getMapTypeInfo(
+          TYPE_TO_TYPEINFO.get(Schema.Type.STRING), value);
+    }
+
+    @Override
+    public TypeInfo primitive(Schema primitive) {
+      return TYPE_TO_TYPEINFO.get(primitive.getType());
+    }
+  }
+
+  private static Collection<String[]> filterByStartsWith(
+      Collection<String[]> fields, LinkedList<String> path, String name) {
+    path.addLast(name);
+
+    List<String[]> startsWithCollection = Lists.newArrayList();
+    for (String[] field : fields) {
+      if (startsWith(field, path)) {
+        startsWithCollection.add(field);
+      }
+    }
+
+    path.removeLast();
+
+    return startsWithCollection;
+  }
+
+  /**
+   * Returns true if left starts with right.
+   */
+  private static boolean startsWith(String[] left, List<String> right) {
+    // short circuit if a match isn't possible
+    if (left.length < right.size()) {
+      return false;
+    }
+
+    for (int i = 0; i < right.size(); i += 1) {
+      if (!left[i].equals(right.get(i))) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  @SuppressWarnings("deprecation")
+  private static Collection<String[]> requiredFields(@Nullable PartitionStrategy strategy) {
+    if (strategy == null) {
+      return NO_REQUIRED_FIELDS;
+    }
+
+    List<String[]> requiredFields = Lists.newArrayList();
+    for (FieldPartitioner fp : strategy.getFieldPartitioners()) {
+      // source name is not present for provided partitioners
+      if (fp.getSourceName() != null) {
+        requiredFields.add(fp.getSourceName().split("\\."));
+      }
+    }
+
+    return requiredFields;
+  }
+}

--- a/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestSchemaConversion.java
+++ b/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestSchemaConversion.java
@@ -67,18 +67,18 @@ public class TestSchemaConversion {
         }
       };
 
-  private static final TypeInfo BOOLEAN_TYPE_INFO = HiveUtils.Converter.TYPE_TO_TYPEINFO.get(Schema.Type.BOOLEAN);
-  private static final TypeInfo INT_TYPE_INFO = HiveUtils.Converter.TYPE_TO_TYPEINFO.get(Schema.Type.INT);
-  private static final TypeInfo LONG_TYPE_INFO = HiveUtils.Converter.TYPE_TO_TYPEINFO.get(Schema.Type.LONG);
-  private static final TypeInfo FLOAT_TYPE_INFO = HiveUtils.Converter.TYPE_TO_TYPEINFO.get(Schema.Type.FLOAT);
-  private static final TypeInfo DOUBLE_TYPE_INFO = HiveUtils.Converter.TYPE_TO_TYPEINFO.get(Schema.Type.DOUBLE);
-  private static final TypeInfo STRING_TYPE_INFO = HiveUtils.Converter.TYPE_TO_TYPEINFO.get(Schema.Type.STRING);
-  private static final TypeInfo BINARY_TYPE_INFO = HiveUtils.Converter.TYPE_TO_TYPEINFO.get(Schema.Type.BYTES);
+  private static final TypeInfo BOOLEAN_TYPE_INFO = HiveSchemaConverter.TYPE_TO_TYPEINFO.get(Schema.Type.BOOLEAN);
+  private static final TypeInfo INT_TYPE_INFO = HiveSchemaConverter.TYPE_TO_TYPEINFO.get(Schema.Type.INT);
+  private static final TypeInfo LONG_TYPE_INFO = HiveSchemaConverter.TYPE_TO_TYPEINFO.get(Schema.Type.LONG);
+  private static final TypeInfo FLOAT_TYPE_INFO = HiveSchemaConverter.TYPE_TO_TYPEINFO.get(Schema.Type.FLOAT);
+  private static final TypeInfo DOUBLE_TYPE_INFO = HiveSchemaConverter.TYPE_TO_TYPEINFO.get(Schema.Type.DOUBLE);
+  private static final TypeInfo STRING_TYPE_INFO = HiveSchemaConverter.TYPE_TO_TYPEINFO.get(Schema.Type.STRING);
+  private static final TypeInfo BINARY_TYPE_INFO = HiveSchemaConverter.TYPE_TO_TYPEINFO.get(Schema.Type.BYTES);
 
   @Test
   public void testConvertSchemaWithPrimitive() {
     Schema primitiveSchema = SchemaBuilder.builder().stringType();
-    List<FieldSchema> fields = HiveUtils.convertSchema(primitiveSchema);
+    List<FieldSchema> fields = HiveSchemaConverter.convertSchema(primitiveSchema);
 
     Assert.assertEquals("Should be a single FieldSchema", 1, fields.size());
     Assert.assertEquals("Should be named \"column\"",
@@ -90,7 +90,7 @@ public class TestSchemaConversion {
   @Test
   public void testConvertSchemaWithSimpleRecord() {
     // convertSchema returns a list of FieldSchema objects rather than TypeInfo
-    List<FieldSchema> fields = HiveUtils.convertSchema(SIMPLE_RECORD);
+    List<FieldSchema> fields = HiveSchemaConverter.convertSchema(SIMPLE_RECORD);
 
     Assert.assertEquals("Field names should match",
         Lists.newArrayList("id", "name"),
@@ -105,7 +105,7 @@ public class TestSchemaConversion {
   @Test
   public void testConvertSchemaWithComplexRecord() {
     // convertSchema returns a list of FieldSchema objects rather than TypeInfo
-    List<FieldSchema> fields = HiveUtils.convertSchema(COMPLEX_RECORD);
+    List<FieldSchema> fields = HiveSchemaConverter.convertSchema(COMPLEX_RECORD);
 
     Assert.assertEquals("Field names should match",
         Lists.newArrayList("groupName", "simpleRecords"),
@@ -124,7 +124,7 @@ public class TestSchemaConversion {
 
   @Test
   public void testSimpleRecord() {
-    TypeInfo type = HiveUtils.convert(SIMPLE_RECORD);
+    TypeInfo type = HiveSchemaConverter.convert(SIMPLE_RECORD);
 
     Assert.assertTrue("Record should be converted to struct",
         type instanceof StructTypeInfo);
@@ -140,7 +140,7 @@ public class TestSchemaConversion {
 
   @Test
   public void testArray() {
-    TypeInfo type = HiveUtils.convert(SchemaBuilder.array()
+    TypeInfo type = HiveSchemaConverter.convert(SchemaBuilder.array()
         .items().floatType());
 
     Assert.assertEquals("Array should be converted to list",
@@ -150,7 +150,7 @@ public class TestSchemaConversion {
 
   @Test
   public void testMap() {
-    TypeInfo type = HiveUtils.convert(SchemaBuilder.builder().map()
+    TypeInfo type = HiveSchemaConverter.convert(SchemaBuilder.builder().map()
         .values().booleanType());
 
     Assert.assertEquals("Map should be converted to map",
@@ -160,7 +160,7 @@ public class TestSchemaConversion {
 
   @Test
   public void testUnion() {
-    TypeInfo type = HiveUtils.convert(SchemaBuilder.builder().unionOf()
+    TypeInfo type = HiveSchemaConverter.convert(SchemaBuilder.builder().unionOf()
         .bytesType().and()
         .fixed("fixed").size(12).and()
         .doubleType().and()
@@ -178,7 +178,7 @@ public class TestSchemaConversion {
 
   @Test
   public void testEnum() {
-    TypeInfo type = HiveUtils.convert(SchemaBuilder.builder()
+    TypeInfo type = HiveSchemaConverter.convert(SchemaBuilder.builder()
         .enumeration("TestEnum").symbols("a", "b", "c"));
 
     Assert.assertEquals("Enum should be converted to string",
@@ -192,6 +192,6 @@ public class TestSchemaConversion {
         .name("children").type().array().items()
             .type("RecursiveRecord").noDefault()
         .endRecord();
-    HiveUtils.convert(recursiveRecord);
+    HiveSchemaConverter.convert(recursiveRecord);
   }
 }

--- a/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestTableConversion.java
+++ b/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestTableConversion.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2013 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data.spi.hive;
+
+import com.google.common.collect.Lists;
+import java.util.LinkedList;
+import java.util.List;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.junit.Assert;
+import org.junit.Test;
+import org.kitesdk.data.PartitionStrategy;
+import org.kitesdk.data.TestHelpers;
+
+import static org.kitesdk.data.spi.hive.HiveSchemaConverter.NO_REQUIRED_FIELDS;
+import static org.kitesdk.data.spi.hive.HiveSchemaConverter.NULL_DEFAULT;
+import static org.kitesdk.data.spi.hive.HiveSchemaConverter.optional;
+import static org.kitesdk.data.spi.hive.HiveSchemaConverter.parseTypeInfo;
+
+public class TestTableConversion {
+
+  private final LinkedList<String> startPath = Lists.newLinkedList();
+
+  private Schema convertPrimitive(String type) {
+    return HiveSchemaConverter.convert(startPath, "test",
+        parseTypeInfo(type), NO_REQUIRED_FIELDS);
+  }
+
+  @Test
+  public void testConvertPrimitives() {
+    Assert.assertEquals(
+        Schema.create(Schema.Type.BOOLEAN), convertPrimitive("boolean"));
+    Assert.assertEquals(
+        Schema.create(Schema.Type.INT), convertPrimitive("tinyint"));
+    Assert.assertEquals(
+        Schema.create(Schema.Type.INT), convertPrimitive("smallint"));
+    Assert.assertEquals(
+        Schema.create(Schema.Type.INT), convertPrimitive("int"));
+    Assert.assertEquals(
+        Schema.create(Schema.Type.LONG), convertPrimitive("bigint"));
+    Assert.assertEquals(
+        Schema.create(Schema.Type.FLOAT), convertPrimitive("float"));
+    Assert.assertEquals(
+        Schema.create(Schema.Type.DOUBLE), convertPrimitive("double"));
+    Assert.assertEquals(
+        Schema.create(Schema.Type.STRING), convertPrimitive("string"));
+    Assert.assertEquals(
+        Schema.create(Schema.Type.BYTES), convertPrimitive("binary"));
+
+    if (HiveSchemaConverter.charClass != null) {
+      Assert.assertEquals(
+          Schema.create(Schema.Type.STRING), convertPrimitive("char(10)"));
+    }
+
+    if (HiveSchemaConverter.varcharClass != null) {
+      Assert.assertEquals(
+          Schema.create(Schema.Type.STRING), convertPrimitive("varchar(32)"));
+    }
+
+    if (HiveSchemaConverter.decimalClass != null) {
+      TestHelpers.assertThrows("Should reject unknown type",
+          IllegalArgumentException.class, new Runnable() {
+            @Override
+            public void run() {
+              convertPrimitive("decimal(2,4)");
+            }
+          });
+    }
+  }
+
+  @Test
+  public void testConvertArrays() {
+    TypeInfo arrayOfStringsType = parseTypeInfo("array<string>");
+    Schema arrayOfStringsSchema = Schema.createArray(
+        optional(Schema.create(Schema.Type.STRING)));
+    Assert.assertEquals("Should convert array of primitive",
+        arrayOfStringsSchema,
+        HiveSchemaConverter.convert(
+            startPath, "test", arrayOfStringsType, NO_REQUIRED_FIELDS));
+
+    TypeInfo arrayOfArraysType = parseTypeInfo("array<array<string>>");
+    Schema arrayOfArraysSchema = Schema.createArray(
+        optional(arrayOfStringsSchema));
+    Assert.assertEquals("Should convert array of arrays",
+        arrayOfArraysSchema,
+        HiveSchemaConverter.convert(
+            startPath, "test", arrayOfArraysType, NO_REQUIRED_FIELDS));
+
+    TypeInfo arrayOfMapsType = parseTypeInfo("array<map<string,float>>");
+    Schema arrayOfMapsSchema = Schema.createArray(
+        optional(Schema.createMap(optional(Schema.create(Schema.Type.FLOAT)))));
+    Assert.assertEquals("Should convert array of maps",
+        arrayOfMapsSchema,
+        HiveSchemaConverter.convert(
+            startPath, "test", arrayOfMapsType, NO_REQUIRED_FIELDS));
+
+    TypeInfo arrayOfStructsType = parseTypeInfo(
+        "array<struct<a:array<array<string>>,b:array<map<string,float>>>>");
+    Schema recordSchema = Schema.createRecord("test", null, null, false);
+    recordSchema.setFields(Lists.newArrayList(
+        new Schema.Field("a", optional(arrayOfArraysSchema), null, NULL_DEFAULT),
+        new Schema.Field("b", optional(arrayOfMapsSchema), null, NULL_DEFAULT)
+    ));
+    Schema arrayOfStructsSchema = Schema.createArray(optional(recordSchema));
+    Assert.assertEquals("Should convert array of structs",
+        arrayOfStructsSchema,
+        HiveSchemaConverter.convert(
+            startPath, "test", arrayOfStructsType, NO_REQUIRED_FIELDS));
+  }
+
+  @Test
+  public void testConvertMaps() {
+    TypeInfo mapOfLongsType = parseTypeInfo("map<string,bigint>");
+    Schema mapOfLongsSchema = Schema.createMap(
+        optional(Schema.create(Schema.Type.LONG)));
+    Assert.assertEquals("Should convert map of primitive",
+        mapOfLongsSchema,
+        HiveSchemaConverter.convert(
+            startPath, "test", mapOfLongsType, NO_REQUIRED_FIELDS));
+
+    TypeInfo mapOfArraysType = parseTypeInfo("array<float>");
+    Schema mapOfArraysSchema = Schema.createArray(
+        optional(Schema.create(Schema.Type.FLOAT)));
+    Assert.assertEquals("Should convert map of arrays",
+        mapOfArraysSchema,
+        HiveSchemaConverter.convert(
+            startPath, "test", mapOfArraysType, NO_REQUIRED_FIELDS));
+
+    TypeInfo mapOfMapsType = parseTypeInfo(
+        "array<map<string,map<string,bigint>>>");
+    Schema mapOfMapsSchema = Schema.createArray(
+        optional(Schema.createMap(optional(mapOfLongsSchema))));
+    Assert.assertEquals("Should convert map of maps",
+        mapOfMapsSchema,
+        HiveSchemaConverter.convert(
+            startPath, "test", mapOfMapsType, NO_REQUIRED_FIELDS));
+
+    TypeInfo mapOfStructsType = parseTypeInfo("map<string," +
+        "struct<a:array<float>,b:array<map<string,map<string,bigint>>>>>");
+    Schema recordSchema = Schema.createRecord("test", null, null, false);
+    recordSchema.setFields(Lists.newArrayList(
+        new Schema.Field("a", optional(mapOfArraysSchema), null, NULL_DEFAULT),
+        new Schema.Field("b", optional(mapOfMapsSchema), null, NULL_DEFAULT)
+    ));
+    Schema mapOfStructsSchema = Schema.createMap(optional(recordSchema));
+    Assert.assertEquals("Should convert map of structs",
+        mapOfStructsSchema,
+        HiveSchemaConverter.convert(
+            startPath, "test", mapOfStructsType, NO_REQUIRED_FIELDS));
+  }
+
+  private static final TypeInfo STRUCT_OF_STRUCTS_TYPE = parseTypeInfo(
+      "struct<str:string,inner:struct<a:int,b:binary>>");
+
+  @Test
+  public void testConvertStructs() {
+    Schema recordSchema = Schema.createRecord("inner", null, null, false);
+    recordSchema.setFields(Lists.newArrayList(
+        new Schema.Field("a",
+            optional(Schema.create(Schema.Type.INT)), null, NULL_DEFAULT),
+        new Schema.Field("b",
+            optional(Schema.create(Schema.Type.BYTES)), null, NULL_DEFAULT)
+    ));
+    Schema structOfStructsSchema = Schema.createRecord("test", null, null, false);
+    structOfStructsSchema.setFields(Lists.newArrayList(
+        new Schema.Field("str",
+            optional(Schema.create(Schema.Type.STRING)), null, NULL_DEFAULT),
+        new Schema.Field("inner", optional(recordSchema), null, NULL_DEFAULT)
+    ));
+
+    Assert.assertEquals("Should convert struct of structs",
+        structOfStructsSchema,
+        HiveSchemaConverter.convert(
+            startPath, "test", STRUCT_OF_STRUCTS_TYPE, NO_REQUIRED_FIELDS));
+  }
+
+  @Test
+  public void testConvertStructWithRequiredFields() {
+    Schema recordSchema = Schema.createRecord("inner", null, null, false);
+    recordSchema.setFields(Lists.newArrayList(
+        new Schema.Field("a", Schema.create(Schema.Type.INT), null, null),
+        new Schema.Field("b",
+            optional(Schema.create(Schema.Type.BYTES)), null, NULL_DEFAULT)
+    ));
+    Schema structOfStructsSchema = Schema.createRecord("test", null, null, false);
+    structOfStructsSchema.setFields(Lists.newArrayList(
+        new Schema.Field("str", Schema.create(Schema.Type.STRING), null, null),
+        new Schema.Field("inner", recordSchema, null, null)
+    ));
+
+    Assert.assertEquals("Should convert struct of structs",
+        structOfStructsSchema,
+        HiveSchemaConverter.convert(
+            startPath, "test", STRUCT_OF_STRUCTS_TYPE,
+            Lists.newArrayList(
+                new String[]{"test", "str"},
+                new String[]{"test", "inner", "a"})));
+  }
+
+  private static final List<FieldSchema> TABLE = Lists.newArrayList(
+      new FieldSchema("str", "string", null),
+      new FieldSchema("inner", "struct<a:int,b:binary>", null)
+  );
+
+  @Test
+  public void testConvertTable() {
+    Schema recordSchema = Schema.createRecord("inner", null, null, false);
+    recordSchema.setFields(Lists.newArrayList(
+        new Schema.Field("a",
+            optional(Schema.create(Schema.Type.INT)), null, NULL_DEFAULT),
+        new Schema.Field("b",
+            optional(Schema.create(Schema.Type.BYTES)), null, NULL_DEFAULT)
+    ));
+    Schema structOfStructsSchema = Schema.createRecord("test", null, null, false);
+    structOfStructsSchema.setFields(Lists.newArrayList(
+        new Schema.Field("str",
+            optional(Schema.create(Schema.Type.STRING)), null, NULL_DEFAULT),
+        new Schema.Field("inner", optional(recordSchema), null, NULL_DEFAULT)
+    ));
+
+    Assert.assertEquals("Should convert struct of structs",
+        structOfStructsSchema,
+        HiveSchemaConverter.convertTable("test", TABLE, null));
+  }
+
+  @Test
+  public void testConvertTableWithRequiredFields() {
+    Schema recordSchema = Schema.createRecord("inner", null, null, false);
+    recordSchema.setFields(Lists.newArrayList(
+        new Schema.Field("a", Schema.create(Schema.Type.INT), null, null),
+        new Schema.Field("b",
+            optional(Schema.create(Schema.Type.BYTES)), null, NULL_DEFAULT)
+    ));
+    Schema structOfStructsSchema = Schema.createRecord("test", null, null, false);
+    structOfStructsSchema.setFields(Lists.newArrayList(
+        new Schema.Field("str", Schema.create(Schema.Type.STRING), null, null),
+        new Schema.Field("inner", recordSchema, null, null)
+    ));
+
+    PartitionStrategy strategy = new PartitionStrategy.Builder()
+        .provided("not_present", "int")
+        .hash("inner.a", 16) // requires both inner and inner.a
+        .identity("str")
+        .build();
+
+    Assert.assertEquals("Should convert table named test",
+        structOfStructsSchema,
+        HiveSchemaConverter.convertTable("test", TABLE, strategy));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
     <vers.hbase2>0.98.3-hadoop2</vers.hbase2>
     <vers.hbase-cdh4>0.94.6-cdh${cdh4.version}</vers.hbase-cdh4>
     <vers.hbase-cdh5>0.96.1.1-cdh${cdh5.version}</vers.hbase-cdh5>
-    <vers.hive>0.10.0</vers.hive>
+    <vers.hive>0.13.0</vers.hive>
     <vers.hive-cdh5>0.12.0-cdh${cdh5.version}</vers.hive-cdh5>
     <vers.jetty>8.1.14.v20131031</vers.jetty>
     <vers.jexl>2.1.1</vers.jexl>


### PR DESCRIPTION
Tables created in Hive using STORED AS AVRO do not have a schema URI or
literal in the table properties. Instead, the schema is generated from
the table DDL when writing. This translates from table DDL if no schema
is set. This also fixes tables created with STORED AS PARQUET.