### PR TITLE
CDK-989: HttpMetricsMorphlineTest assumes only ConnectionException 

### DIFF
--- a/kite-morphlines/kite-morphlines-metrics-servlets/src/test/java/org/kitesdk/morphline/metrics/servlets/HttpMetricsMorphlineTest.java
+++ b/kite-morphlines/kite-morphlines-metrics-servlets/src/test/java/org/kitesdk/morphline/metrics/servlets/HttpMetricsMorphlineTest.java
@@ -21,6 +21,7 @@ import java.io.Reader;
 import java.net.ConnectException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.net.SocketException;
 import java.util.Iterator;
 
 import org.junit.Test;
@@ -93,6 +94,8 @@ public class HttpMetricsMorphlineTest extends AbstractMorphlineTest {
         fail();
       } catch (ConnectException e) {
         ; // expected
+      } catch (SocketException e) {
+        ; // expected on some OSes
       }
     }    
   }


### PR DESCRIPTION
The documentation of URLConnection.getInputStream() is that it may throw IOException. Which derived IOException which are thrown though is somewhat platform dependent. For some of the platforms a closed socket will instead throw SocketException.