### PR TITLE
CDK-898: Use MRPipeline instead of MemPipeline

### DIFF
--- a/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/Main.java
+++ b/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/Main.java
@@ -26,6 +26,7 @@ import com.google.common.io.Closeables;
 import java.io.InputStream;
 import java.util.Properties;
 import java.util.Set;
+import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
@@ -255,6 +256,10 @@ public class Main extends Configured implements Tool {
     PropertyConfigurator.configure(
         Main.class.getResource("/kite-cli-logging.properties"));
     Logger console = LoggerFactory.getLogger(Main.class);
+    // use Log4j for any libraries using commons-logging
+    LogFactory.getFactory().setAttribute(
+        "org.apache.commons.logging.Log",
+        "org.apache.commons.logging.impl.Log4JLogger");
     int rc = ToolRunner.run(new Configuration(), new Main(console), args);
     System.exit(rc);
   }

--- a/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/tools/TransformTask.java
+++ b/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/tools/TransformTask.java
@@ -18,11 +18,9 @@ package org.kitesdk.tools;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
-import com.google.common.io.Closeables;
 import java.io.IOException;
 import java.net.URI;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.mapreduce.AvroKeyInputFormat;
 import org.apache.crunch.DoFn;
 import org.apache.crunch.MapFn;
 import org.apache.crunch.PCollection;
@@ -30,7 +28,6 @@ import org.apache.crunch.Pipeline;
 import org.apache.crunch.PipelineResult;
 import org.apache.crunch.PipelineResult.StageResult;
 import org.apache.crunch.Target;
-import org.apache.crunch.impl.mem.MemPipeline;
 import org.apache.crunch.impl.mr.MRPipeline;
 import org.apache.crunch.types.PType;
 import org.apache.crunch.types.avro.AvroType;
@@ -40,7 +37,6 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.kitesdk.compat.DynMethods;
 import org.kitesdk.data.Dataset;
 import org.kitesdk.data.DatasetException;
-import org.kitesdk.data.DatasetWriter;
 import org.kitesdk.data.View;
 import org.kitesdk.data.crunch.CrunchDatasets;
 
@@ -96,6 +92,10 @@ public class TransformTask<S, T> extends Configured {
   }
 
   public PipelineResult run() throws IOException {
+    if (isLocal(from.getDataset()) || isLocal(to.getDataset())) {
+      getConf().set("mapreduce.framework.name", "local");
+    }
+
     PType<T> toPType = ptype(to);
     MapFn<T, T> validate = new CheckEntityClass<T>(to.getType());
 

--- a/kite-tools-parent/kite-tools/src/main/resources/kite-cli-logging.properties
+++ b/kite-tools-parent/kite-tools/src/main/resources/kite-cli-logging.properties
@@ -36,7 +36,7 @@ log4j.appender.component=org.apache.log4j.varia.NullAppender
 
 # Define the layout for component appender
 log4j.appender.component.layout=org.apache.log4j.PatternLayout
-log4j.appender.component.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p :: %m%n
+log4j.appender.component.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p :: %m [%C]%n
 
 # silence native code warnings
 log4j.logger.org.apache.hadoop.util.NativeCodeLoader=ERROR
@@ -45,3 +45,7 @@ log4j.logger.org.apache.hadoop.util.NativeCodeLoader=ERROR
 log4j.logger.org.kitesdk.data.filesystem=INFO
 log4j.logger.org.kitesdk.data.hcatalog=INFO
 log4j.logger.org.kitesdk.data.hbase=INFO
+
+# set up logging levels for MR
+log4j.logger.org.apache.hadoop.mapred.LocalJobRunner=WARN, console
+log4j.logger.org.apache.hadoop.mapreduce.Job=INFO, console

--- a/kite-tools-parent/kite-tools/src/test/java/org/kitesdk/cli/commands/TestCSVImportCommand.java
+++ b/kite-tools-parent/kite-tools/src/test/java/org/kitesdk/cli/commands/TestCSVImportCommand.java
@@ -23,7 +23,6 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecordBuilder;
@@ -36,14 +35,16 @@ import org.junit.Test;
 import org.kitesdk.cli.TestUtil;
 import org.kitesdk.data.Dataset;
 import org.kitesdk.data.DatasetNotFoundException;
-import org.kitesdk.data.DatasetRecordException;
 import org.kitesdk.data.Datasets;
 import org.kitesdk.data.TestHelpers;
 import org.kitesdk.data.URIBuilder;
 import org.kitesdk.data.spi.filesystem.DatasetTestUtilities;
 import org.slf4j.Logger;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class TestCSVImportCommand {
 

--- a/kite-tools-parent/kite-tools/src/test/java/org/kitesdk/cli/commands/TestCSVImportCommand.java
+++ b/kite-tools-parent/kite-tools/src/test/java/org/kitesdk/cli/commands/TestCSVImportCommand.java
@@ -196,15 +196,10 @@ public class TestCSVImportCommand {
 
     // This will fail because NaN isn't a valid long and the field is required
     command.targets = Lists.newArrayList("target/incompatible.csv", datasetName);
-    TestHelpers.assertThrows("Should complain about schema compatibility",
-        DatasetRecordException.class, new Callable() {
-          @Override
-          public Object call() throws Exception {
-            command.run();
-            return null;
-          }
-        }
-    );
+
+    int rc = command.run();
+    Assert.assertEquals(1, rc);
+
     verify(console).trace(contains("repo:file:target/data"));
     verifyNoMoreInteractions(console);
   }


### PR DESCRIPTION
This is based on #303, but fixes the logging configuration so that a link to the MR job is given when running on a cluster and task errors are printed to the console when running locally.