### PR TITLE
CDK-615: Permissions issue writing to a partitioned Hive external dataset

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/PartitionedDatasetWriter.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/PartitionedDatasetWriter.java
@@ -15,6 +15,7 @@
  */
 package org.kitesdk.data.spi.filesystem;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Map;
 import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.DatasetWriter;
@@ -186,7 +187,8 @@ abstract class PartitionedDatasetWriter<E, W extends FileSystemWriter<E>> extend
         .toString();
   }
 
-  private static class DatasetWriterCacheLoader<E> extends
+  @VisibleForTesting
+  static class DatasetWriterCacheLoader<E> extends
     CacheLoader<StorageKey, FileSystemWriter<E>> {
 
     private final FileSystemView<E> view;
@@ -216,6 +218,9 @@ abstract class PartitionedDatasetWriter<E, W extends FileSystemWriter<E>> extend
             dataset.getNamespace(), dataset.getName(), partition.toString());
       }
 
+      // initialize the writer after calling the listener
+      // this lets the listener decide if and how to create the
+      // partition directory
       writer.initialize();
 
       return writer;
@@ -223,7 +228,8 @@ abstract class PartitionedDatasetWriter<E, W extends FileSystemWriter<E>> extend
 
   }
 
-  private static class IncrementalDatasetWriterCacheLoader<E> extends
+  @VisibleForTesting
+  static class IncrementalDatasetWriterCacheLoader<E> extends
       CacheLoader<StorageKey, FileSystemWriter.IncrementalWriter<E>> {
 
     private final FileSystemView<E> view;
@@ -256,6 +262,9 @@ abstract class PartitionedDatasetWriter<E, W extends FileSystemWriter<E>> extend
             dataset.getNamespace(), dataset.getName(), partition.toString());
       }
 
+      // initialize the writer after calling the listener
+      // this lets the listener decide if and how to create the
+      // partition directory
       writer.initialize();
 
       return (FileSystemWriter.IncrementalWriter<E>) writer;

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestDatasetWriterCacheLoader.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestDatasetWriterCacheLoader.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2015 Cloudera, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kitesdk.data.spi.filesystem;
+
+import com.google.common.io.Files;
+import java.io.IOException;
+import junit.framework.Assert;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kitesdk.data.DatasetDescriptor;
+import org.kitesdk.data.PartitionStrategy;
+import org.kitesdk.data.spi.PartitionListener;
+import org.kitesdk.data.spi.StorageKey;
+import static org.kitesdk.data.spi.filesystem.DatasetTestUtilities.USER_SCHEMA;
+
+public class TestDatasetWriterCacheLoader {
+
+  private Configuration conf;
+  private FileSystem fileSystem;
+  private Path testDirectory;
+  private FileSystemDatasetRepository repo;
+  private PartitionStrategy partitionStrategy;
+  private FileSystemView<Object> view;
+
+  @Before
+  public void setUp() throws IOException {
+    this.conf = new Configuration();
+    this.fileSystem = FileSystem.get(conf);
+    this.testDirectory = new Path(Files.createTempDir().getAbsolutePath());
+    this.repo = new FileSystemDatasetRepository(conf, testDirectory,
+      new EnusrePartitionPathDoesNotExistMetadataProvider(conf, testDirectory));
+
+    partitionStrategy = new PartitionStrategy.Builder()
+      .hash("username", 2).build();
+    FileSystemDataset<Object> users = (FileSystemDataset<Object>) repo.create(
+      "ns", "users",
+      new DatasetDescriptor.Builder()
+      .schema(USER_SCHEMA)
+      .partitionStrategy(partitionStrategy)
+      .build());
+    view = new FileSystemView<Object>(users, null, Object.class);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    fileSystem.delete(testDirectory, true);
+  }
+
+  @Test
+  public void testInitializeAfterParitionAddedCallback() throws Exception {
+    PartitionedDatasetWriter.DatasetWriterCacheLoader<Object> loader
+      = new PartitionedDatasetWriter.DatasetWriterCacheLoader<Object>(view);
+
+    StorageKey key = new StorageKey.Builder(partitionStrategy)
+      .add("username", "test1")
+      .build();
+    loader.load(key);
+  }
+
+  @Test
+  public void testIncrementatlInitializeAfterParitionAddedCallback() throws Exception {
+    PartitionedDatasetWriter.IncrementalDatasetWriterCacheLoader<Object> loader
+      = new PartitionedDatasetWriter.IncrementalDatasetWriterCacheLoader<Object>(view);
+
+    StorageKey key = new StorageKey.Builder(partitionStrategy)
+      .add("username", "test1")
+      .build();
+    loader.load(key);
+  }
+
+  private static class EnusrePartitionPathDoesNotExistMetadataProvider
+    extends FileSystemMetadataProvider implements PartitionListener {
+
+    public EnusrePartitionPathDoesNotExistMetadataProvider(Configuration conf, Path rootDirectory) {
+      super(conf, rootDirectory);
+    }
+
+    @Override
+    public void partitionAdded(String namespace, String name, String partition) {
+      Path root = getRootDirectory();
+      Path partitionPath = new Path(
+        FileSystemDatasetRepository.pathForDataset(root, namespace, name),
+        partition);
+      try {
+        Assert.assertFalse("Partition path " + partitionPath + " does not exist",
+          getFileSytem().exists(partitionPath));
+      } catch (IOException ex) {
+        Assert.fail(ex.getMessage());
+      }
+    }
+
+    @Override
+    public void partitionDeleted(String namespace, String name, String partition) {
+    }
+  }
+
+}

--- a/kite-data/kite-data-hive/src/main/java/org/kitesdk/data/spi/hive/HiveExternalMetadataProvider.java
+++ b/kite-data/kite-data-hive/src/main/java/org/kitesdk/data/spi/hive/HiveExternalMetadataProvider.java
@@ -126,4 +126,17 @@ class HiveExternalMetadataProvider extends HiveAbstractMetadataProvider {
     return rootFileSystem.makeQualified(
         HiveUtils.pathForDataset(rootDirectory, namespace, name));
   }
+
+  @Override
+  public void partitionAdded(String namespace, String name, String path) {
+    Path partitionPath = new Path(pathForDataset(namespace, name), path);
+    try {
+      rootFileSystem.mkdirs(partitionPath);
+    } catch (IOException ex) {
+      throw new DatasetIOException(
+        "Unable to create partition directory  " + partitionPath, ex);
+    }
+    super.partitionAdded(namespace, name, path);
+  }
+
 }


### PR DESCRIPTION
* Added a test of `load()` methods of `DatasetWriterCacheLoader` and
  `IncrementalDatasetWriterCacheLoader`.
* Moved the `writer.initialize()` call to happen before the
  `listener.partitionAdded()` call in `DatasetWriterCacheLoader#load`
  and `IncrementalDatasetWriterCacheLoader#load`.