### PR TITLE
CDK-937: Fix findbugs error.

### DIFF
--- a/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/SchemaCommand.java
+++ b/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/SchemaCommand.java
@@ -52,7 +52,8 @@ public class SchemaCommand extends BaseDatasetCommand {
   }
 
   @Override
-  @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="NP_NULL_ON_SOME_PATH",
+  @edu.umd.cs.findbugs.annotations.SuppressWarnings(
+      value={"NP_GUARANTEED_DEREF", "NP_NULL_ON_SOME_PATH"},
       justification="Null case checked by precondition")
   public int run() throws IOException {
     Preconditions.checkArgument(


### PR DESCRIPTION
The error is that datasets may be null and is always (not conditionally)
dereferenced. This is actually checked by a precondition so the code is
safe.