### PR TITLE
Speed up schema migration when loading all schemas from a directory

### DIFF
--- a/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/avro/example/UserProfileExample.java
+++ b/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/avro/example/UserProfileExample.java
@@ -68,7 +68,7 @@ public class UserProfileExample {
    * The constructor will start by registering the schemas with the meta store
    * table in HBase, and create the required tables to run.
    */
-  public UserProfileExample() {
+  public UserProfileExample() throws InterruptedException {
     Configuration conf = HBaseConfiguration.create();
     HTablePool pool = new HTablePool(conf, 10);
     SchemaManager schemaManager = new DefaultSchemaManager(pool);
@@ -272,7 +272,8 @@ public class UserProfileExample {
    * @param schemaManager
    *          The schema manager SchemaTool needs to create the schemas.
    */
-  private void registerSchemas(Configuration conf, SchemaManager schemaManager) {
+  private void registerSchemas(Configuration conf, SchemaManager schemaManager)
+      throws InterruptedException {
     HBaseAdmin admin;
     try {
       // Construct an HBaseAdmin object (required by schema tool), and delete it
@@ -297,7 +298,7 @@ public class UserProfileExample {
    * 
    * @param args
    */
-  public static void main(String[] args) {
+  public static void main(String[] args) throws InterruptedException {
     UserProfileExample example = new UserProfileExample();
 
     // Let's create some user profiles


### PR DESCRIPTION
The following changes are made
1. kicking off HbaseAdmin.createTableAsync for a bunch of tables and waiting for HBaseAdmin.isTableAvailable for all the tables is much quicker than the sync version HBaseAdmin.createTable sequentially for all the tables. The SchemaTool waits for a maximum of 10 minutes for all the tables to become available which seems like a very legible buffer.
2. HBaseAdmin.disableTable and HBaseAdmin.enableTable are very costly (~25% time spent over the schema migration). Instead of creating tables as and when we know about a entity schema, construct the HTableDescriptor for all the entity schemas for a specific table, this was we dont have to add column families at a later point of time which requires the disable and enable