### PR TITLE
CDK-864: Add DatasetRecordException.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetRecordException.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetRecordException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data;
+
+/**
+ * A DatasetException that signals that an individual record has failed.
+ * <p>
+ * When writing, this exception indicates that a record could not be written,
+ * but the writer is still valid and ready to write other records.
+ * <p>
+ * When reading, this exception indicates that a record could not be built from
+ * record data, but that reader is still valid and able to read other records.
+ */
+public class DatasetRecordException extends DatasetException {
+  public DatasetRecordException(String message) {
+    super(message);
+  }
+
+  public DatasetRecordException(String message, Throwable t) {
+    super(message, t);
+  }
+}

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetWriter.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetWriter.java
@@ -38,13 +38,14 @@ import javax.annotation.concurrent.NotThreadSafe;
  * is called, so you <strong>must</strong> follow the normal try / finally
  * pattern to ensure these resources are properly freed when the writer is no
  * longer needed. Do not rely on implementations automatically invoking the
- * {@code close()} method upon object finalization (implementations must not do
+ * {@code close} method upon object finalization (implementations must not do
  * so). All implementations must silently ignore multiple invocations of
- * {@code close()} as well as a close of an unopened writer.
+ * {@code close} as well as a close of an unopened writer.
  * </p>
  * <p>
- * If any method throws an exception, the writer is no longer valid, and the
- * only method that can be subsequently called is {@code close()}.
+ * If any method throws an exception other than {@link DatasetRecordException},
+ * the writer is no longer valid, and the only method that can be subsequently
+ * called is {@code close}.
  * </p>
  * <p>
  * Implementations of {@link DatasetWriter} are typically not thread-safe; that
@@ -59,16 +60,18 @@ public interface DatasetWriter<E> extends Flushable, Closeable {
 
   /**
    * <p>
-   * Write an entity of type {@code E} to the associated dataset.
+   * Write an entity to the underlying dataset.
    * </p>
    * <p>
-   * Implementations can buffer entities internally (see the {@link #flush()} and {@link #sync()}
-   * methods). All instances of {@code entity} must conform to the dataset's
-   * schema. If they don't, implementations should throw an exception, although
-   * this is not required.
+   * If any exception other than {@link DatasetRecordException} is thrown, this
+   * writer is no longer valid and should be closed.
    * </p>
    *
    * @param entity The entity to write
+   * @throws DatasetRecordException
+   *            If a record could not be written, but the writer is still valid.
+   * @throws DatasetIOException
+   *            To wrap an internal {@link java.io.IOException}
    * @throws DatasetWriterException
    */
   void write(E entity);

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/AvroAppender.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/AvroAppender.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.kitesdk.compat.Hadoop;
 import org.kitesdk.data.CompressionType;
+import org.kitesdk.data.DatasetRecordException;
 import org.kitesdk.data.Formats;
 
 class AvroAppender<E> implements FileSystemWriter.FileAppender<E> {
@@ -67,7 +68,11 @@ class AvroAppender<E> implements FileSystemWriter.FileAppender<E> {
 
   @Override
   public void append(E entity) throws IOException {
-    dataFileWriter.append(entity);
+    try {
+      dataFileWriter.append(entity);
+    } catch (DataFileWriter.AppendWriteException e) {
+      throw new DatasetRecordException("Failed to append record", e);
+    }
   }
 
   @Override

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemWriter.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemWriter.java
@@ -18,6 +18,7 @@ package org.kitesdk.data.spi.filesystem;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
 import java.io.Closeable;
 import java.io.Flushable;
 import java.io.IOException;
@@ -29,6 +30,7 @@ import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.DatasetIOException;
+import org.kitesdk.data.DatasetRecordException;
 import org.kitesdk.data.DatasetWriterException;
 import org.kitesdk.data.Format;
 import org.kitesdk.data.Formats;
@@ -117,6 +119,10 @@ class FileSystemWriter<E> extends AbstractDatasetWriter<E> {
     try {
       appender.append(entity);
       count += 1;
+    } catch (RuntimeException e) {
+      Throwables.propagateIfInstanceOf(e, DatasetRecordException.class);
+      this.state = ReaderWriterState.ERROR;
+      throw e;
     } catch (IOException e) {
       this.state = ReaderWriterState.ERROR;
       throw new DatasetIOException(


### PR DESCRIPTION
This is similar to Avro's AppendWriteException and signals that a write
operation failed because an invalid (or otherwise unusable) record was
passed in, but the writer can still be used.