### PR TITLE
CDK-845: Refactor CSV to support String parsing.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVRecordBuilder.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVRecordBuilder.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2013 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data.spi.filesystem;
+
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.reflect.ReflectData;
+import org.kitesdk.data.DatasetReaderException;
+import org.kitesdk.data.DatasetRecordException;
+import org.kitesdk.data.spi.SchemaUtil;
+
+class CSVRecordBuilder<E> {
+  private final Schema schema;
+  private final Class<E> recordClass;
+  private final Schema.Field[] fields;
+  private final int[] indexes; // Record position to CSV field position
+
+  public CSVRecordBuilder(Schema schema, Class<E> recordClass,
+                          @Nullable List<String> header) {
+    this.schema = schema;
+    this.recordClass = recordClass;
+
+    // initialize the index and field arrays
+    fields = schema.getFields().toArray(new Schema.Field[schema.getFields().size()]);
+    indexes = new int[fields.length];
+
+    if (header != null) {
+      for (int i = 0; i < fields.length; i += 1) {
+        fields[i] = schema.getFields().get(i);
+        indexes[i] = Integer.MAX_VALUE; // never present in the row
+      }
+
+      // there's a header in next
+      for (int i = 0; i < header.size(); i += 1) {
+        Schema.Field field = schema.getField(header.get(i));
+        if (field != null) {
+          indexes[field.pos()] = i;
+        }
+      }
+
+    } else {
+      // without a header, map to fields by position
+      for (int i = 0; i < fields.length; i += 1) {
+        fields[i] = schema.getFields().get(i);
+        indexes[i] = i;
+      }
+    }
+  }
+
+  public E makeRecord(String[] fields, @Nullable E reuse) {
+    try {
+      E record = reuse;
+      if (record == null) {
+        record = newRecordInstance();
+      }
+
+      if (record instanceof IndexedRecord) {
+        fillIndexed((IndexedRecord) record, fields);
+      } else {
+        fillReflect(record, fields);
+      }
+
+      return record;
+    } catch (AvroRuntimeException e) {
+      // expected when a field has no default and no value can be constructed
+      throw new DatasetRecordException("Unable to construct record", e);
+    } catch (NumberFormatException e) {
+      // expected when a value should be a number but can't be parsed
+      throw new DatasetRecordException("Unable to construct record", e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private E newRecordInstance() {
+    if (recordClass != GenericData.Record.class && !recordClass.isInterface()) {
+      E record = (E) ReflectData.newInstance(recordClass, schema);
+      if (record != null) {
+        return record;
+      }
+    }
+    return (E) new GenericData.Record(schema);
+  }
+
+  private void fillIndexed(IndexedRecord record, String[] data) {
+    for (int i = 0; i < indexes.length; i += 1) {
+      int index = indexes[i];
+      record.put(i,
+          makeValue(index < data.length ? data[index] : null, fields[i]));
+    }
+  }
+
+  private void fillReflect(Object record, String[] data) {
+    for (int i = 0; i < indexes.length; i += 1) {
+      Schema.Field field = fields[i];
+      int index = indexes[i];
+      Object value = makeValue(index < data.length ? data[index] : null, field);
+      ReflectData.get().setField(record, field.name(), i, value);
+    }
+  }
+
+  private static Object makeValue(@Nullable String string, Schema.Field field) {
+    Object value = makeValue(string, field.schema());
+    if (value != null || SchemaUtil.nullOk(field.schema())) {
+      return value;
+    } else {
+      // this will fail if there is no default value
+      return ReflectData.get().getDefaultValue(field);
+    }
+  }
+
+  /**
+   * Returns a the value as the first matching schema type or null.
+   *
+   * Note that if the value may be null even if the schema does not allow the
+   * value to be null.
+   *
+   * @param string a String representation of the value
+   * @param schema a Schema
+   * @return the string coerced to the correct type from the schema or null
+   */
+  private static Object makeValue(@Nullable String string, Schema schema) {
+    if (string == null) {
+      return null;
+    }
+
+    try {
+      switch (schema.getType()) {
+        case BOOLEAN:
+          return Boolean.valueOf(string);
+        case STRING:
+          return string;
+        case FLOAT:
+          return Float.valueOf(string);
+        case DOUBLE:
+          return Double.valueOf(string);
+        case INT:
+          return Integer.valueOf(string);
+        case LONG:
+          return Long.valueOf(string);
+        case ENUM:
+          // TODO: translate to enum class
+          if (schema.hasEnumSymbol(string)) {
+            return string;
+          } else {
+            try {
+              return schema.getEnumSymbols().get(Integer.parseInt(string));
+            } catch (IndexOutOfBoundsException ex) {
+              return null;
+            }
+          }
+        case UNION:
+          Object value = null;
+          for (Schema possible : schema.getTypes()) {
+            value = makeValue(string, possible);
+            if (value != null) {
+              return value;
+            }
+          }
+          return null;
+        case NULL:
+          return null;
+        default:
+          // FIXED, BYTES, MAP, ARRAY, RECORD are not supported
+          throw new DatasetReaderException(
+              "Unsupported field type:" + schema.getType());
+      }
+    } catch (NumberFormatException e) {
+      // empty string is considered null for numeric types
+      if (string.isEmpty()) {
+        return null;
+      } else {
+        throw e;
+      }
+    }
+  }
+}

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVRecordParser.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVRecordParser.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data.spi.filesystem;
+
+import au.com.bytecode.opencsv.CSVParser;
+import java.io.IOException;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.kitesdk.data.DatasetIOException;
+import org.kitesdk.data.View;
+import org.kitesdk.data.spi.DataModelUtil;
+
+public class CSVRecordParser<E> {
+  private final CSVParser parser;
+  private final CSVRecordBuilder<E> builder;
+
+  public CSVRecordParser(CSVProperties props,
+                         View<E> view,
+                         List<String> header) {
+    this.parser = CSVUtil.newParser(props);
+    this.builder = new CSVRecordBuilder<E>(
+        DataModelUtil.getReaderSchema(
+            view.getType(), view.getDataset().getDescriptor().getSchema()),
+        view.getType(), header);
+  }
+
+  public E read(String line) {
+    return read(line, null);
+  }
+
+  public E read(String line, @Nullable E reuse) {
+    try {
+      return builder.makeRecord(parser.parseLine(line), reuse);
+    } catch (IOException e) {
+      throw new DatasetIOException("Cannot parse line: " + line, e);
+    }
+  }
+}

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVUtil.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVUtil.java
@@ -16,6 +16,7 @@
 
 package org.kitesdk.data.spi.filesystem;
 
+import au.com.bytecode.opencsv.CSVParser;
 import au.com.bytecode.opencsv.CSVReader;
 import au.com.bytecode.opencsv.CSVWriter;
 import com.google.common.collect.ImmutableSet;
@@ -41,6 +42,14 @@ import org.kitesdk.data.spi.Compatibility;
 import static java.lang.Math.min;
 
 public class CSVUtil {
+
+  public static CSVParser newParser(CSVProperties props) {
+    return new CSVParser(
+        props.delimiter.charAt(0), props.quote.charAt(0),
+        props.escape.charAt(0),
+        false /* strict quotes off: don't ignore unquoted strings */,
+        true /* ignore leading white-space */ );
+  }
 
   public static CSVReader newReader(InputStream incoming, CSVProperties props) {
     return new CSVReader(

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemProperties.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemProperties.java
@@ -43,4 +43,9 @@ public class FileSystemProperties {
    */
   @VisibleForTesting
   static final String ALLOW_CSV_PROP = "kite.allow.csv";
+
+  /**
+   * Used to enable record reuse, if supported by the implementation.
+   */
+  public static final String REUSE_RECORDS = "kite.reader.reuse-records";
 }

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestCSVFileReader.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestCSVFileReader.java
@@ -18,9 +18,9 @@ package org.kitesdk.data.spi.filesystem;
 
 import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.DatasetReader;
+import org.kitesdk.data.DatasetRecordException;
 import org.kitesdk.data.TestDatasetReaders;
 import org.kitesdk.data.TestHelpers;
-import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericData;
@@ -312,7 +312,7 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
 
     Assert.assertTrue(reader.hasNext());
     TestHelpers.assertThrows("Should complain about null as a number",
-        NumberFormatException.class, new Runnable() {
+        DatasetRecordException.class, new Runnable() {
           @Override
           public void run() {
             reader.next();
@@ -321,7 +321,7 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
 
     Assert.assertTrue(reader.hasNext());
     TestHelpers.assertThrows("Should complain about missing default",
-        AvroRuntimeException.class, new Runnable() {
+        DatasetRecordException.class, new Runnable() {
       @Override
       public void run() {
         reader.next();
@@ -342,7 +342,7 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
     reader.initialize();
     Assert.assertTrue(reader.hasNext());
     TestHelpers.assertThrows("Should reject float value for integer schema",
-        NumberFormatException.class, new Runnable() {
+        DatasetRecordException.class, new Runnable() {
           @Override public void run() {
             reader.next();
           }
@@ -376,7 +376,7 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
 
     Assert.assertTrue(reader.hasNext());
     TestHelpers.assertThrows("Should complain about null as a number",
-        NumberFormatException.class, new Runnable() {
+        DatasetRecordException.class, new Runnable() {
           @Override
           public void run() {
             reader.next();
@@ -385,7 +385,7 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
 
     Assert.assertTrue(reader.hasNext());
     TestHelpers.assertThrows("Should complain about missing default",
-        AvroRuntimeException.class, new Runnable() {
+        DatasetRecordException.class, new Runnable() {
           @Override
           public void run() {
             reader.next();
@@ -422,7 +422,7 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
 
     Assert.assertTrue(reader.hasNext());
     TestHelpers.assertThrows("Should complain about null as a number",
-        NumberFormatException.class, new Runnable() {
+        DatasetRecordException.class, new Runnable() {
           @Override
           public void run() {
             reader.next();
@@ -468,7 +468,7 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
 
     Assert.assertTrue(reader.hasNext());
     TestHelpers.assertThrows("Should complain about null as a number",
-        NumberFormatException.class, new Runnable() {
+        DatasetRecordException.class, new Runnable() {
           @Override
           public void run() {
             reader.next();
@@ -514,7 +514,7 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
 
     Assert.assertTrue(reader.hasNext());
     TestHelpers.assertThrows("Should complain about null as a number",
-        NumberFormatException.class, new Runnable() {
+        DatasetRecordException.class, new Runnable() {
       @Override
       public void run() {
         reader.next();
@@ -523,7 +523,7 @@ public class TestCSVFileReader extends TestDatasetReaders<GenericData.Record> {
 
     Assert.assertTrue(reader.hasNext());
     TestHelpers.assertThrows("Should complain about missing default",
-        AvroRuntimeException.class, new Runnable() {
+        DatasetRecordException.class, new Runnable() {
       @Override
       public void run() {
         reader.next();


### PR DESCRIPTION
Extracts the Avro record building from CSVFileReader into CSVRecordBuilder
that can be used by passing an already-parsed String[]. Adds
CSVRecordParser that wraps a CSVParser, which will parse a single line
of CSV passed as a String. This is to support changes to the flume sink
that can read events with CSV payloads.