### PR TITLE
CDK-766: Add CSV header CLI option.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVProperties.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVProperties.java
@@ -16,6 +16,7 @@
 
 package org.kitesdk.data.spi.filesystem;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.kitesdk.data.DatasetDescriptor;
@@ -31,6 +32,7 @@ public class CSVProperties {
   public static final String DELIMITER_PROPERTY = "kite.csv.delimiter";
   public static final String QUOTE_CHAR_PROPERTY = "kite.csv.quote-char";
   public static final String ESCAPE_CHAR_PROPERTY = "kite.csv.escape-char";
+  public static final String HEADER_PROPERTY = "kite.csv.header";
   public static final String HAS_HEADER_PROPERTY = "kite.csv.has-header";
   public static final String LINES_TO_SKIP_PROPERTY = "kite.csv.lines-to-skip";
 
@@ -53,15 +55,18 @@ public class CSVProperties {
   public final String delimiter;
   public final String quote;
   public final String escape;
+  public final String header;
   public final boolean useHeader;
   public final int linesToSkip;
 
   private CSVProperties(String charset, String delimiter, String quote,
-                       String escape, boolean useHeader, int linesToSkip) {
+                        String escape, String header, boolean useHeader,
+                        int linesToSkip) {
     this.charset = charset;
     this.delimiter = delimiter;
     this.quote = quote;
     this.escape = escape;
+    this.header = header;
     this.useHeader = useHeader;
     this.linesToSkip = linesToSkip;
   }
@@ -83,6 +88,7 @@ public class CSVProperties {
         descriptor.getProperty(ESCAPE_CHAR_PROPERTY),
         descriptor.getProperty(OLD_ESCAPE_CHAR_PROPERTY),
         DEFAULT_ESCAPE);
+    this.header = descriptor.getProperty(HEADER_PROPERTY);
     this.useHeader = Boolean.parseBoolean(coalesce(
         descriptor.getProperty(HAS_HEADER_PROPERTY),
         DEFAULT_HAS_HEADER));
@@ -116,14 +122,19 @@ public class CSVProperties {
   }
 
   public DatasetDescriptor addToDescriptor(DatasetDescriptor descriptor) {
-    return new DatasetDescriptor.Builder(descriptor)
+    DatasetDescriptor.Builder builder = new DatasetDescriptor.Builder(descriptor)
         .property(CHARSET_PROPERTY, charset)
         .property(DELIMITER_PROPERTY, delimiter)
         .property(ESCAPE_CHAR_PROPERTY, escape)
         .property(QUOTE_CHAR_PROPERTY, quote)
         .property(HAS_HEADER_PROPERTY, Boolean.toString(useHeader))
-        .property(LINES_TO_SKIP_PROPERTY, Integer.toString(linesToSkip))
-        .build();
+        .property(LINES_TO_SKIP_PROPERTY, Integer.toString(linesToSkip));
+
+    if (header != null) {
+      builder.property(HEADER_PROPERTY, header);
+    }
+
+    return builder.build();
   }
 
   public static CSVProperties fromDescriptor(DatasetDescriptor descriptor) {
@@ -137,6 +148,7 @@ public class CSVProperties {
     private String escape = DEFAULT_ESCAPE;
     private boolean useHeader = Boolean.valueOf(DEFAULT_HAS_HEADER);
     private int linesToSkip = DEFAULT_LINES_TO_SKIP;
+    private String header = null;
 
     public Builder charset(String charset) {
       this.charset = charset;
@@ -158,6 +170,11 @@ public class CSVProperties {
       return this;
     }
 
+    public Builder header(@Nullable String header) {
+      this.header = header;
+      return this;
+    }
+
     public Builder hasHeader() {
       this.useHeader = true;
       return this;
@@ -176,7 +193,7 @@ public class CSVProperties {
     public CSVProperties build() {
       return new CSVProperties(
           charset, delimiter, quote, escape,
-          useHeader, linesToSkip);
+          header, useHeader, linesToSkip);
     }
   }
 }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVUtil.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVUtil.java
@@ -113,6 +113,11 @@ public class CSVUtil {
       line = reader.readNext();
       Preconditions.checkNotNull(line, "No content to infer schema");
 
+    } else if (props.header != null) {
+      header = newParser(props).parseLine(props.header);
+      line = reader.readNext();
+      Preconditions.checkNotNull(line, "No content to infer schema");
+
     } else {
       // use the first line to create a header
       line = reader.readNext();

--- a/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/CSVImportCommand.java
+++ b/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/CSVImportCommand.java
@@ -76,6 +76,10 @@ public class CSVImportCommand extends BaseDatasetCommand {
   @Parameter(names="--charset", description="Character set name", hidden = true)
   String charsetName = Charset.defaultCharset().displayName();
 
+  @Parameter(names="--header",
+      description="Line to use as a header. Must match the CSV settings.")
+  String header;
+
   @Parameter(names="--skip-schema-check",
       description="Override schema checks (safety valve)", hidden = true)
   boolean skipSchemaChecks = false;
@@ -113,10 +117,16 @@ public class CSVImportCommand extends BaseDatasetCommand {
     Preconditions.checkArgument(sourceFS.exists(source),
         "CSV path does not exist: " + source);
 
+    if (header != null) {
+      // if a header is given on the command line, do assume one is in the file
+      noHeader = true;
+    }
+
     CSVProperties props = new CSVProperties.Builder()
         .delimiter(delimiter)
         .escape(escape)
         .quote(quote)
+        .header(header)
         .hasHeader(!noHeader)
         .linesToSkip(linesToSkip)
         .charset(charsetName)

--- a/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/CSVSchemaCommand.java
+++ b/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/CSVSchemaCommand.java
@@ -82,6 +82,10 @@ public class CSVSchemaCommand extends BaseCommand {
   @Parameter(names="--charset", description="Character set name", hidden = true)
   String charsetName = Charset.defaultCharset().displayName();
 
+  @Parameter(names="--header",
+      description="Line to use as a header. Must match the CSV settings.")
+  String header;
+
   @Parameter(names="--require",
       description="Do not allow null values for the given field")
   List<String> requiredFields;
@@ -93,10 +97,16 @@ public class CSVSchemaCommand extends BaseCommand {
     Preconditions.checkArgument(samplePaths.size() == 1,
         "Only one CSV sample can be given");
 
+    if (header != null) {
+      // if a header is given on the command line, do assume one is in the file
+      noHeader = true;
+    }
+
     CSVProperties props = new CSVProperties.Builder()
         .delimiter(delimiter)
         .escape(escape)
         .quote(quote)
+        .header(header)
         .hasHeader(!noHeader)
         .linesToSkip(linesToSkip)
         .charset(charsetName)


### PR DESCRIPTION
This adds --header to csv-schema and csv-import. The option is a single
string that is passed to the CSV code in kite-data-core in
CSVProperties. The header can be stored as a new descriptor property,
kite.csv.header.

The CSVProperties header is always low-precedence. If useHeader is set
in properties, a header line is read from the file or data sample (for
inferSchema) and used instead. For CSVRecordParser, the properites
header is only used if the header passed is null.

The header line is always parsed using the other properties. There is no
special header CSV delimiter or other options.