### PR TITLE
CDK-935: Fix log4j test for new Hive URL behavior.

### DIFF
--- a/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/Log4jConfigCommand.java
+++ b/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/Log4jConfigCommand.java
@@ -73,7 +73,7 @@ public class Log4jConfigCommand extends BaseDatasetCommand {
     URL schemaUrl = load(datasetName.get(0), GenericRecord.class).getDataset()
         .getDescriptor().getSchemaUrl();
     if (schemaUrl == null) {
-      console.warn("Warning: The dataset {} doese not have a schema URL. The schema will be sent with each event.", datasetName.get(0));
+      console.warn("Warning: The dataset {} does not have a schema URL. The schema will be sent with each event.", datasetName.get(0));
     }
 
     StringBuilder sb = new StringBuilder();

--- a/kite-tools-parent/kite-tools/src/test/java/org/kitesdk/cli/commands/TestLog4jConfigurationCommand.java
+++ b/kite-tools-parent/kite-tools/src/test/java/org/kitesdk/cli/commands/TestLog4jConfigurationCommand.java
@@ -93,10 +93,10 @@ public class TestLog4jConfigurationCommand {
         "log4j.appender.flume.Hostname = quickstart.cloudera\n" +
         "log4j.appender.flume.Port = 41415\n" +
         "log4j.appender.flume.UnsafeMode = true\n" +
-        "log4j.appender.flume.AvroSchemaUrl = file:.*/.metadata/schemas/1.avsc\n" +
         "\n" +
         "# Log events from the following Java class/package:\n" +
         "log4j.logger.org.kitesdk.test.logging = INFO, flume\n"));
+    verify(console).warn("Warning: The dataset {} does not have a schema URL. The schema will be sent with each event.", "users");
     verifyNoMoreInteractions(console);
   }
 
@@ -132,10 +132,10 @@ public class TestLog4jConfigurationCommand {
         "log4j.appender.flume.Hostname = quickstart.cloudera\n" +
         "log4j.appender.flume.Port = 41415\n" +
         "log4j.appender.flume.UnsafeMode = true\n" +
-        "log4j.appender.flume.AvroSchemaUrl = file:.*/.metadata/schemas/1.avsc\n" +
         "\n" +
         "# Log events from the following Java class/package:\n" +
         "log4j.logger.org.kitesdk.test.logging = INFO, flume\n"));
+    verify(console).warn("Warning: The dataset {} does not have a schema URL. The schema will be sent with each event.", "users");
     verifyNoMoreInteractions(console);
   }
 


### PR DESCRIPTION
Hive no longer uses the schema URL property if the schema is not in
HDFS. This updates the log4j test, removing the schema URL configuration
and adding the expected warning when not using a schema URL.