### PR TITLE
CDK-927: Use requested type as reader schema in MapReduce jobs.

### DIFF
--- a/kite-data/kite-data-crunch/pom.xml
+++ b/kite-data/kite-data-crunch/pom.xml
@@ -31,7 +31,19 @@
   </description>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/test/avro</directory>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+    </resources>
     <plugins>
+      <plugin>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro-maven-plugin</artifactId>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/kite-data/kite-data-crunch/src/test/avro/newuser.avsc
+++ b/kite-data/kite-data-crunch/src/test/avro/newuser.avsc
@@ -1,0 +1,17 @@
+{
+  "namespace": "org.kitesdk.data.user",
+  "type": "record",
+  "name": "NewUserRecord",
+  "aliases": ["org.kitesdk.data.user.OldUserRecord"],
+  "fields": [
+    {
+      "type": "string",
+      "name": "username"
+    },
+    {
+      "type": ["null", "string"],
+      "name": "email",
+      "default": null
+    }
+  ]
+}


### PR DESCRIPTION
If a Dataset is loaded with a specific Avro type provided by the caller, that type is effectively the reader schema and should be honored by MapReduce jobs. This PR simply sets the reader schema appropriately in the input format and includes a test to ensure it is used.