### PR TITLE
CDK-674. DatasetDescriptor.checkPartitionStrategy should throw Validatio...

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetDescriptor.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetDescriptor.java
@@ -905,7 +905,7 @@ public class DatasetDescriptor {
      * @since 0.9.0
      */
     public DatasetDescriptor build() {
-      Preconditions.checkState(schema != null,
+      ValidationException.check(schema != null,
           "Descriptor schema is required and cannot be null");
 
       // if no partition strategy is defined, check for one in the schema
@@ -974,7 +974,6 @@ public class DatasetDescriptor {
       if (strategy == null) {
         return;
       }
-      // TODO: the exceptions thrown by this should all be ValidationException
       for (FieldPartitioner fp : strategy.getFieldPartitioners()) {
         if (fp instanceof ProvidedFieldPartitioner) {
           // provided partitioners are not based on the entity fields
@@ -982,7 +981,7 @@ public class DatasetDescriptor {
         }
 
         // check the entity is a record if there is a non-provided partitioner
-        Preconditions.checkState(schema.getType() == Schema.Type.RECORD,
+        ValidationException.check(schema.getType() == Schema.Type.RECORD,
             "Cannot partition non-records: " + schema);
 
         // the source name should be a field in the schema, but not necessarily
@@ -991,10 +990,10 @@ public class DatasetDescriptor {
         try {
           fieldSchema = SchemaUtil.fieldSchema(schema, fp.getSourceName());
         } catch (IllegalArgumentException e) {
-          throw new IllegalStateException(
+          throw new ValidationException(
               "Cannot partition on " + fp.getSourceName(), e);
         }
-        Preconditions.checkState(
+        ValidationException.check(
             SchemaUtil.isConsistentWithExpectedType(
                 fieldSchema.getType(), fp.getSourceType()),
             "Field type %s does not match partitioner %s",
@@ -1010,8 +1009,8 @@ public class DatasetDescriptor {
       return;
     }
 
-    Preconditions.checkState(format.getSupportedCompressionTypes()
-        .contains(compressionType),
+    ValidationException.check(format.getSupportedCompressionTypes()
+            .contains(compressionType),
         "Format %s doesn't support compression format %s", format.getName(),
         compressionType.getName());
   }
@@ -1022,7 +1021,7 @@ public class DatasetDescriptor {
     if (mappings == null) {
       return;
     }
-    Preconditions.checkState(schema.getType() == Schema.Type.RECORD,
+    ValidationException.check(schema.getType() == Schema.Type.RECORD,
         "Cannot map non-records: " + schema);
     Set<String> keyMappedFields = Sets.newHashSet();
     for (FieldMapping fm : mappings.getFieldMappings()) {

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetDescriptor.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetDescriptor.java
@@ -982,7 +982,7 @@ public class DatasetDescriptor {
 
         // check the entity is a record if there is a non-provided partitioner
         ValidationException.check(schema.getType() == Schema.Type.RECORD,
-            "Cannot partition non-records: " + schema);
+            "Cannot partition non-records: %s", schema);
 
         // the source name should be a field in the schema, but not necessarily
         // the record.
@@ -1022,7 +1022,7 @@ public class DatasetDescriptor {
       return;
     }
     ValidationException.check(schema.getType() == Schema.Type.RECORD,
-        "Cannot map non-records: " + schema);
+        "Cannot map non-records: %s", schema);
     Set<String> keyMappedFields = Sets.newHashSet();
     for (FieldMapping fm : mappings.getFieldMappings()) {
       Schema.Field field = schema.getField(fm.getFieldName());

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/PartitionStrategy.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/PartitionStrategy.java
@@ -600,13 +600,9 @@ public class PartitionStrategy {
     }
 
     private void add(FieldPartitioner fp) {
-      // in 0.14.0, change to a Precondition
-      //Preconditions.checkState(!names.contains(fp.getName()),
-      //    "Partition name conflicts with an existing field or partition name");
-      if (names.contains(fp.getName())) {
-        LOG.warn(
-            "Partition name conflicts with an existing partition name");
-      }
+      ValidationException.check(!names.contains(fp.getName()),
+          "Partition name %s conflicts with an existing field or partition name",
+          fp.getName());
       fieldPartitioners.add(fp);
       names.add(fp.getName());
     }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/Compatibility.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/Compatibility.java
@@ -97,10 +97,10 @@ public abstract class Compatibility {
   public static void checkDatasetName(String namespace, String name) {
     Preconditions.checkNotNull(namespace, "Namespace cannot be null");
     Preconditions.checkNotNull(name, "Dataset name cannot be null");
-    Preconditions.checkArgument(Compatibility.isCompatibleName(namespace),
+    ValidationException.check(Compatibility.isCompatibleName(namespace),
         "Namespace %s is not alphanumeric (plus '_')",
         namespace);
-    Preconditions.checkArgument(Compatibility.isCompatibleName(name),
+    ValidationException.check(Compatibility.isCompatibleName(name),
         "Dataset name %s is not alphanumeric (plus '_')",
         name);
   }
@@ -113,7 +113,7 @@ public abstract class Compatibility {
   public static void checkSchema(Schema schema) {
     Preconditions.checkNotNull(schema, "Schema cannot be null");
     List<String> incompatible = getIncompatibleNames(schema);
-    Preconditions.checkState(incompatible.isEmpty(),
+    ValidationException.check(incompatible.isEmpty(),
         "Field names are not alphanumeric (plus '_'): %s",
         Joiner.on(", ").join(incompatible));
   }
@@ -152,10 +152,10 @@ public abstract class Compatibility {
           names.add(name);
         }
       }
-      Preconditions.checkState(incompatible.isEmpty(),
+      ValidationException.check(incompatible.isEmpty(),
           "Partition names are not alphanumeric (plus '_'): %s",
           Joiner.on(", ").join(incompatible));
-      Preconditions.checkState(duplicates.isEmpty(),
+      ValidationException.check(duplicates.isEmpty(),
           "Partition names duplicate data fields: %s",
           Joiner.on(", ").join(duplicates));
     }

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/TestDatasetDescriptor.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/TestDatasetDescriptor.java
@@ -338,7 +338,7 @@ public class TestDatasetDescriptor {
   @Test
   public void testPartitionSourceMustBeSchemaField() {
     TestHelpers.assertThrows("Should reject partition source not in schema",
-        IllegalStateException.class, new Runnable() {
+        ValidationException.class, new Runnable() {
           @Override
           public void run() {
             new DatasetDescriptor.Builder()

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/TestDescriptorValidation.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/TestDescriptorValidation.java
@@ -73,7 +73,7 @@ public class TestDescriptorValidation {
       }
     });
     TestHelpers.assertThrows("Should reject missing schema",
-        IllegalStateException.class, new Runnable() {
+        ValidationException.class, new Runnable() {
       @Override
       public void run() {
         new DatasetDescriptor.Builder()
@@ -96,7 +96,7 @@ public class TestDescriptorValidation {
   @Test
   public void testRejectsPartitioningWithNonRecordSchema() {
     TestHelpers.assertThrows("Should reject partitioning without a record",
-        IllegalStateException.class, new Runnable() {
+        ValidationException.class, new Runnable() {
       @Override
       public void run() {
         new DatasetDescriptor.Builder()
@@ -112,7 +112,7 @@ public class TestDescriptorValidation {
   @Test
   public void testRejectsPartitioningOnMissingField() {
     TestHelpers.assertThrows("Should reject partitioning on a missing field",
-        IllegalStateException.class, new Runnable() {
+        ValidationException.class, new Runnable() {
       @Override
       public void run() {
         new DatasetDescriptor.Builder()
@@ -132,7 +132,7 @@ public class TestDescriptorValidation {
   public void testRejectsSchemaPartitionerTypeMismatch() {
     // obvious type mismatches
     TestHelpers.assertThrows("Should reject int for long partitioner",
-        IllegalStateException.class, new Runnable() {
+        ValidationException.class, new Runnable() {
       @Override
       public void run() {
         new DatasetDescriptor.Builder()
@@ -146,7 +146,7 @@ public class TestDescriptorValidation {
       }
     });
     TestHelpers.assertThrows("Should reject string for int partitioner",
-        IllegalStateException.class, new Runnable() {
+        ValidationException.class, new Runnable() {
       @Override
       public void run() {
         new DatasetDescriptor.Builder()
@@ -160,7 +160,7 @@ public class TestDescriptorValidation {
       }
     });
     TestHelpers.assertThrows("Should reject int for string partitioner",
-        IllegalStateException.class, new Runnable() {
+        ValidationException.class, new Runnable() {
       @Override
       public void run() {
         new DatasetDescriptor.Builder()
@@ -175,7 +175,7 @@ public class TestDescriptorValidation {
     });
     // Null is not allowed when partitioning
     TestHelpers.assertThrows("Should reject optional int for int partitioner",
-        IllegalStateException.class, new Runnable() {
+        ValidationException.class, new Runnable() {
       @Override
       public void run() {
         new DatasetDescriptor.Builder()
@@ -190,7 +190,7 @@ public class TestDescriptorValidation {
     });
     // Cannot assign to a Long from an Integer
     TestHelpers.assertThrows("Should reject int for long partitioner",
-        IllegalStateException.class, new Runnable() {
+        ValidationException.class, new Runnable() {
       @Override
       public void run() {
         new DatasetDescriptor.Builder()

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/TestPartitionStrategy.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/TestPartitionStrategy.java
@@ -80,7 +80,7 @@ public class TestPartitionStrategy {
             .year("timestamp").month("timestamp")
             .build());
     TestHelpers.assertThrows("Should reject duplicate partition fields",
-        IllegalStateException.class, new Runnable() {
+        ValidationException.class, new Runnable() {
       @Override
       public void run() {
         new PartitionStrategy.Builder()

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/TestCompatibilityChecks.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/TestCompatibilityChecks.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.PartitionStrategy;
 import org.kitesdk.data.TestHelpers;
+import org.kitesdk.data.ValidationException;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -96,7 +97,7 @@ public class TestCompatibilityChecks {
   public void testIllegalPartitionNames() {
     // no need to check sources because '.' and '-' aren't allowed in schemas
     TestHelpers.assertThrows("Should reject '-' in partition name",
-        IllegalStateException.class, new Runnable() {
+        ValidationException.class, new Runnable() {
       @Override
       public void run() {
         Compatibility.checkDescriptor(
@@ -109,7 +110,7 @@ public class TestCompatibilityChecks {
       }
     });
     TestHelpers.assertThrows("Should reject '.' in partition name",
-        IllegalStateException.class, new Runnable() {
+        ValidationException.class, new Runnable() {
       @Override
       public void run() {
         Compatibility.checkDescriptor(
@@ -127,7 +128,7 @@ public class TestCompatibilityChecks {
   public void testDuplicatePartitionNames() {
     TestHelpers.assertThrows(
         "Should reject partition names that duplicate partition names",
-        IllegalArgumentException.class, new Runnable() {
+        ValidationException.class, new Runnable() {
       @Override
       public void run() {
         Compatibility.checkDescriptor(
@@ -142,7 +143,7 @@ public class TestCompatibilityChecks {
     });
     TestHelpers.assertThrows(
         "Should reject partition names that duplicate source names",
-        IllegalStateException.class, new Runnable() {
+        ValidationException.class, new Runnable() {
       @Override
       public void run() {
         Compatibility.checkDescriptor(

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/TestNestedFieldPartitioning.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/TestNestedFieldPartitioning.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.PartitionStrategy;
 import org.kitesdk.data.TestHelpers;
+import org.kitesdk.data.ValidationException;
 
 public class TestNestedFieldPartitioning {
 
@@ -83,7 +84,7 @@ public class TestNestedFieldPartitioning {
             .build();
 
     TestHelpers.assertThrows("Should complain that p is missing",
-        IllegalStateException.class, new Runnable() {
+        ValidationException.class, new Runnable() {
           @Override
           public void run() {
             new DatasetDescriptor.Builder()
@@ -100,7 +101,7 @@ public class TestNestedFieldPartitioning {
             .build();
 
     TestHelpers.assertThrows("Should complain that position.long is missing",
-        IllegalStateException.class, new Runnable() {
+        ValidationException.class, new Runnable() {
           @Override
           public void run() {
             new DatasetDescriptor.Builder()
@@ -117,7 +118,7 @@ public class TestNestedFieldPartitioning {
             .build();
 
     TestHelpers.assertThrows("Should complain about mismatched expected type",
-        IllegalStateException.class, new Runnable() {
+        ValidationException.class, new Runnable() {
           @Override
           public void run() {
             new DatasetDescriptor.Builder()

--- a/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestHiveExternalMetadataProvider.java
+++ b/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestHiveExternalMetadataProvider.java
@@ -26,6 +26,7 @@ import org.junit.After;
 import org.junit.Test;
 import org.kitesdk.data.PartitionStrategy;
 import org.kitesdk.data.TestHelpers;
+import org.kitesdk.data.ValidationException;
 import org.kitesdk.data.spi.MetadataProvider;
 import org.kitesdk.data.spi.TestMetadataProviders;
 
@@ -76,7 +77,7 @@ public class TestHiveExternalMetadataProvider extends TestMetadataProviders {
             .build())
         .build();
     TestHelpers.assertThrows("Should reject duplicate field and partition name",
-        IllegalStateException.class, new Runnable() {
+        ValidationException.class, new Runnable() {
       @Override
       public void run() {
         provider.create(NAMESPACE, "reject", descriptor);

--- a/kite-tools-parent/kite-tools/src/test/java/org/kitesdk/cli/commands/TestCreatePartitionStrategyCommand.java
+++ b/kite-tools-parent/kite-tools/src/test/java/org/kitesdk/cli/commands/TestCreatePartitionStrategyCommand.java
@@ -92,7 +92,7 @@ public class TestCreatePartitionStrategyCommand {
   public void testUnknownSourceField() {
     command.partitions = Lists.newArrayList("id:copy");
     TestHelpers.assertThrows("Should reject missing field \"id\"",
-        IllegalStateException.class, new Callable() {
+        ValidationException.class, new Callable() {
           @Override
           public Object call() throws Exception {
             command.run();


### PR DESCRIPTION
...nException.

I changed methods in DatasetDescriptor, PartitionStrategy, and Compatibility to throw ValidationException rather than IllegalArgumentException or IllegalStateException when an invalid value is specified.