### PR TITLE
CDK-870: Use blank skin instead of custom empty skin.

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -20,9 +20,9 @@
   <version position="bottom" />
 
   <skin>
-    <groupId>com.cloudera</groupId>
-    <artifactId>empty-maven-skin</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <groupId>lt.velykis.maven.skins</groupId>
+    <artifactId>blank-maven-skin</artifactId>
+    <version>1.0.0</version>
   </skin>
 
 </project>


### PR DESCRIPTION
The blank-maven-skin is already published and works when the content is
embedded in the jekyll site as well.