### PR TITLE
CDK-885: Fix FS writer error handling.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetException.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetException.java
@@ -46,4 +46,11 @@ public class DatasetException extends RuntimeException {
     super(t);
   }
 
+  protected static String format(String message, Object... args) {
+    String[] argStrings = new String[args.length];
+    for (int i = 0; i < args.length; i += 1) {
+      argStrings[i] = String.valueOf(args[i]);
+    }
+    return String.format(String.valueOf(message), (Object[]) argStrings);
+  }
 }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetOperationException.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetOperationException.java
@@ -23,6 +23,14 @@ package org.kitesdk.data;
  * @since 0.17.0
  */
 public class DatasetOperationException extends DatasetException {
+  public DatasetOperationException(String message, Object... args) {
+    super(format(message, args));
+  }
+
+  public DatasetOperationException(Throwable t, String message, Object... args) {
+    super(format(message, args), t);
+  }
+
   public DatasetOperationException(String message, Throwable t) {
     super(message, t);
   }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemView.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemView.java
@@ -91,7 +91,7 @@ class FileSystemView<E> extends AbstractRefinableView<E> implements InputFormatA
     if (dataset.getDescriptor().isPartitioned()) {
       writer = new PartitionedDatasetWriter<E>(this);
     } else {
-      writer = new FileSystemWriter<E>(fs, root, dataset.getDescriptor());
+      writer = FileSystemWriter.newWriter(fs, root, dataset.getDescriptor());
     }
     writer.initialize();
     return writer;

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemWriter.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemWriter.java
@@ -21,7 +21,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import java.io.Closeable;
-import java.io.Flushable;
 import java.io.IOException;
 import java.util.Set;
 import java.util.UUID;
@@ -32,10 +31,13 @@ import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.DatasetIOException;
+import org.kitesdk.data.DatasetOperationException;
 import org.kitesdk.data.DatasetRecordException;
 import org.kitesdk.data.DatasetWriterException;
+import org.kitesdk.data.Flushable;
 import org.kitesdk.data.Format;
 import org.kitesdk.data.Formats;
+import org.kitesdk.data.Syncable;
 import org.kitesdk.data.ValidationException;
 import org.kitesdk.data.spi.AbstractDatasetWriter;
 import org.kitesdk.data.spi.DescriptorUtil;
@@ -59,26 +61,30 @@ class FileSystemWriter<E> extends AbstractDatasetWriter<E> {
     ));
   }
 
