### PR TITLE
CDK-974: Update Hive DDL when updating a table.

### DIFF
--- a/kite-data/kite-data-hive/src/main/java/org/kitesdk/data/spi/hive/HiveUtils.java
+++ b/kite-data/kite-data-hive/src/main/java/org/kitesdk/data/spi/hive/HiveUtils.java
@@ -349,6 +349,10 @@ class HiveUtils {
 
     // keep the custom properties up-to-date
     addPropertiesForDescriptor(table, descriptor);
+
+    // keep the table DDL up to-to-date with the Schema
+    table.getSd().setCols(
+        HiveSchemaConverter.convertSchema(descriptor.getSchema()));
   }
 
   static FileSystem fsForPath(Configuration conf, Path path) {


### PR DESCRIPTION
Kite sets the table DDL when it creates a table and should update the
DDL if the schema changes.

Contributed by Andrew Stevenson.