### PR TITLE
CDK-863: Deprecate DatasetWriter flush/sync, add Flushable.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetWriter.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetWriter.java
@@ -16,7 +16,6 @@
 package org.kitesdk.data;
 
 import java.io.Closeable;
-import java.io.Flushable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -56,7 +55,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  * @param <E> The type of entity accepted by this writer.
  */
 @NotThreadSafe
-public interface DatasetWriter<E> extends Flushable, Closeable {
+public interface DatasetWriter<E> extends Flushable, Syncable, Closeable {
 
   /**
    * <p>
@@ -78,20 +77,25 @@ public interface DatasetWriter<E> extends Flushable, Closeable {
 
   /**
    * <p>
-   * Force or commit any outstanding buffered data to the underlying stream (optional
-   * operation).
+   * Force or commit any outstanding buffered data to the underlying stream if
+   * supported.
    * </p>
    * <p>
-   * <strong>Note:</strong> Some implementations may not implement this method
-   * depending on the guarantees available to the underlying storage system.
-   * In particular, when using HDFS-backed datasets the {@link Formats#PARQUET Parquet
-   * format} does <em>not</em> implement {@link #flush()} by default,
-   * and calling it has no effect.
+   * <strong>Note:</strong> Some implementations do not implement this method.
+   * In particular, {@link Formats#PARQUET Parquet format} does <em>not</em>
+   * implement {@link #flush()} and calling it has no effect.
+   * </p>
+   * <p>
+   * After 0.18.0, DatasetWriter will no longer require flush. Instead,
+   * implementations that can support a durability guarantee, such as Avro,
+   * can be {@link Flushable} and {@link Syncable}.
    * </p>
    *
    * @throws DatasetWriterException
+   * @deprecated will be removed after 0.18.0; use {@link Flushable#flush}
    */
   @Override
+  @Deprecated
   void flush();
 
   /**
@@ -100,17 +104,23 @@ public interface DatasetWriter<E> extends Flushable, Closeable {
    * operation).
    * </p>
    * <p>
-   * <strong>Note:</strong> Some implementations may not implement this method
-   * depending on the guarantees available to the underlying storage system.
-   * In particular, when using HDFS-backed datasets the {@link Formats#PARQUET Parquet
-   * format} does <em>not</em> implement {@link #sync()} by default,
-   * and calling it has no effect.
+   * <strong>Note:</strong> Some implementations do not implement this method.
+   * In particular, {@link Formats#PARQUET Parquet format} does <em>not</em>
+   * implement {@link #flush()} and calling it has no effect.
+   * </p>
+   * <p>
+   * After 0.18.0, DatasetWriter will no longer require sync. Instead,
+   * implementations that can support a durability guarantee, such as Avro,
+   * can be {@link Flushable} and {@link Syncable}.
    * </p>
    *
    * @throws DatasetWriterException
    *
    * @since 0.16.0
+   * @deprecated will be removed after 0.18.0; use {@link Syncable#sync}
    */
+  @Override
+  @Deprecated
   void sync();
 
   /**

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/Flushable.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/Flushable.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data;
+
+/**
+ * A writer that can guarantee data is present on data nodes.
+ * <p>
+ * {@link #flush} has a stronger guarantee than {@link java.io.Flushable#flush}.
+ * When it returns, data already written is flushed to the OS buffers on all
+ * data nodes responsible for replicas.
+ * <p>
+ * Once data has been flushed, it will be tolerant to single-node and rack
+ * failures.
+ */
+@edu.umd.cs.findbugs.annotations.SuppressWarnings(
+    value="NM_SAME_SIMPLE_NAME_AS_INTERFACE",
+    justification="Intended to be a stricter version of the parent interface")
+public interface Flushable extends java.io.Flushable {
+  /**
+   * Ensure that data has been flushed to OS buffers on all replica data nodes.
+   * <p>
+   * This method has a stronger guarantee than {@link java.io.Flushable#flush}.
+   * When this method returns, data already written has been flushed to the OS
+   * buffers on all data nodes responsible for replicas.
+   */
+  @Override
+  void flush();
+}

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/Syncable.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/Syncable.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data;
+
+/**
+ * A writer that can guarantee data is persisted to disk.
+ * <p>
+ * When {@link #sync} returns, data already written is flushed to data nodes
+ * responsible for replicas and persisted to disk, not just to the underlying
+ * OS buffer.
+ */
+public interface Syncable {
+  /**
+   * Ensure that data has been synced to disk on all replica data nodes.
+   */
+  void sync();
+}


### PR DESCRIPTION
This deprecates the DatasetWriter#flush and #sync methods, which are
replaced by Flushable#flush. Sync needed to call flush to guarantee the
records were durable, but flush was still exposed, requiring callers to
flush and sync, with sync calling flush immediately afterwards. Instead,
the new Flushable interface carries a stronger guarantee that records
have not only been flushed to the underlying buffer, but that they are
persisted to disk also.