### PR TITLE
CDK-451 signal ready views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,9 @@ build
 test-output
 .surefire-*
 .DS_Store
+.fbExcludeFilterFile
 kite-data/kite-data-hcatalog/metastore_db
-kite-data/kite-data-hcatalog/derby.log
+derby.log
 .idea
 *.iml
 nbactions.xml

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/Signalable.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/Signalable.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 Cloudera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kitesdk.data;
+
+/**
+ * Signalable views may signal consumers when their underlying data is ready for
+ * consumption. Not all View implementations provide this capability.
+ */
+public interface Signalable<E> extends View<E> {
+
+  /**
+   * Signal that the view's data is ready for consumption.
+   *
+   * Note that an {@link #isEmpty() empty} view may be signaled as ready.
+   *
+   * @since 1.1.0
+   */
+  public void signalReady();
+
+  /**
+   * Returns {@code true} if the view's data is ready for consumption.
+   *
+   * A view is considered ready if
+   * <ul>
+   * <li>it has been {@link #signalReady() signaled ready}</li>
+   * <li>it is a subset of a ready view (may not be implemented)</li>
+   * <li>
+   *   it is completely covered by a union of ready views, or is a subset of such
+   *   a union (may not be implemented)
+   * </li>
+   * <ul>
+   *
+   * Note that ready views may also be {@link #isEmpty() empty}.
+   *
+   * @since 1.1.0
+   */
+  public boolean isReady();
+
+}

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/Constraints.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/Constraints.java
@@ -448,12 +448,30 @@ public class Constraints {
 
   public Map<String, String> toQueryMap() {
     Map<String, String> query = Maps.newLinkedHashMap();
+    return toQueryMap(query, false);
+  }
+
+  /**
+   * Get a normalized query map for the constraints. A normalized query map will
+   * be equal in value and iteration order for any logically equivalent set of
+   * constraints.
+   */
+  public Map<String, String> toNormalizedQueryMap() {
+    Map<String, String> query = Maps.newTreeMap();
+    return toQueryMap(query, true);
+  }
+
+  private Map<String, String> toQueryMap(Map<String, String> queryMap, boolean normalized) {
     for (Map.Entry<String, Predicate> entry : constraints.entrySet()) {
       String name = entry.getKey();
       Schema fieldSchema = SchemaUtil.fieldSchema(schema, strategy, name);
-      query.put(name, Predicates.toString(entry.getValue(), fieldSchema));
+      if(normalized) {
+        queryMap.put(name, Predicates.toNormalizedString(entry.getValue(), fieldSchema));
+      } else {
+        queryMap.put(name, Predicates.toString(entry.getValue(), fieldSchema));
+      }
     }
-    return query;
+    return queryMap;
   }
 
   public static Constraints fromQueryMap(Schema schema,

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/SignalManager.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/SignalManager.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright 2015 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kitesdk.data.spi.filesystem;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.kitesdk.data.DatasetException;
+import org.kitesdk.data.DatasetIOException;
+import org.kitesdk.data.spi.Constraints;
+import org.kitesdk.data.Signalable;
+
+import com.google.common.base.Joiner;
+
+/**
+ * Manager for creating, and checking {@link Signalable#isReady() ready} signals.
+ * Stored in a filesystem, typically HDFS.
+ */
+public class SignalManager {
+
+  private final Path signalDirectory;
+  private final FileSystem rootFileSystem;
+
+  private static final String UNBOUNDED_CONSTRAINT = "unbounded";
+
+  /**
+   * Creates a new signal manager using the given signal directory.
+   *
+   * @param conf the Hadoop configuration
+   * @param signalDirectory directory in which the manager
+   *                        stores signals.
+   *
+   * @return a signal manager instance.
+   */
+  public SignalManager(FileSystem fileSystem, Path signalDirectory) {
+    this.signalDirectory = signalDirectory;
+    this.rootFileSystem = fileSystem;
+  }
+
+  /**
+   * Create a signal for the specified constraints.
+   *
+   * @param viewConstraints The constraints to create a signal for.
+   *
+   * @throws DatasetException if the signal could not be created.
+   */
+  public void signalReady(Constraints viewConstraints) {
+    try {
+      rootFileSystem.mkdirs(signalDirectory);
+    } catch (IOException e) {
+      throw new DatasetIOException("Unable to create signal manager directory: "
+              + signalDirectory, e);
+    }
+
+    String normalizedConstraints = getNormalizedConstraints(viewConstraints);
+
+    Path signalPath = new Path(signalDirectory, normalizedConstraints);
+    try{
+      // create the output stream to overwrite the current contents, if the directory or file
+      // exists it will be overwritten to get a new timestamp
+      FSDataOutputStream os = rootFileSystem.create(signalPath, true);
+      os.close();
+    } catch (IOException e) {
+      throw new DatasetIOException("Could not access signal path: " + signalPath, e);
+    }
+  }
+
+  /**
+   * Check the last time the specified constraints have been signaled as ready.
+   *
+   * @param viewConstraints The constraints to check for a signal.
+   *
+   * @return the timestamp of the last time the constraints were signaled as ready.
+   *          if the constraints have never been signaled, -1 will be returned.
+   *
+   * @throws DatasetException if the signals could not be accessed.
+   */
+  public long getReadyTimestamp(Constraints viewConstraints) {
+    String normalizedConstraints = getNormalizedConstraints(viewConstraints);
+
+    Path signalPath = new Path(signalDirectory, normalizedConstraints);
+    // check if the signal exists
+    try {
+      try {
+        FileStatus signalStatus = rootFileSystem.getFileStatus(signalPath);
+        return signalStatus.getModificationTime();
+      } catch (final FileNotFoundException ex) {
+        // empty, will be thrown when the signal path doesn't exist
+      }
+      return -1;
+    } catch (IOException e) {
+      throw new DatasetIOException("Could not access signal path: " + signalPath, e);
+    }
+  }
+
+  /**
+   * Get a normalized query string for the {@link Constraints} that identifies a
+   * logical {@code View}.
+   *
+   * The normalized constraints will match to the query portion of a URI that will
+   * be exactly the same as another logically equivalent URI.
+   * (where, for example, the query parameters may be re-ordered)
+   *
+   * If the constraints are {@link Constraints#isUnbounded() unbounded} a special case
+   * of "unbounded" will be returned.
+   *
+   * @return a normalized query string for the specified constraints.
+   *
+   * @since 1.1
+   */
+  public static String getNormalizedConstraints(Constraints constraints) {
+    // the constraints map isn't naturally ordered
+    // we want to ensure that our output is
+
+    if (constraints.isUnbounded()) {
+      // unbounded constrains is a special case, here we just use
+      // "unbounded" as the constraint
+      return UNBOUNDED_CONSTRAINT;
+    }
+
+    Map<String, String> orderedConstraints = constraints.toNormalizedQueryMap();
+
+    List<String> parts = new ArrayList<String>();
+    // build a query portion of the URI
+    for (Map.Entry<String, String> entry : orderedConstraints.entrySet()) {
+      StringBuilder builder = new StringBuilder();
+      String key = entry.getKey();
+      String value = entry.getValue();
+      builder.append(key);
+      builder.append("=");
+      if (value != null) {
+        builder.append(value);
+      }
+      parts.add(builder.toString());
+    }
+
+    return Joiner.on('&').join(parts);
+  }
+
+}

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/predicates/In.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/predicates/In.java
@@ -120,6 +120,17 @@ public class In<T> extends RegisteredPredicate<T> {
         Iterables.transform(set, new ToString<T>(schema)));
   }
 
+  @Override
+  public String toNormalizedString(Schema schema) {
+    // we want the string this returns to be consistent
+    // ensure the set is sorted before joining it.
+    // ToString first allows us to consistently sort even when
+    // the value may not be comparable
+
+    Iterable<String> strings = Iterables.transform(set, new ToString<T>(schema));
+    return Joiner.on(',').join(Sets.newTreeSet(strings));
+  }
+
   private static class ToString<T> implements Function<T, String> {
     private final Schema schema;
 

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/predicates/Predicates.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/predicates/Predicates.java
@@ -70,6 +70,26 @@ public abstract class Predicates {
     }
   }
 
+  public static <T> String toNormalizedString(Predicate<T> predicate, Schema schema) {
+    if (predicate instanceof Exists) {
+      return "";
+    } else if (predicate instanceof Range) {
+      return ((Range) predicate).toString(schema);
+    } else if (predicate instanceof In) {
+      String values = ((In) predicate).toNormalizedString(schema);
+      if (values.length() != 0) {
+        return values;
+      }
+      // "" is a special case that conflicts with exists, use the named version
+      return "in()";
+    } else if (predicate instanceof RegisteredPredicate) {
+      return RegisteredPredicate.toNormalizedString(
+          (RegisteredPredicate) predicate, schema);
+    } else {
+      throw new DatasetException("Unknown predicate: " + predicate);
+    }
+  }
+
   public static <T> Predicate<T> fromString(String pString, Schema schema) {
     if (pString.length() == 0) {
       return exists();

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/predicates/RegisteredPredicate.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/predicates/RegisteredPredicate.java
@@ -48,6 +48,13 @@ public abstract class RegisteredPredicate<T> implements Predicate<T> {
     return predicate.getName() + "(" + predicate.toString(schema) + ")";
   }
 
+  public static String toNormalizedString(RegisteredPredicate<?> predicate, Schema schema) {
+    // ensure fromString will be successful
+    Preconditions.checkArgument(REGISTRY.containsKey(predicate.getName()),
+        "Predicate is not registered: " + predicate.getName());
+    return predicate.getName() + "(" + predicate.toNormalizedString(schema) + ")";
+  }
+
   public static <T> RegisteredPredicate<T> fromString(String predicate, Schema schema) {
     Matcher match = FUNCTION.matcher(predicate);
     if (match.matches()) {
@@ -59,4 +66,13 @@ public abstract class RegisteredPredicate<T> implements Predicate<T> {
 
   public abstract String getName();
   public abstract String toString(Schema schema);
+
+  /**
+   * Return a normalized form of the predicate such that any logically equivalent
+   * predicate returns the same string. Some predicates may need to override
+   * this method to ensure they are normalized correctly.
+   */
+  public String toNormalizedString(Schema schema) {
+    return toString(schema);
+  }
 }

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestDatasetWriterCacheLoader.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestDatasetWriterCacheLoader.java
@@ -55,7 +55,7 @@ public class TestDatasetWriterCacheLoader {
       .schema(USER_SCHEMA)
       .partitionStrategy(partitionStrategy)
       .build());
-    view = new FileSystemView<Object>(users, null, Object.class);
+    view = new FileSystemView<Object>(users, null, null, Object.class);
   }
 
   @After

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestPartitionedDatasetWriter.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestPartitionedDatasetWriter.java
@@ -66,7 +66,7 @@ public class TestPartitionedDatasetWriter {
             .build());
 
     writer = PartitionedDatasetWriter.newWriter(
-        new FileSystemView<Object>(users, null, Object.class));
+        new FileSystemView<Object>(users, null, null, Object.class));
   }
 
   @After

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestSignalManager.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestSignalManager.java
@@ -1,0 +1,228 @@
+/**
+ * Copyright 2015 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kitesdk.data.spi.filesystem;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kitesdk.data.MiniDFSTest;
+import org.kitesdk.data.spi.Constraints;
+import com.google.common.io.Files;
+
+@RunWith(Parameterized.class)
+public class TestSignalManager extends MiniDFSTest {
+
+  Path testDirectory;
+  Configuration conf;
+  FileSystem fileSystem;
+
+  boolean distributed;
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> data() {
+    Object[][] data = new Object[][] {
+            { false },  // default to local FS
+            { true } }; // default to distributed FS
+    return Arrays.asList(data);
+  }
+
+  public TestSignalManager(boolean distributed) {
+    this.distributed = distributed;
+  }
+
+  @Before
+  public void setup() throws IOException {
+    this.conf = (distributed ?
+            MiniDFSTest.getConfiguration() :
+            new Configuration());
+
+    this.fileSystem = FileSystem.get(conf);
+
+    Path baseDirectory = fileSystem.makeQualified(
+        new Path(Files.createTempDir().getAbsolutePath()));
+    this.testDirectory = new Path(baseDirectory, ".signals");
+  }
+
+  @Test
+  public void testNormalizeConstraints() throws IOException {
+    Constraints constraints = new Constraints(DatasetTestUtilities.USER_SCHEMA).
+        with("email", "user@domain.com");
+
+    String normalizedConstraints = SignalManager.getNormalizedConstraints(constraints);
+
+    Assert.assertEquals("email=user%40domain.com", normalizedConstraints);
+  }
+
+  @Test
+  public void testNormalizeConstraintsUnbounded() throws IOException {
+    Constraints constraints = new Constraints(DatasetTestUtilities.USER_SCHEMA);
+
+    String normalizedConstraints = SignalManager.getNormalizedConstraints(constraints);
+
+    Assert.assertEquals("unbounded", normalizedConstraints);
+  }
+
+  @Test
+  public void testNormalizeConstraintsValueExists() throws IOException {
+    Constraints constraints = new Constraints(DatasetTestUtilities.USER_SCHEMA).
+        with("email", "");
+
+    String normalizedConstraints = SignalManager.getNormalizedConstraints(constraints);
+
+    Assert.assertEquals("email=in()", normalizedConstraints);
+  }
+
+  @Test
+  public void testNormalizeConstraintsOrderedSets() throws IOException {
+    Constraints constraints = new Constraints(DatasetTestUtilities.OLD_VALUE_SCHEMA).
+        with("value", 7L,2L,3L);
+
+    String normalizedConstraints = SignalManager.getNormalizedConstraints(constraints);
+
+    Assert.assertEquals("value=2,3,7", normalizedConstraints);
+  }
+
+  @Test
+  public void testNormalizeConstraintsIntervals() throws IOException {
+    Constraints constraints = new Constraints(DatasetTestUtilities.OLD_VALUE_SCHEMA).
+        toBefore("value", 12L);
+
+    String normalizedConstraints = SignalManager.getNormalizedConstraints(constraints);
+
+    Assert.assertEquals("value=(,12)", normalizedConstraints);
+  }
+
+  @Test
+  public void testNormalizeConstraintsOrderedKeys() throws IOException {
+    Constraints constraints = new Constraints(DatasetTestUtilities.USER_SCHEMA).
+        with("username", "kite").with("email", "kite@domain.com");
+
+    String normalizedConstraints = SignalManager.getNormalizedConstraints(constraints);
+
+    Assert.assertEquals("email=kite%40domain.com&username=kite", normalizedConstraints);
+  }
+
+  @Test
+  public void testSignalDirectoryCreatedOnSignal() throws IOException {
+    SignalManager manager = new SignalManager(fileSystem, testDirectory);
+
+    Assert.assertFalse("Signal directory shouldn't exist before signals",
+        fileSystem.exists(testDirectory));
+
+    Constraints constraints = new Constraints(DatasetTestUtilities.USER_SCHEMA).
+        with("email", "signalCreatesDir@domain.com");
+    manager.signalReady(constraints);
+
+    Assert.assertTrue("Signal directory created on signals",
+        fileSystem.exists(testDirectory));
+  }
+
+  @Test
+  public void testConstraintsSignaledReady() throws IOException {
+    SignalManager manager = new SignalManager(fileSystem, testDirectory);
+
+    Constraints constraints = new Constraints(DatasetTestUtilities.USER_SCHEMA).
+        with("email", "testConstraintsSignaledReady@domain.com");
+    manager.signalReady(constraints);
+
+    String normalizedConstraints = SignalManager.getNormalizedConstraints(constraints);
+    Assert.assertTrue(this.fileSystem.exists(new Path(this.testDirectory,
+        normalizedConstraints)));
+  }
+
+  @Test
+  public void testMultiConstraintsSignaledReady() throws IOException {
+    SignalManager manager = new SignalManager(fileSystem, testDirectory);
+
+    Constraints constraints = new Constraints(DatasetTestUtilities.USER_SCHEMA).
+        with("email", "kiteuser@domain.com").with("username", "kiteuser");
+    manager.signalReady(constraints);
+
+    String normalizedConstraints = SignalManager.getNormalizedConstraints(constraints);
+    Assert.assertTrue(this.fileSystem.exists(new Path(this.testDirectory,
+        normalizedConstraints)));
+  }
+
+  @Test
+  public void testConstraintsSignaledReadyPreviouslySignaled()
+      throws IOException, InterruptedException {
+    SignalManager manager = new SignalManager(fileSystem, testDirectory);
+
+    Constraints constraints =
+        new Constraints(DatasetTestUtilities.USER_SCHEMA)
+          .with("email",
+              "testConstraintsSignaledReadyPreviouslySignaled@domain.com");
+
+    String normalizedConstraints = SignalManager.getNormalizedConstraints(constraints);
+    Path signalFilePath = new Path(this.testDirectory,normalizedConstraints);
+
+    manager.signalReady(constraints);
+
+    Assert.assertTrue(this.fileSystem.exists(signalFilePath));
+    long firstSignalContents = this.fileSystem.getFileStatus(signalFilePath).getModificationTime();
+
+    // the modified time depends on the filesystem, and may only be granular to the second
+    // signal and check until the modified time is after the current time, or until
+    // enough time has past that the signal should have been distinguishable
+    long spinStart = System.currentTimeMillis();
+    long signaledTime = 0;
+    while(firstSignalContents >= signaledTime && (System.currentTimeMillis() - spinStart) <= 2000) {
+      manager.signalReady(constraints);
+      signaledTime = manager.getReadyTimestamp(constraints);
+    }
+
+    Assert.assertFalse("Second signal should not match the first",
+        signaledTime == firstSignalContents);
+  }
+
+  @Test
+  public void testConstraintsGetReadyTimestamp() throws IOException {
+    SignalManager manager = new SignalManager(fileSystem, testDirectory);
+
+    Constraints constraints = new Constraints(DatasetTestUtilities.USER_SCHEMA).
+        with("email", "testConstraintsReady@domain.com");
+
+    Path signalFilePath = new Path(this.testDirectory,
+        "email=testConstraintsReady%40domain.com");
+    // drop a file at the signal path
+    FSDataOutputStream stream = this.fileSystem.create(signalFilePath, true);
+    stream.writeUTF(String.valueOf(System.currentTimeMillis()));
+    stream.close();
+
+    Assert.assertTrue(manager.getReadyTimestamp(constraints) != -1);
+  }
+
+  @Test
+  public void testConstraintsGetReadyTimestampNotYetSignaled() throws IOException {
+    SignalManager manager = new SignalManager(fileSystem, testDirectory);
+
+    Constraints constraints = new Constraints(DatasetTestUtilities.USER_SCHEMA).
+        with("email", "testConstraintsGetReadyTimestampNotYetSignaled@domain.com");
+
+    Assert.assertEquals("A constraint that is not signaled should show -1",
+        -1, manager.getReadyTimestamp(constraints));
+  }
+
+}

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/predicates/TestInToFromString.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/predicates/TestInToFromString.java
@@ -85,6 +85,16 @@ public class TestInToFromString {
   }
 
   @Test
+  public void testMultipleStringValuesNormalized() {
+    Assert.assertEquals("In<Utf8>#toNormalizedString(STRING)",
+        "ab,al,m,z",
+        Predicates.in(new Utf8("z"), new Utf8("al"), new Utf8("ab"), new Utf8("m"))
+        .toNormalizedString(STRING));
+    Assert.assertEquals("In#toNormalizedString(STRING)",
+        "ab,al,m,z", Predicates.in("z", "al", "ab", "m").toNormalizedString(STRING));
+  }
+
+  @Test
   public void testSingleBooleanValue() {
     Assert.assertEquals("In#toString(BOOL)",
         "false", Predicates.in(false, false).toString(BOOL));
@@ -114,6 +124,16 @@ public class TestInToFromString {
         "3,4,5", Predicates.in(3,4,5).toString(INT));
     Assert.assertEquals("In.fromString(String, INT)",
         Predicates.in(3,4,5), In.<Integer>fromString("3,4,5", INT));
+  }
+
+  @Test
+  public void testMultipleIntegerValuesNormalized() {
+    // normalized predicate normalizes the string values,
+    // so they won't be sorted numerically.
+    // ensures that cases where the type may not be comparable directly
+    // that they will be consistently sorted
+    Assert.assertEquals("In#toString(INT)",
+        "123,45", Predicates.in(45,123).toNormalizedString(INT));
   }
 
   @Test


### PR DESCRIPTION
Implementation for hdfs and hive based views, hbase is currently unimplemented.

Includes updates to interfaces for views for the basic signalReady/isReady concept

Updates were also made to the dataset repository interface to create these signals for datasets based on constraints, and to determine the last time those constraints were signaled.

MapReduce was updated to create these signals (if possible) when a write to a dataset is successful. Crunch was updated to support using these signals for WriteMode.CHECKPOINT (with a 'ready' view essentially indicating a previous success)