-  static interface FileAppender<E> extends Flushable, Closeable {
+  static interface FileAppender<E> extends java.io.Flushable, Closeable {
     public void open() throws IOException;
     public void append(E entity) throws IOException;
     public void sync() throws IOException;
     public void cleanup() throws IOException;
   }
 
-  protected final FileSystem fs;
   private final Path directory;
   private final DatasetDescriptor descriptor;
-  private FileAppender<E> appender;
   private Path tempPath;
   private Path finalPath;
-  private ReaderWriterState state;
   private int count = 0;
+
+  protected final FileSystem fs;
+  protected FileAppender<E> appender;
+  protected boolean flushed = false;
+
+  @VisibleForTesting
+  ReaderWriterState state;
 
   @VisibleForTesting
   final Configuration conf;
 
-  public FileSystemWriter(FileSystem fs, Path path, DatasetDescriptor descriptor) {
+  private FileSystemWriter(FileSystem fs, Path path, DatasetDescriptor descriptor) {
     Preconditions.checkNotNull(fs, "File system is not defined");
     Preconditions.checkNotNull(path, "Destination directory is not defined");
     Preconditions.checkNotNull(descriptor, "Descriptor is not defined");
@@ -105,18 +111,32 @@ class FileSystemWriter<E> extends AbstractDatasetWriter<E> {
     // ensure the directory exists
     try {
       fs.mkdirs(directory);
+    } catch (RuntimeException e) {
+      this.state = ReaderWriterState.ERROR;
+      throw new DatasetOperationException(e,
+          "Failed to create path %s", directory);
     } catch (IOException ex) {
       this.state = ReaderWriterState.ERROR;
       throw new DatasetIOException("Failed to create path " + directory, ex);
     }
 
     // initialize paths
-    this.finalPath = new Path(directory, uniqueFilename(descriptor.getFormat()));
-    this.tempPath = tempFilename(finalPath);
-    this.appender = newAppender(tempPath);
+    try {
+      this.finalPath = new Path(directory, uniqueFilename(descriptor.getFormat()));
+      this.tempPath = tempFilename(finalPath);
+    } catch (RuntimeException e) {
+      this.state = ReaderWriterState.ERROR;
+      throw new DatasetOperationException(e,
+          "Failed to initialize file paths under %s", directory);
+    }
 
     try {
+      this.appender = newAppender(tempPath);
       appender.open();
+    } catch (RuntimeException e) {
+      this.state = ReaderWriterState.ERROR;
+      throw new DatasetOperationException(e,
+          "Failed to open appender %s", appender);
     } catch (IOException e) {
       this.state = ReaderWriterState.ERROR;
       throw new DatasetIOException("Failed to open appender " + appender, e);
@@ -140,7 +160,8 @@ class FileSystemWriter<E> extends AbstractDatasetWriter<E> {
     } catch (RuntimeException e) {
       Throwables.propagateIfInstanceOf(e, DatasetRecordException.class);
       this.state = ReaderWriterState.ERROR;
-      throw e;
+      throw new DatasetOperationException(e,
+          "Failed to append %s to %s", entity, appender);
     } catch (IOException e) {
       this.state = ReaderWriterState.ERROR;
       throw new DatasetIOException(
@@ -148,64 +169,74 @@ class FileSystemWriter<E> extends AbstractDatasetWriter<E> {
     }
   }
 
+  /**
+   * @deprecated will be removed in 1.0.0; use Flushable#flush instead
+   */
   @Override
+  @Deprecated
   public void flush() {
-    Preconditions.checkState(state.equals(ReaderWriterState.OPEN),
-        "Attempt to flush a writer in state:%s", state);
-    try {
-      appender.flush();
-    } catch (IOException e) {
-      this.state = ReaderWriterState.ERROR;
-      throw new DatasetWriterException("Failed to flush appender " + appender);
-    }
   }
 
+  /**
+   * @deprecated will be removed in 1.0.0; use Syncable#sync instead
+   */
   @Override
+  @Deprecated
   public void sync() {
-    Preconditions.checkState(state.equals(ReaderWriterState.OPEN),
-        "Attempt to sync a writer in state:%s", state);
-    try {
-      appender.sync();
-    } catch (IOException e) {
-      this.state = ReaderWriterState.ERROR;
-      throw new DatasetIOException("Failed to sync appender " + appender, e);
-    }
   }
 
   @Override
   public final void close() {
-    if (state.equals(ReaderWriterState.OPEN)) {
-      try {
-        appender.close();
-      } catch (IOException e) {
-        this.state = ReaderWriterState.ERROR;
-        throw new DatasetIOException("Failed to close appender " + appender, e);
+    try {
+      if (ReaderWriterState.NEW.equals(state) ||
+          ReaderWriterState.CLOSED.equals(state)) {
+        return;
       }
 
-      if (count > 0) {
+      // Only try to close the appender if not in an error state. Any calls to
+      // flush and sync must produce recoverable data without a call to close.
+      if (!ReaderWriterState.ERROR.equals(state)) {
+        try {
+          appender.close();
+        } catch (RuntimeException e) {
+          throw new DatasetOperationException(e,
+              "Failed to close appender %s", appender);
+        } catch (IOException e) {
+          throw new DatasetIOException("Failed to close appender " + appender, e);
+        }
+      }
+
+      // Make the file visible if any data was written and either some data has
+      // been flushed or the writer is not in an error state. Only instances of
+      // IncrementalWriter set flushed to true.
+      if (count > 0 && (flushed || ReaderWriterState.OPEN.equals(state))) {
         // commit the temp file
         try {
           if (!fs.rename(tempPath, finalPath)) {
-            this.state = ReaderWriterState.ERROR;
-            throw new DatasetWriterException(
-                "Failed to move " + tempPath + " to " + finalPath);
+            throw new DatasetOperationException(
+                "Failed to move %s to %s", tempPath, finalPath);
           }
+        } catch (RuntimeException e) {
+          throw new DatasetOperationException(e,
+              "Failed to commit %s", finalPath);
         } catch (IOException e) {
-          this.state = ReaderWriterState.ERROR;
           throw new DatasetIOException("Failed to commit " + finalPath, e);
         }
 
         LOG.debug("Committed {} for appender {} ({} entities)",
             new Object[]{finalPath, appender, count});
+
       } else {
         // discard the temp file
         try {
           if (!fs.delete(tempPath, true)) {
-            this.state = ReaderWriterState.ERROR;
-            throw new DatasetWriterException("Failed to delete " + tempPath);
+            throw new DatasetOperationException(
+                "Failed to delete %s", tempPath);
           }
+        } catch (RuntimeException e) {
+          throw new DatasetOperationException(e,
+              "Failed to remove temporary file %s", tempPath);
         } catch (IOException e) {
-          this.state = ReaderWriterState.ERROR;
           throw new DatasetIOException(
               "Failed to remove temporary file " + tempPath, e);
         }
@@ -219,9 +250,7 @@ class FileSystemWriter<E> extends AbstractDatasetWriter<E> {
         throw new DatasetIOException("Failed to clean up " + appender, e);
       }
 
-      this.state = ReaderWriterState.CLOSED;
-
-    } else if (state.equals(ReaderWriterState.ERROR)) {
+    } finally {
       this.state = ReaderWriterState.CLOSED;
     }
   }
@@ -263,6 +292,70 @@ class FileSystemWriter<E> extends AbstractDatasetWriter<E> {
     } else {
       this.state = ReaderWriterState.ERROR;
       throw new DatasetWriterException("Unknown format " + descriptor);
+    }
+  }
+
+  static <E> FileSystemWriter<E> newWriter(FileSystem fs, Path path,
+                                           DatasetDescriptor descriptor) {
+    Format format = descriptor.getFormat();
+    if (Formats.PARQUET.equals(format)) {
+      // by default, Parquet is not durable
+      if (DescriptorUtil.isDisabled(
+          FileSystemProperties.NON_DURABLE_PARQUET_PROP, descriptor)) {
+        return new IncrementalWriter<E>(fs, path, descriptor);
+      } else {
+        return new FileSystemWriter<E>(fs, path, descriptor);
+      }
+    } else if (Formats.AVRO.equals(format) || Formats.CSV.equals(format)) {
+      return new IncrementalWriter<E>(fs, path, descriptor);
+    } else {
+      return new FileSystemWriter<E>(fs, path, descriptor);
+    }
+  }
+
+  @VisibleForTesting
+  @edu.umd.cs.findbugs.annotations.SuppressWarnings(
+      value="RI_REDUNDANT_INTERFACES",
+      justification="Interfaces will be removed from DatasetWriter in 1.0.0")
+  static class IncrementalWriter<E> extends FileSystemWriter<E>
+      implements Flushable, Syncable {
+    private IncrementalWriter(FileSystem fs, Path path,
+                              DatasetDescriptor descriptor) {
+      super(fs, path, descriptor);
+    }
+
+    @Override
+    public void flush() {
+      Preconditions.checkState(isOpen(),
+          "Attempt to flush a writer in state:%s", state);
+      try {
+        appender.flush();
+        this.flushed = true;
+      } catch (RuntimeException e) {
+        this.state = ReaderWriterState.ERROR;
+        throw new DatasetOperationException(e,
+            "Failed to flush appender %s", appender);
+      } catch (IOException e) {
+        this.state = ReaderWriterState.ERROR;
+        throw new DatasetIOException("Failed to flush appender " + appender, e);
+      }
+    }
+
+    @Override
+    public void sync() {
+      Preconditions.checkState(isOpen(),
+          "Attempt to sync a writer in state:%s", state);
+      try {
+        appender.sync();
+        this.flushed = true;
+      } catch (RuntimeException e) {
+        this.state = ReaderWriterState.ERROR;
+        throw new DatasetOperationException(e,
+            "Failed to sync appender %s", appender);
+      } catch (IOException e) {
+        this.state = ReaderWriterState.ERROR;
+        throw new DatasetIOException("Failed to sync appender " + appender, e);
+      }
     }
   }
 

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestAvroWriter.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestAvroWriter.java
@@ -16,17 +16,79 @@
 
 package org.kitesdk.data.spi.filesystem;
 
+import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericData.Record;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+import org.junit.Assert;
+import org.junit.Test;
 import org.kitesdk.data.DatasetDescriptor;
+import org.kitesdk.data.DatasetReader;
 import org.kitesdk.data.DatasetWriter;
+import org.kitesdk.data.Flushable;
+import org.kitesdk.data.Syncable;
+import org.kitesdk.data.spi.ReaderWriterState;
 
-public class TestAvroWriter extends TestFileSystemWriters<Object> {
+public class TestAvroWriter extends TestFileSystemWriters {
   @Override
-  public DatasetWriter<Object> newWriter(Path directory) {
-    return new FileSystemWriter<Object>(fs, directory,
+  public FileSystemWriter<Record> newWriter(Path directory, Schema schema) {
+    return FileSystemWriter.newWriter(fs, directory,
         new DatasetDescriptor.Builder()
-            .schemaLiteral("\"string\"")
+            .schema(schema)
             .format("avro")
             .build());
+  }
+
+  @Override
+  public DatasetReader<Record> newReader(Path path, Schema schema) {
+    return new FileSystemDatasetReader<Record>(fs, path, schema, Record.class);
+  }
+
+  @Test
+  public void testIsFlushable() {
+    Assert.assertTrue(fsWriter instanceof FileSystemWriter.IncrementalWriter);
+  }
+
+  @Test
+  public void testIsSyncable() {
+    Assert.assertTrue(fsWriter instanceof FileSystemWriter.IncrementalWriter);
+  }
+
+  @Test
+  public void testCommitFlushedRecords() throws IOException {
+    init(fsWriter);
+
+    List<Record> written = Lists.newArrayList();
+    long i;
+    for (i = 0; i < 10000; i += 1) {
+      Record record = record(i, "test-" + i);
+      fsWriter.write(record);
+      written.add(record);
+    }
+
+    ((FileSystemWriter.IncrementalWriter) fsWriter).flush();
+
+    for (i = 10000; i < 11000; i += 1) {
+      fsWriter.write(record(i, "test-" + i));
+    }
+
+    // put the writer into an error state, simulating either:
+    // 1. A failed record with an IOException or unknown RuntimeException
+    // 2. A failed flush or sync for IncrementableWriters
+    fsWriter.state = ReaderWriterState.ERROR;
+
+    fsWriter.close();
+
+    FileStatus[] stats = fs.listStatus(testDirectory, PathFilters.notHidden());
+    Assert.assertEquals("Should contain a visible data file", 1, stats.length);
+
+    DatasetReader<Record> reader = newReader(stats[0].getPath(), TEST_SCHEMA);
+    Assert.assertEquals("Should match written records",
+        written, Lists.newArrayList((Iterator) init(reader)));
   }
 }

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemWriters.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemWriters.java
@@ -16,34 +16,45 @@
 
 package org.kitesdk.data.spi.filesystem;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
 import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData.Record;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.kitesdk.data.DatasetWriter;
-import org.kitesdk.data.Formats;
-import org.kitesdk.data.LocalFileSystem;
+import org.kitesdk.data.DatasetReader;
+import org.kitesdk.data.MiniDFSTest;
 import org.kitesdk.data.spi.InitializeAccessor;
+import org.kitesdk.data.spi.ReaderWriterState;
 
-public abstract class TestFileSystemWriters<E> {
+public abstract class TestFileSystemWriters extends MiniDFSTest {
 
-  public abstract DatasetWriter<E> newWriter(Path directory);
+  public static final Schema TEST_SCHEMA = SchemaBuilder.record("Message").fields()
+      .requiredLong("id")
+      .requiredString("message")
+      .endRecord();
+
+  public abstract FileSystemWriter<Record> newWriter(Path directory, Schema schema);
+  public abstract DatasetReader<Record> newReader(Path path, Schema schema);
 
   protected FileSystem fs = null;
   protected Path testDirectory = null;
-  protected DatasetWriter<E> fsWriter = null;
+  protected FileSystemWriter<Record> fsWriter = null;
 
   @Before
   public void setup() throws IOException {
-    this.fs = LocalFileSystem.getInstance();
+    this.fs = getDFS();
     this.testDirectory = new Path(Files.createTempDir().getAbsolutePath());
-    this.fsWriter = newWriter(testDirectory);
+    this.fsWriter = newWriter(testDirectory, TEST_SCHEMA);
   }
 
   @After
@@ -52,35 +63,74 @@ public abstract class TestFileSystemWriters<E> {
   }
 
   @Test
-  public void testDiscardEmptyFiles() throws IOException {
+  public void testBasicWrite() throws IOException {
     init(fsWriter);
+
+    FileStatus[] stats = fs.listStatus(testDirectory, PathFilters.notHidden());
+    Assert.assertEquals("Should contain no visible files", 0, stats.length);
+    stats = fs.listStatus(testDirectory);
+    Assert.assertEquals("Should contain a hidden file", 1, stats.length);
+
+    List<Record> written = Lists.newArrayList();
+    for (long i = 0; i < 10000; i += 1) {
+      Record record = record(i, "test-" + i);
+      fsWriter.write(record);
+      written.add(record);
+    }
+
+    stats = fs.listStatus(testDirectory, PathFilters.notHidden());
+    Assert.assertEquals("Should contain no visible files", 0, stats.length);
+    stats = fs.listStatus(testDirectory);
+    Assert.assertEquals("Should contain a hidden file", 1, stats.length);
+
     fsWriter.close();
-    Assert.assertEquals("Should not contain any files", 0,
-        ImmutableList.copyOf(fs.listStatus(testDirectory)).size());
+
+    stats = fs.listStatus(testDirectory, PathFilters.notHidden());
+    Assert.assertEquals("Should contain a visible data file", 1, stats.length);
+
+    DatasetReader<Record> reader = newReader(stats[0].getPath(), TEST_SCHEMA);
+    Assert.assertEquals("Should match written records",
+        written, Lists.newArrayList((Iterator) init(reader)));
   }
 
   @Test
-  public void testWrite() throws IOException {
-    AvroAppender<String> writer = new AvroAppender<String>(
-        fs, new Path(testDirectory, "write-1.avro"),
-        Schema.create(Schema.Type.STRING), Formats.AVRO.getDefaultCompressionType());
+  public void testDiscardEmptyFiles() throws IOException {
+    init(fsWriter);
+    fsWriter.close();
 
-    writer.open();
-
-    for (int i = 0; i < 100; i++) {
-      writer.append("entry " + i);
-
-      if (i % 10 == 0) {
-        writer.flush();
-      }
-    }
-
-    writer.close();
+    FileStatus[] stats = fs.listStatus(testDirectory, PathFilters.notHidden());
+    Assert.assertEquals("Should not contain any files", 0, stats.length);
   }
 
-  public void init(DatasetWriter<?> writer) {
-    if (writer instanceof InitializeAccessor) {
-      ((InitializeAccessor) writer).initialize();
+  @Test
+  public void testDiscardErrorFiles() throws IOException {
+    init(fsWriter);
+    for (long i = 0; i < 10000; i += 1) {
+      fsWriter.write(record(i, "test-" + i));
     }
+
+    // put the writer into an error state, simulating either:
+    // 1. A failed record with an IOException or unknown RuntimeException
+    // 2. A failed flush or sync for IncrementableWriters
+    fsWriter.state = ReaderWriterState.ERROR;
+
+    fsWriter.close();
+
+    FileStatus[] stats = fs.listStatus(testDirectory, PathFilters.notHidden());
+    Assert.assertEquals("Should not contain any files", 0, stats.length);
+  }
+
+  protected static Record record(long id, String message) {
+    Record record = new Record(TEST_SCHEMA);
+    record.put("id", id);
+    record.put("message", message);
+    return record;
+  }
+
+  protected static <C> C init(C obj) {
+    if (obj instanceof InitializeAccessor) {
+      ((InitializeAccessor) obj).initialize();
+    }
+    return obj;
   }
 }

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestParquetWriter.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestParquetWriter.java
@@ -17,31 +17,52 @@
 package org.kitesdk.data.spi.filesystem;
 
 import java.io.IOException;
+import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericData.Record;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kitesdk.data.DatasetDescriptor;
+import org.kitesdk.data.DatasetReader;
 import org.kitesdk.data.DatasetWriter;
+import org.kitesdk.data.Flushable;
 import org.kitesdk.data.LocalFileSystem;
+import org.kitesdk.data.Syncable;
 
-public class TestParquetWriter extends TestFileSystemWriters<Object> {
+public class TestParquetWriter extends TestFileSystemWriters {
   @Override
-  public DatasetWriter<Object> newWriter(Path directory) {
-    return new FileSystemWriter<Object>(fs, directory,
+  public FileSystemWriter<Record> newWriter(Path directory, Schema schema) {
+    return FileSystemWriter.newWriter(fs, directory,
         new DatasetDescriptor.Builder()
-            .schema(SchemaBuilder.record("test").fields()
-                .requiredString("s")
-                .endRecord())
+            .schema(schema)
             .format("parquet")
             .build());
+  }
+
+  @Override
+  public DatasetReader<Record> newReader(Path path, Schema schema) {
+    return new ParquetFileSystemDatasetReader<Record>(
+        fs, path, schema, Record.class);
+  }
+
+  @Test
+  public void testIsFlushable() {
+    Assert.assertFalse(fsWriter instanceof FileSystemWriter.IncrementalWriter);
+  }
+
+  @Test
+  public void testIsSyncable() {
+    Assert.assertFalse(fsWriter instanceof FileSystemWriter.IncrementalWriter);
   }
 
   @Test
   public void testParquetConfiguration() throws IOException {
     FileSystem fs = LocalFileSystem.getInstance();
-    FileSystemWriter<Object> writer = new FileSystemWriter<Object>(
+    FileSystemWriter<Object> writer = FileSystemWriter.newWriter(
         fs, new Path("/tmp"),
         new DatasetDescriptor.Builder()
             .property("parquet.block.size", "34343434")
@@ -56,15 +77,14 @@ public class TestParquetWriter extends TestFileSystemWriters<Object> {
 
   @Test
   public void testDefaultToParquetAppender() throws IOException {
-    FileSystemWriter<Object> writer = (FileSystemWriter<Object>) fsWriter;
     Assert.assertEquals("Should default to non-durable parquet appender",
-        ParquetAppender.class, writer.newAppender(testDirectory).getClass());
+        ParquetAppender.class, fsWriter.newAppender(testDirectory).getClass());
   }
 
   @Test
   public void testConfigureDurableParquetAppender() throws IOException {
     FileSystem fs = LocalFileSystem.getInstance();
-    FileSystemWriter<Object> writer = new FileSystemWriter<Object>(
+    FileSystemWriter<Object> writer = FileSystemWriter.newWriter(
         fs, new Path("/tmp"),
         new DatasetDescriptor.Builder()
             .property(FileSystemProperties.NON_DURABLE_PARQUET_PROP, "false")
@@ -80,7 +100,7 @@ public class TestParquetWriter extends TestFileSystemWriters<Object> {
   @Test
   public void testConfigureNonDurableParquetAppender() throws IOException {
     FileSystem fs = LocalFileSystem.getInstance();
-    FileSystemWriter<Object> writer = new FileSystemWriter<Object>(
+    FileSystemWriter<Object> writer = FileSystemWriter.newWriter(
         fs, new Path("/tmp"),
         new DatasetDescriptor.Builder()
             .property(FileSystemProperties.NON_DURABLE_PARQUET_PROP, "true")


### PR DESCRIPTION
This updates the FileSystemWriter's error handling. First,
RuntimeException is now caught throughout the class to ensure that
unknown exceptions in appenders (or FS calls) cannot put the writer in
an unknown state. Second, this updates the close method so that it
handles more error cases correctly:

* After a call to close, the writer state is always CLOSED
* Close does nothing when writer is NEW or CLOSED
* Close is called (on Appender) only if the writer is not in ERROR
* A data file is released if:
  1. Data has been written to the file
  2. Data has been committed with a flush() or sync()
  3. The writer is not in an ERROR state
* If a data file is not to be released, it is discarded
* Appender cleanup is called for OPEN or ERROR
* Any failure in close will prevent the next close task
* No close tasks will be retried b/c state is CLOSED

This also updates the TestFileSystemWriters tests and adds tests for
Parquet, which were previously missing.