### PR TITLE
CDK-843: Add replace to rewrite partitions

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/Replaceable.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/Replaceable.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data.spi;
+
+/**
+ * This interface is for classes that can replace parts of themselves in some
+ * (undefined) way. Once replaced, the update can be discarded without losing
+ * information.
+ *
+ * @param <T> the type of the object to replace
+ */
+public interface Replaceable<T> {
+  /**
+   * Check whether {@code part} can be replaced.
+   *
+   * @param part the object to replace parts of this
+   * @return {@code true} if the object can replace parts of this
+   */
+  public boolean canReplace(T part);
+
+  /**
+   * Replace part of {@code this} with the {@code replacement} object.
+   *
+   * @param replacement the object to replace parts of this
+   */
+  public void replace(T replacement);
+}

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemDataset.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemDataset.java
@@ -380,7 +380,10 @@ public class FileSystemDataset<E> extends AbstractDataset<E> implements
 
   @Override
   public boolean canReplace(View<E> part) {
-    if (part instanceof FileSystemView) {
+    if (!descriptor.isPartitioned()) {
+      // don't attempt to replace the root directory
+      return false;
+    } else if (part instanceof FileSystemView) {
       return equals(part.getDataset()) &&
           ((FileSystemView) part).getConstraints().alignedWithBoundaries();
     } else if (part instanceof FileSystemDataset) {

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemPartitionView.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemPartitionView.java
@@ -156,7 +156,7 @@ class FileSystemPartitionView<E> extends FileSystemView<E>
   @edu.umd.cs.findbugs.annotations.SuppressWarnings(
       value="NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
       justification="Null value checked by precondition")
-  private static URI relativize(@Nullable URI root, URI location) {
+  private static URI relativize(@Nullable URI root, @Nullable URI location) {
     Preconditions.checkNotNull(root, "Cannot find location relative to null");
 
     if (location == null) {

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemPartitionView.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemPartitionView.java
@@ -111,8 +111,8 @@ class FileSystemPartitionView<E> extends FileSystemView<E>
         new Predicate<PartitionView<E>>() {
           @Override
           public boolean apply(@Nullable PartitionView<E> input) {
-            return input != null && input.getLocation().getPath()
-                .startsWith(location.toUri().getPath());
+            return input != null &&
+                contains(location.toUri(), root, input.getLocation());
           }
         });
   }
@@ -151,6 +151,11 @@ class FileSystemPartitionView<E> extends FileSystemView<E>
   @Override
   public int hashCode() {
     return Objects.hashCode(super.hashCode(), location);
+  }
+
+  private static boolean contains(URI location, Path root, URI relative) {
+    URI full = new Path(root, relative.getPath()).toUri();
+    return !location.relativize(full).isAbsolute();
   }
 
   @edu.umd.cs.findbugs.annotations.SuppressWarnings(
@@ -249,12 +254,10 @@ class FileSystemPartitionView<E> extends FileSystemView<E>
 
     @Override
     public boolean apply(@Nullable StorageKey key) {
-      return (key != null && key.getPath() != null && contains(key.getPath()));
+      return (key != null &&
+          key.getPath() != null &&
+          contains(location, root, key.getPath().toUri()));
     }
 
-    private boolean contains(Path relative) {
-      URI full = new Path(root, relative.toUri().getPath()).toUri();
-      return !location.relativize(full).isAbsolute();
-    }
   }
 }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemView.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemView.java
@@ -16,7 +16,6 @@
 
 package org.kitesdk.data.spi.filesystem;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterators;
 import java.util.Iterator;

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestPartitionReplacement.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestPartitionReplacement.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2015 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data.spi.filesystem;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Sets;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Set;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.kitesdk.data.DatasetDescriptor;
+import org.kitesdk.data.DatasetWriter;
+import org.kitesdk.data.Datasets;
+import org.kitesdk.data.LocalFileSystem;
+import org.kitesdk.data.PartitionStrategy;
+import org.kitesdk.data.TestHelpers;
+import org.kitesdk.data.ValidationException;
+import org.kitesdk.data.View;
+
+public class TestPartitionReplacement {
+  public static class TestRecord {
+    private long id;
+    private String data;
+  }
+
+  private FileSystemDataset<TestRecord> unpartitioned = null;
+  private FileSystemDataset<TestRecord> partitioned = null;
+  private FileSystemDataset<TestRecord> temporary = null;
+
+  @Before
+  public void createTestDatasets() {
+    Datasets.delete("dataset:file:/tmp/datasets/unpartitioned");
+    Datasets.delete("dataset:file:/tmp/datasets/partitioned");
+    Datasets.delete("dataset:file:/tmp/datasets/temporary");
+
+    DatasetDescriptor descriptor = new DatasetDescriptor.Builder()
+        .schema(TestRecord.class)
+        .build();
+    unpartitioned = Datasets.create("dataset:file:/tmp/datasets/unpartitioned",
+        descriptor, TestRecord.class);
+
+    descriptor = new DatasetDescriptor.Builder(descriptor)
+        .property("kite.writer.cache-size", "20")
+        .partitionStrategy(new PartitionStrategy.Builder()
+            .hash("id", 4)
+            .build())
+        .build();
+    partitioned = Datasets.create("dataset:file:/tmp/datasets/partitioned",
+        descriptor, TestRecord.class);
+
+    // create a second dataset with the same partitioning for replacement parts
+    temporary = Datasets.create("dataset:file:/tmp/datasets/temporary",
+        descriptor, TestRecord.class);
+
+    writeTestRecords(unpartitioned);
+    writeTestRecords(partitioned);
+    writeTestRecords(temporary);
+  }
+
+  @After
+  public void removeTestDatasets() {
+    Datasets.delete("dataset:file:/tmp/datasets/unpartitioned");
+    Datasets.delete("dataset:file:/tmp/datasets/partitioned");
+    Datasets.delete("dataset:file:/tmp/datasets/temporary");
+  }
+
+  @Test
+  public void testUnpartitionedReplace() {
+    Assert.assertFalse("Should not allow replacing an unpartitioned dataset",
+        unpartitioned.canReplace(unpartitioned));
+  }
+
+  @Test
+  public void testReplaceWithDifferentStrategy() {
+    Assert.assertTrue("Should allow replacing a whole dataset",
+        partitioned.canReplace(partitioned));
+
+    TestHelpers.assertThrows(
+        "Should not allow replacement with a different partition strategy",
+        ValidationException.class, new Runnable() {
+          @Override
+          public void run() {
+            partitioned.replace(unpartitioned);
+          }
+        });
+  }
+
+  @Test
+  public void testPartitionedReplace() {
+    Assert.assertTrue("Should allow replacing a whole dataset",
+        partitioned.canReplace(partitioned));
+    Assert.assertTrue(
+        "Should not allow replacement test with a different dataset",
+        partitioned.canReplace(partitioned));
+
+    Set<String> originalFiles = Sets.newHashSet(
+        Iterators.transform(partitioned.pathIterator(), new GetFilename()));
+    Set<String> replacementFiles = Sets.newHashSet(
+        Iterators.transform(temporary.pathIterator(), new GetFilename()));
+    Assert.assertEquals("Sanity check",
+        originalFiles.size(), replacementFiles.size());
+    Assert.assertFalse("Sanity check", originalFiles.equals(replacementFiles));
+
+    partitioned.replace(temporary);
+
+    Set<String> replacedFiles = Sets.newHashSet(
+        Iterators.transform(partitioned.pathIterator(), new GetFilename()));
+    Assert.assertEquals("Should contain the replacement files",
+        replacementFiles, replacedFiles);
+  }
+
+  @Test
+  public void testReplaceSinglePartition() {
+    FileSystemPartitionView<TestRecord> partition0 = partitioned.getPartitionView(
+        new Path("id_hash=0"));
+    FileSystemPartitionView<TestRecord> temp0 = temporary.getPartitionView(
+        new Path("id_hash=0"));
+
+    Assert.assertTrue("Should allow replacing a single partition",
+        partitioned.canReplace(partition0));
+    Assert.assertFalse(
+        "Should not allow replacement test with a different dataset",
+        partitioned.canReplace(temp0));
+
+    Set<String> replacementFiles = Sets.newHashSet(
+        Iterators.transform(temp0.pathIterator(), new GetFilename()));
+    Set<String> originalPartitionFiles = Sets.newHashSet(
+        Iterators.transform(partition0.pathIterator(), new GetFilename()));
+
+    Assert.assertEquals("Sanity check",
+        originalPartitionFiles.size(), replacementFiles.size());
+    Assert.assertFalse("Sanity check",
+        originalPartitionFiles.equals(replacementFiles));
+
+    Set<String> expectedFiles = Sets.newHashSet(
+        Iterators.transform(partitioned.pathIterator(), new GetFilename()));
+    expectedFiles.removeAll(originalPartitionFiles);
+    expectedFiles.addAll(replacementFiles);
+
+    partitioned.replace(temp0);
+
+    Set<String> replacedFiles = Sets.newHashSet(
+        Iterators.transform(partitioned.pathIterator(), new GetFilename()));
+    Assert.assertEquals("Should contain the replacement files",
+        expectedFiles, replacedFiles);
+  }
+
+  @Test
+  public void testReplacePartitionsByConstraints() throws IOException {
+    // like testReplaceSinglePartition, this will replace partition0 with temp0
+    // but, this will also remove partitions that have equivalent constraints
+    // to simulate the case where directories 0, hash_0, id_hash=0, and
+    // id_hash=00 are compacted to a single replacement folder
+
+    FileSystemPartitionView<TestRecord> partition0 = partitioned.getPartitionView(
+        new Path("id_hash=0"));
+    FileSystemPartitionView<TestRecord> temp0 = temporary.getPartitionView(
+        new Path("id_hash=0"));
+
+    Set<String> replacementFiles = Sets.newHashSet(
+        Iterators.transform(temp0.pathIterator(), new GetFilename()));
+
+    // move other partitions so they match the partition0 constraint
+    FileSystem local = LocalFileSystem.getInstance();
+    local.rename(
+        new Path(partitioned.getDirectory(), "id_hash=1"),
+        new Path(partitioned.getDirectory(), "0"));
+    local.rename(
+        new Path(partitioned.getDirectory(), "id_hash=2"),
+        new Path(partitioned.getDirectory(), "hash=0"));
+    local.rename(
+        new Path(partitioned.getDirectory(), "id_hash=3"),
+        new Path(partitioned.getDirectory(), "id_hash=00"));
+
+    Assert.assertTrue("Should allow replacing a single partition",
+        partitioned.canReplace(partition0));
+    Assert.assertFalse(
+        "Should not allow replacement test with a different dataset",
+        partitioned.canReplace(temp0));
+
+    partitioned.replace(temp0);
+
+    Set<String> replacedFiles = Sets.newHashSet(
+        Iterators.transform(partitioned.pathIterator(), new GetFilename()));
+    Assert.assertEquals("Should contain the replacement files",
+        replacementFiles, replacedFiles);
+
+    Iterator<Path> dirIterator = partitioned.dirIterator();
+    Path onlyDirectory = dirIterator.next();
+    Assert.assertFalse("Should contain only one directory",
+        dirIterator.hasNext());
+    Assert.assertEquals("Should have the correct directory name",
+        "id_hash=0", onlyDirectory.getName());
+  }
+
+  @Test
+  public void testReplacePartitionsByConstraintsWithoutOriginal() throws IOException {
+    // like testReplacePartitionsByConstraints, but the target partition does
+    // not exist
+
+    FileSystemPartitionView<TestRecord> temp0 = temporary.getPartitionView(
+        new Path("id_hash=0"));
+
+    Set<String> replacementFiles = Sets.newHashSet(
+        Iterators.transform(temp0.pathIterator(), new GetFilename()));
+
+    // move other partitions so they match the partition0 constraint
+    FileSystem local = LocalFileSystem.getInstance();
+    local.rename(
+        new Path(partitioned.getDirectory(), "id_hash=0"),
+        new Path(partitioned.getDirectory(), "id-hash=0"));
+    local.rename(
+        new Path(partitioned.getDirectory(), "id_hash=1"),
+        new Path(partitioned.getDirectory(), "0"));
+    local.rename(
+        new Path(partitioned.getDirectory(), "id_hash=2"),
+        new Path(partitioned.getDirectory(), "hash=0"));
+    local.rename(
+        new Path(partitioned.getDirectory(), "id_hash=3"),
+        new Path(partitioned.getDirectory(), "id_hash=00"));
+
+    FileSystemPartitionView<TestRecord> partition0 = partitioned.getPartitionView(
+        new Path("id-hash=0"));
+
+    Assert.assertTrue("Should allow replacing a single partition",
+        partitioned.canReplace(partition0));
+    Assert.assertFalse(
+        "Should not allow replacement test with a different dataset",
+        partitioned.canReplace(temp0));
+
+    partitioned.replace(temp0);
+
+    Set<String> replacedFiles = Sets.newHashSet(
+        Iterators.transform(partitioned.pathIterator(), new GetFilename()));
+    Assert.assertEquals("Should contain the replacement files",
+        replacementFiles, replacedFiles);
+
+    Iterator<Path> dirIterator = partitioned.dirIterator();
+    Path onlyDirectory = dirIterator.next();
+    Assert.assertFalse("Should contain only one directory",
+        dirIterator.hasNext());
+    Assert.assertEquals("Should have the correct directory name",
+        "id_hash=0", onlyDirectory.getName());
+  }
+
+  private static class GetFilename implements Function<Path, String> {
+    @Override
+    public String apply(Path path) {
+      return path.getName();
+    }
+  }
+
+  private static void writeTestRecords(View<TestRecord> view) {
+    DatasetWriter<TestRecord> writer = null;
+    try {
+      writer = view.newWriter();
+      for (int i = 0; i < 10; i += 1) {
+        TestRecord record = new TestRecord();
+        record.id = i;
+        record.data = "test-" + i;
+        writer.write(record);
+      }
+
+    } finally {
+      if (writer != null) {
+        writer.close();
+      }
+    }
+  }
+}

--- a/kite-data/kite-data-crunch/src/main/java/org/kitesdk/data/crunch/DatasetTarget.java
+++ b/kite-data/kite-data-crunch/src/main/java/org/kitesdk/data/crunch/DatasetTarget.java
@@ -76,6 +76,9 @@ class DatasetTarget<E> implements MapReduceTarget {
   @SuppressWarnings("unchecked")
   public boolean handleExisting(WriteMode writeMode, long lastModForSource,
       Configuration entries) {
+    outputConf(
+        DatasetKeyOutputFormat.KITE_WRITE_MODE,
+        kiteWriteMode(writeMode).toString());
 
     if (view == null) {
       try {
@@ -98,11 +101,10 @@ class DatasetTarget<E> implements MapReduceTarget {
           LOG.error("Dataset/view " + view + " already exists!");
           throw new CrunchRuntimeException("Dataset/view already exists: " + view);
         case OVERWRITE:
-          LOG.info("Deleting all data from: " + view);
-          delete(view);
+          LOG.info("Overwriting existing dataset/view: " + view);
           break;
         case APPEND:
-          LOG.info("Writing to existing dataset/view: " + view);
+          LOG.info("Appending to existing dataset/view: " + view);
           break;
         case CHECKPOINT:
           long lastModForTarget = -1;
@@ -131,6 +133,20 @@ class DatasetTarget<E> implements MapReduceTarget {
       LOG.info("Writing to empty dataset/view: " + view);
     }
     return exists;
+  }
+
+  private DatasetKeyOutputFormat.WriteMode kiteWriteMode(WriteMode mode) {
+    switch (mode) {
+      case DEFAULT:
+        return DatasetKeyOutputFormat.WriteMode.DEFAULT;
+      case APPEND:
+        return DatasetKeyOutputFormat.WriteMode.APPEND;
+      case OVERWRITE:
+        return DatasetKeyOutputFormat.WriteMode.OVERWRITE;
+      default:
+        // use APPEND and enforce in handleExisting
+        return DatasetKeyOutputFormat.WriteMode.APPEND;
+    }
   }
 
   private void delete(View view) {

--- a/kite-data/kite-data-mapreduce/src/test/java/org/kitesdk/data/mapreduce/TestMapReduce.java
+++ b/kite-data/kite-data-mapreduce/src/test/java/org/kitesdk/data/mapreduce/TestMapReduce.java
@@ -214,7 +214,7 @@ public class TestMapReduce extends FileSystemTestBase {
     job.setReducerClass(GenericStatsReducer.class);
 
     View<Record> outputView = outputDataset.with("name", "apple", "banana", "carrot");
-    DatasetKeyOutputFormat.configure(job).overwrite(outputView).withType(GenericData.Record.class);
+    DatasetKeyOutputFormat.configure(job).appendTo(outputView).withType(GenericData.Record.class);
 
     Assert.assertTrue(job.waitForCompletion(true));
 

--- a/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/Main.java
+++ b/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/Main.java
@@ -36,6 +36,7 @@ import org.apache.log4j.Level;
 import org.apache.log4j.PropertyConfigurator;
 import org.kitesdk.cli.commands.CSVImportCommand;
 import org.kitesdk.cli.commands.CSVSchemaCommand;
+import org.kitesdk.cli.commands.CompactCommand;
 import org.kitesdk.cli.commands.CopyCommand;
 import org.kitesdk.cli.commands.CreateColumnMappingCommand;
 import org.kitesdk.cli.commands.CreateDatasetCommand;
@@ -98,6 +99,7 @@ public class Main extends Configured implements Tool {
     jc.addCommand("create", new CreateDatasetCommand(console));
     jc.addCommand("copy", new CopyCommand(console));
     jc.addCommand("transform", new TransformCommand(console));
+    jc.addCommand("compact", new CompactCommand(console));
     jc.addCommand("update", new UpdateDatasetCommand(console));
     jc.addCommand("delete", new DeleteCommand(console));
     jc.addCommand("schema", new SchemaCommand(console));

--- a/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/BaseDatasetCommand.java
+++ b/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/BaseDatasetCommand.java
@@ -153,4 +153,31 @@ abstract class BaseDatasetCommand extends BaseCommand {
     return new URIBuilder(buildRepoURI(), namespace, uriOrName).build().toString();
   }
 
+  /**
+   * Verify that a view matches the URI that loaded it without extra options.
+   * <p>
+   * This is used to prevent mis-interpreted URIs from succeeding. For example,
+   * the URI: view:file:./table?year=2014&month=3&dy=14 resolves a view for
+   * all of March 2014 because "dy" wasn't recognized as "day" and was ignored.
+   * This works by verifying that all of the options are accounted for in the
+   * final view and would fail the above because "dy" is not in the view's
+   * options.
+   *
+   * @param view a View's URI
+   * @param requested the requested View URI
+   * @return true if the view's URI and the requested URI match exactly
+   */
+  @VisibleForTesting
+  static boolean viewMatches(URI view, String requested) {
+    // test that the requested options are a subset of the final options
+    Map<String, String> requestedOptions = optionsForUri(URI.create(requested));
+    Map<String, String> finalOptions = optionsForUri(view);
+    for (Map.Entry<String, String> entry : requestedOptions.entrySet()) {
+      if (!finalOptions.containsKey(entry.getKey()) ||
+          !finalOptions.get(entry.getKey()).equals(entry.getValue())) {
+        return false;
+      }
+    }
+    return true;
+  }
 }

--- a/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/CompactCommand.java
+++ b/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/CompactCommand.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2013 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.cli.commands;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.util.List;
+import org.apache.crunch.PipelineResult;
+import org.kitesdk.data.View;
+import org.kitesdk.tools.CompactionTask;
+import org.slf4j.Logger;
+
+import static org.apache.avro.generic.GenericData.Record;
+
+@Parameters(commandDescription="Compact all or part of a dataset")
+public class CompactCommand extends BaseDatasetCommand {
+
+  public CompactCommand(Logger console) {
+    super(console);
+  }
+
+  @Parameter(description="<dataset-or-view>")
+  List<String> datasets;
+
+  @Parameter(names={"--num-writers"},
+      description="The number of writer processes to use")
+  int numWriters = -1;
+
+  @Override
+  public int run() throws IOException {
+    Preconditions.checkArgument(datasets.size() == 1,
+        "Cannot compact multiple datasets");
+
+    String uriOrName = datasets.get(0);
+    View<Record> view = load(uriOrName, Record.class);
+
+    if (isDatasetOrViewUri(uriOrName)) {
+      Preconditions.checkArgument(viewMatches(view.getUri(), uriOrName),
+          "Resolved view does not match requested view: " + view.getUri());
+    }
+
+    CompactionTask task = new CompactionTask<Record>(view);
+
+    task.setConf(getConf());
+
+    if (numWriters >= 0) {
+      task.setNumWriters(numWriters);
+    }
+
+    PipelineResult result = task.run();
+
+    if (result.succeeded()) {
+      console.info("Compacted {} records in \"{}\"",
+          task.getCount(), uriOrName);
+      return 0;
+    } else {
+      return 1;
+    }
+  }
+
+  @Override
+  public List<String> getExamples() {
+    return Lists.newArrayList(
+        "# Compact the contents of movies",
+        "movies"
+    );
+  }
+}

--- a/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/CopyCommand.java
+++ b/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/CopyCommand.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.List;
 import org.apache.crunch.PipelineResult;
+import org.apache.crunch.Target;
 import org.kitesdk.data.View;
 import org.kitesdk.tools.CopyTask;
 import org.slf4j.Logger;
@@ -47,6 +48,11 @@ public class CopyCommand extends BaseDatasetCommand {
       description="The number of writer processes to use")
   int numWriters = -1;
 
+  @Parameter(
+      names={"--overwrite"},
+      description="Remove any data already in the target view or dataset")
+  boolean overwrite = false;
+
   @Override
   public int run() throws IOException {
     Preconditions.checkArgument(datasets != null && datasets.size() > 1,
@@ -67,6 +73,10 @@ public class CopyCommand extends BaseDatasetCommand {
 
     if (numWriters >= 0) {
       task.setNumWriters(numWriters);
+    }
+
+    if (overwrite) {
+      task.setWriteMode(Target.WriteMode.OVERWRITE);
     }
 
     PipelineResult result = task.run();

--- a/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/DeleteCommand.java
+++ b/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/DeleteCommand.java
@@ -64,34 +64,6 @@ public class DeleteCommand extends BaseDatasetCommand {
     return 0;
   }
 
-  /**
-   * Verify that a view matches the URI that loaded it without extra options.
-   * <p>
-   * This is used to prevent mis-interpreted URIs from succeeding. For example,
-   * the URI: view:file:./table?year=2014&month=3&dy=14 resolves a view for
-   * all of March 2014 because "dy" wasn't recognized as "day" and was ignored.
-   * This works by verifying that all of the options are accounted for in the
-   * final view and would fail the above because "dy" is not in the view's
-   * options.
-   *
-   * @param view a View's URI
-   * @param requested the requested View URI
-   * @return true if the view's URI and the requested URI match exactly
-   */
-  @VisibleForTesting
-  static boolean viewMatches(URI view, String requested) {
-    // test that the requested options are a subset of the final options
-    Map<String, String> requestedOptions = optionsForUri(URI.create(requested));
-    Map<String, String> finalOptions = optionsForUri(view);
-    for (Map.Entry<String, String> entry : requestedOptions.entrySet()) {
-      if (!finalOptions.containsKey(entry.getKey()) ||
-          !finalOptions.get(entry.getKey()).equals(entry.getValue())) {
-        return false;
-      }
-    }
-    return true;
-  }
-
   @Override
   public List<String> getExamples() {
     return Lists.newArrayList(

--- a/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/tools/CompactionTask.java
+++ b/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/tools/CompactionTask.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2013 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.tools;
+
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import org.apache.crunch.PipelineResult;
+import org.apache.crunch.Target;
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.kitesdk.data.Dataset;
+import org.kitesdk.data.View;
+import org.kitesdk.data.spi.Replaceable;
+
+/**
+ * @since 1.1.0
+ */
+public class CompactionTask<T> implements Configurable {
+
+  private final CopyTask<T> task;
+
+  public CompactionTask(View<T> view) {
+    checkCompactable(view);
+    this.task = new CopyTask<T>(view, view);
+    task.setWriteMode(Target.WriteMode.OVERWRITE);
+  }
+
+  public long getCount() {
+    return task.getCount();
+  }
+
+  public CompactionTask setNumWriters(int numWriters) {
+    task.setNumWriters(numWriters);
+    return this;
+  }
+
+  public PipelineResult run() throws IOException {
+    return task.run();
+  }
+
+  @Override
+  public void setConf(Configuration configuration) {
+    task.setConf(configuration);
+  }
+
+  @Override
+  public Configuration getConf() {
+    return task.getConf();
+  }
+
+  @SuppressWarnings("unchecked")
+  private void checkCompactable(View<T> view) {
+    Dataset<T> dataset = view.getDataset();
+    if (!(dataset instanceof Replaceable)) {
+      throw new IllegalArgumentException("Cannot compact dataset: " + dataset);
+    }
+    Replaceable<View<T>> replaceable = ((Replaceable<View<T>>) dataset);
+    Preconditions.checkArgument(replaceable.canReplace(view),
+        "Cannot compact view: " + view);
+  }
+}


### PR DESCRIPTION
This is a work-in-progress. This adds a replace method, similar to merge, that replaces a partition. The use case is to copy data out of a dataset with MR and then replace the original partitions with the rewritten partition, which compacts the data.

The first commit adds `PartitionView` as discussed on the mailing list, and adds `getCoveringPartitions` to the `View` API. The second commit rewrites merge and adds replace in terms of those partition views.