### PR TITLE
CDK-973: Add View#asSchema and View#asType projection methods

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/View.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/View.java
@@ -170,11 +170,24 @@ public interface View<E> {
    * <p>
    * This method always returns a {@code View} with type {@link GenericRecord}.
    *
-   * @param <T> the type of {@code GenericRecord} to use
    * @param schema an Avro schema to project entities to
    * @return a copy of this view that projects entities to the given schema
-   * @throws IncompatibleSchemaException the given {@code schema} is incompatible
-   * with the underlying dataset.
+   * @throws IncompatibleSchemaException
+   *          If the given {@code schema} is incompatible with the underlying
+   *          dataset.
    */
-  <T extends GenericRecord> View<T> asSchema(Schema schema);
+  View<GenericRecord> asSchema(Schema schema);
+
+  /**
+   * Creates a copy of this {@code View} that reads and writes entities of the
+   * given type class.
+   *
+   * @param <T> the type of entities that will be read or written by this view
+   * @param type an entity class to use
+   * @return a copy of this view that projects entities to the given type
+   * @throws IncompatibleSchemaException
+   *          If the given {@code type} is incompatible with the underlying
+   *          dataset.
+   */
+  <T> View<T> asType(Class<T> type);
 }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/View.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/View.java
@@ -17,6 +17,8 @@ package org.kitesdk.data;
 
 import java.net.URI;
 import javax.annotation.concurrent.Immutable;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
 
 /**
  * A {@code View} is a subset of a {@link Dataset}.
@@ -109,6 +111,15 @@ public interface View<E> {
   public Class<E> getType();
 
   /**
+   * Get the schema of entities contained in this {@code View}.
+   *
+   * @return the schema of entities contained in this view
+   *
+   * @since 1.1.0
+   */
+  public Schema getSchema();
+
+  /**
    * Check whether this {@link View} contains any records.
    *
    * Implementations should return once a single record in this view is found.
@@ -152,4 +163,18 @@ public interface View<E> {
    * @since 1.1.0
    */
   public Iterable<PartitionView<E>> getCoveringPartitions();
+
+  /**
+   * Creates a copy of this {@code View} that projects entities to the given
+   * {@link Schema}.
+   * <p>
+   * This method always returns a {@code View} with type {@link GenericRecord}.
+   *
+   * @param <T> the type of {@code GenericRecord} to use
+   * @param schema an Avro schema to project entities to
+   * @return a copy of this view that projects entities to the given schema
+   * @throws IncompatibleSchemaException the given {@code schema} is incompatible
+   * with the underlying dataset.
+   */
+  <T extends GenericRecord> View<T> asSchema(Schema schema);
 }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractDataset.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractDataset.java
@@ -24,6 +24,8 @@ import org.kitesdk.data.PartitionView;
 import org.kitesdk.data.RefinableView;
 import javax.annotation.concurrent.Immutable;
 import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.kitesdk.data.View;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,9 +42,11 @@ public abstract class AbstractDataset<E> implements Dataset<E>, RefinableView<E>
 
   protected abstract RefinableView<E> asRefinableView();
   protected final Class<E> type;
+  protected final Schema schema;
 
   public AbstractDataset(Class<E> type, Schema schema) {
     this.type = DataModelUtil.resolveType(type, schema);
+    this.schema = DataModelUtil.getReaderSchema(this.type, schema);
   }
 
   @Override
@@ -83,6 +87,11 @@ public abstract class AbstractDataset<E> implements Dataset<E>, RefinableView<E>
   }
 
   @Override
+  public Schema getSchema() {
+    return schema;
+  }
+
+  @Override
   public RefinableView<E> with(String name, Object... values) {
     return asRefinableView().with(name, values);
   }
@@ -105,6 +114,11 @@ public abstract class AbstractDataset<E> implements Dataset<E>, RefinableView<E>
   @Override
   public RefinableView<E> toBefore(String name, Comparable value) {
     return asRefinableView().toBefore(name, value);
+  }
+
+  @Override
+  public <T extends GenericRecord> View<T> asSchema(Schema schema) {
+    return asRefinableView().asSchema(schema);
   }
 
   @Override

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractDataset.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractDataset.java
@@ -20,6 +20,7 @@ import com.google.common.base.Objects;
 import org.kitesdk.data.Dataset;
 import org.kitesdk.data.DatasetReader;
 import org.kitesdk.data.DatasetWriter;
+import org.kitesdk.data.Datasets;
 import org.kitesdk.data.PartitionView;
 import org.kitesdk.data.RefinableView;
 import javax.annotation.concurrent.Immutable;
@@ -56,6 +57,27 @@ public abstract class AbstractDataset<E> implements Dataset<E>, RefinableView<E>
 
   public abstract AbstractRefinableView<E> filter(Constraints c);
 
+  /**
+   * Creates a copy of this {@code Dataset} that reads and writes entities of
+   * the given type class.
+   *
+   * @param <T>
+   *          The type of entities that will be read or written by this
+   *          dataset.
+   * @param type an entity class to use
+   * @return a copy of this view that projects entities to the given type
+   * @throws org.kitesdk.data.IncompatibleSchemaException
+   *          If the given {@code type} is incompatible with the underlying
+   *          dataset.
+   */
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> Dataset<T> asType(Class<T> type) {
+    if (getType().equals(type)) {
+      return (Dataset<T>) this;
+    }
+    return Datasets.load(getUri(), type);
+  }
   @Override
   public DatasetWriter<E> newWriter() {
     LOG.debug("Getting writer to dataset:{}", this);
@@ -117,7 +139,7 @@ public abstract class AbstractDataset<E> implements Dataset<E>, RefinableView<E>
   }
 
   @Override
-  public <T extends GenericRecord> View<T> asSchema(Schema schema) {
+  public View<GenericRecord> asSchema(Schema schema) {
     return asRefinableView().asSchema(schema);
   }
 

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractRefinableView.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/AbstractRefinableView.java
@@ -21,6 +21,7 @@ import com.google.common.base.Predicate;
 import java.net.URI;
 import java.util.Map;
 import javax.annotation.concurrent.Immutable;
+import org.apache.avro.Schema;
 import org.kitesdk.data.Dataset;
 import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.DatasetReader;
@@ -74,6 +75,17 @@ public abstract class AbstractRefinableView<E> implements RefinableView<E> {
     this.entityTest = constraints.toEntityPredicate(accessor);
   }
 
+  protected AbstractRefinableView(AbstractRefinableView<?> view, Schema schema) {
+    this.dataset = (Dataset<E>) view.dataset;
+    this.comparator = view.comparator;
+    this.constraints = view.constraints;
+    // thread-safe, so okay to reuse when views share a partition strategy
+    this.keys = view.keys;
+    // Resolve our type according to the given schema
+    this.accessor = DataModelUtil.accessor(schema);
+    this.entityTest = constraints.toEntityPredicate(accessor);
+  }
+
   protected AbstractRefinableView(AbstractRefinableView<E> view, Constraints constraints) {
     this.dataset = view.dataset;
     this.comparator = view.comparator;
@@ -106,6 +118,11 @@ public abstract class AbstractRefinableView<E> implements RefinableView<E> {
   @Override
   public Class<E> getType() {
     return accessor.getType();
+  }
+
+  @Override
+  public Schema getSchema() {
+    return accessor.getEntitySchema();
   }
 
   public EntityAccessor<E> getAccessor() {

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/DataModelUtil.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/DataModelUtil.java
@@ -33,7 +33,6 @@ import org.apache.avro.reflect.ReflectDatumReader;
 import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificRecord;
-import org.kitesdk.data.IncompatibleSchemaException;
 
 /**
  * Utilities for determining the appropriate data model at runtime.
@@ -101,22 +100,20 @@ public class DataModelUtil {
   }
 
   /**
-   * Returns true if the type implements GenericRecord but not SpecificRecord
+   * Test whether the class is a generic {@link GenericRecord} and not a
+   * {@link SpecificRecord}. This is necessary instead of testing if
+   * {@code GenericRecord} is assignable from the class because
+   * {@link org.apache.avro.specific.SpecificRecordBase} implements
+   * {@code GenericRecord}.
    *
-   * @param <E> The entity type
-   * @param type The Java class of the entity type
-   * @return true if the type implements GenericRecord but not SpecificRecord
+   * @param type a Java class
+   * @return true if the class is an Avro generic and not specific
    */
-  public static <E> boolean isGeneric(Class<E> type) {
-    // Need to check if SpecificRecord first because specific records also
-    // implement GenericRecord
-    if (SpecificRecord.class.isAssignableFrom(type)) {
-      return false;
-    } else if (IndexedRecord.class.isAssignableFrom(type)) {
-      return true;
-    } else {
-      return false;
-    }
+  public static boolean isGeneric(Class<?> type) {
+    return (
+        !SpecificRecord.class.isAssignableFrom(type) &&
+            GenericRecord.class.isAssignableFrom(type)
+    );
   }
 
   /**
@@ -151,8 +148,6 @@ public class DataModelUtil {
    * @param type The Java class of the entity type
    * @param schema The {@link Schema} for the entity
    * @return The resolved Java class object
-   * @throws IncompatibleSchemaException The schema for the resolved type is not
-   * compatible with the schema that was given.
    */
   @SuppressWarnings("unchecked")
   public static <E> Class<E> resolveType(Class<E> type, Schema schema) {
@@ -162,13 +157,6 @@ public class DataModelUtil {
 
     if (type == null) {
       type = (Class<E>) GenericData.Record.class;
-    }
-
-    Schema readerSchema = getReaderSchema(type, schema);
-    if (false == SchemaValidationUtil.canRead(schema, readerSchema)) {
-      throw new IncompatibleSchemaException(
-          String.format("The reader schema derived from %s is not compatible "
-          + "with the dataset's given writer schema.", type.toString()));
     }
 
     return type;
@@ -194,6 +182,29 @@ public class DataModelUtil {
   }
 
   /**
+   * Get the writer schema based on the given type and dataset schema.
+   *
+   * @param <E> The entity type
+   * @param type The Java class of the entity type
+   * @param schema The {@link Schema} for the entity
+   * @return The reader schema based on the given type and writer schema
+   */
+  public static <E> Schema getWriterSchema(Class<E> type, Schema schema) {
+    Schema writerSchema = schema;
+    GenericData dataModel = getDataModelForType(type);
+    if (dataModel instanceof AllowNulls) {
+      // assume fields are non-null by default to avoid schema conflicts
+      dataModel = ReflectData.get();
+    }
+
+    if (dataModel instanceof SpecificData) {
+      writerSchema = ((SpecificData)dataModel).getSchema(type);
+    }
+
+    return writerSchema;
+  }
+
+  /**
    * If E implements GenericRecord, but does not implement SpecificRecord, then
    * create a new instance of E using reflection so that GenericDataumReader
    * will use the expected type.
@@ -210,9 +221,7 @@ public class DataModelUtil {
   @SuppressWarnings("unchecked")
   public static <E> E createRecord(Class<E> type, Schema schema) {
     // Don't instantiate SpecificRecords or interfaces.
-    if (!SpecificRecord.class.isAssignableFrom(type) &&
-        GenericRecord.class.isAssignableFrom(type) &&
-        !type.isInterface()) {
+    if (isGeneric(type) && !type.isInterface()) {
       if (GenericData.Record.class.equals(type)) {
         return (E) GenericData.get().newRecord(null, schema);
       }
@@ -223,11 +232,6 @@ public class DataModelUtil {
   }
 
   public static <E> EntityAccessor<E> accessor(Class<E> type, Schema schema) {
-    return new EntityAccessor<E>(type, schema);
-  }
-
-  public static <E> EntityAccessor<E> accessor(Schema schema) {
-    Class<E> type = resolveType(null, schema);
     return new EntityAccessor<E>(type, schema);
   }
 }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/DataModelUtil.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/DataModelUtil.java
@@ -101,6 +101,25 @@ public class DataModelUtil {
   }
 
   /**
+   * Returns true if the type implements GenericRecord but not SpecificRecord
+   *
+   * @param <E> The entity type
+   * @param type The Java class of the entity type
+   * @return true if the type implements GenericRecord but not SpecificRecord
+   */
+  public static <E> boolean isGeneric(Class<E> type) {
+    // Need to check if SpecificRecord first because specific records also
+    // implement GenericRecord
+    if (SpecificRecord.class.isAssignableFrom(type)) {
+      return false;
+    } else if (IndexedRecord.class.isAssignableFrom(type)) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /**
    * Get the DatumReader for the given type.
    *
    * @param <E> The entity type
@@ -160,11 +179,11 @@ public class DataModelUtil {
    *
    * @param <E> The entity type
    * @param type The Java class of the entity type
-   * @param writerSchema The writer {@link Schema} for the entity
+   * @param schema The {@link Schema} for the entity
    * @return The reader schema based on the given type and writer schema
    */
-  public static <E> Schema getReaderSchema(Class<E> type, Schema writerSchema) {
-    Schema readerSchema = writerSchema;
+  public static <E> Schema getReaderSchema(Class<E> type, Schema schema) {
+    Schema readerSchema = schema;
     GenericData dataModel = getDataModelForType(type);
 
     if (dataModel instanceof SpecificData) {
@@ -207,4 +226,8 @@ public class DataModelUtil {
     return new EntityAccessor<E>(type, schema);
   }
 
+  public static <E> EntityAccessor<E> accessor(Schema schema) {
+    Class<E> type = resolveType(null, schema);
+    return new EntityAccessor<E>(type, schema);
+  }
 }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/EntityAccessor.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/EntityAccessor.java
@@ -34,13 +34,15 @@ import org.kitesdk.data.spi.partition.ProvidedFieldPartitioner;
 public class EntityAccessor<E> {
 
   private final Schema schema;
+  private final Schema writeSchema;
   private final Class<E> type;
   private final GenericData model;
   private final Map<String, List<Schema.Field>> cache = Maps.newHashMap();
 
-  EntityAccessor(Class<E> type, Schema readerSchema) {
-    this.type = DataModelUtil.resolveType(type, readerSchema);
-    this.schema = DataModelUtil.getReaderSchema(this.type, readerSchema);
+  EntityAccessor(Class<E> type, Schema schema) {
+    this.type = DataModelUtil.resolveType(type, schema);
+    this.schema = DataModelUtil.getReaderSchema(this.type, schema);
+    this.writeSchema = DataModelUtil.getWriterSchema(this.type, this.schema);
     this.model = DataModelUtil.getDataModelForType(this.type);
   }
 
@@ -48,8 +50,12 @@ public class EntityAccessor<E> {
     return type;
   }
 
-  public Schema getEntitySchema() {
+  public Schema getReadSchema() {
     return schema;
+  }
+
+  public Schema getWriteSchema() {
+    return writeSchema;
   }
 
   public Object get(E object, String name) {

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/EntityAccessor.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/EntityAccessor.java
@@ -38,9 +38,9 @@ public class EntityAccessor<E> {
   private final GenericData model;
   private final Map<String, List<Schema.Field>> cache = Maps.newHashMap();
 
-  EntityAccessor(Class<E> type, Schema schema) {
-    this.type = DataModelUtil.resolveType(type, schema);
-    this.schema = DataModelUtil.getReaderSchema(this.type, schema);
+  EntityAccessor(Class<E> type, Schema readerSchema) {
+    this.type = DataModelUtil.resolveType(type, readerSchema);
+    this.schema = DataModelUtil.getReaderSchema(this.type, readerSchema);
     this.model = DataModelUtil.getDataModelForType(this.type);
   }
 

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVFileReader.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVFileReader.java
@@ -74,7 +74,7 @@ public class CSVFileReader<E> extends AbstractDatasetReader<E> {
                        EntityAccessor<E> accessor) {
     this.fs = fileSystem;
     this.path = path;
-    this.schema = accessor.getEntitySchema();
+    this.schema = accessor.getReadSchema();
     this.recordClass = accessor.getType();
     this.state = ReaderWriterState.NEW;
     this.props = CSVProperties.fromDescriptor(descriptor);

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVInputFormat.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVInputFormat.java
@@ -28,6 +28,8 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 import org.kitesdk.compat.Hadoop;
 import org.kitesdk.data.DatasetDescriptor;
+import org.kitesdk.data.View;
+import org.kitesdk.data.spi.AbstractRefinableView;
 import org.kitesdk.data.spi.DataModelUtil;
 import org.kitesdk.data.spi.EntityAccessor;
 
@@ -35,12 +37,9 @@ class CSVInputFormat<E> extends FileInputFormat<E, Void> {
   private DatasetDescriptor descriptor = null;
   private EntityAccessor<E> accessor = null;
 
-  public void setDescriptor(DatasetDescriptor descriptor) {
-    this.descriptor = descriptor;
-  }
-
-  public void setType(Class<E> type) {
-    this.accessor = DataModelUtil.accessor(type, descriptor.getSchema());
+  public void setView(View<E> view) {
+    this.descriptor = view.getDataset().getDescriptor();
+    this.accessor = DataModelUtil.accessor(view.getType(), view.getSchema());
   }
 
   @Override

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemView.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemView.java
@@ -43,7 +43,10 @@ import org.apache.hadoop.fs.Path;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import java.io.IOException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.conf.Configuration;
+import org.kitesdk.data.RefinableView;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,9 +85,21 @@ class FileSystemView<E> extends AbstractRefinableView<E> implements InputFormatA
     this.signalManager = view.signalManager;
   }
 
+  private FileSystemView(FileSystemView<?> view, Schema schema) {
+    super(view, schema);
+    this.fs = view.fs;
+    this.root = view.root;
+    this.listener = view.listener;
+  }
+
   @Override
   protected FileSystemView<E> filter(Constraints c) {
     return new FileSystemView<E>(this, c);
+  }
+
+  @Override
+  public <T extends GenericRecord> RefinableView<T> asSchema(Schema schema) {
+    return new FileSystemView<T>(this, schema);
   }
 
   @Override

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/JSONFileReader.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/JSONFileReader.java
@@ -63,7 +63,7 @@ public class JSONFileReader<E> extends AbstractDatasetReader<E> {
                         EntityAccessor<E> accessor) {
     this.fs = fileSystem;
     this.path = path;
-    this.schema = accessor.getEntitySchema();
+    this.schema = accessor.getReadSchema();
     this.model = DataModelUtil.getDataModelForType(accessor.getType());
     this.state = ReaderWriterState.NEW;
   }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/JSONInputFormat.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/JSONInputFormat.java
@@ -28,19 +28,16 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 import org.kitesdk.compat.Hadoop;
 import org.kitesdk.data.DatasetDescriptor;
+import org.kitesdk.data.View;
+import org.kitesdk.data.spi.AbstractRefinableView;
 import org.kitesdk.data.spi.DataModelUtil;
 import org.kitesdk.data.spi.EntityAccessor;
 
 class JSONInputFormat<E> extends FileInputFormat<E, Void> {
-  private DatasetDescriptor descriptor = null;
   private EntityAccessor<E> accessor = null;
 
-  public void setDescriptor(DatasetDescriptor descriptor) {
-    this.descriptor = descriptor;
-  }
-
-  public void setType(Class<E> type) {
-    this.accessor = DataModelUtil.accessor(type, descriptor.getSchema());
+  public void setView(View<E> view) {
+    this.accessor = DataModelUtil.accessor(view.getType(), view.getSchema());
   }
 
   @Override

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/MultiFileDatasetReader.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/MultiFileDatasetReader.java
@@ -90,7 +90,7 @@ class MultiFileDatasetReader<E> extends AbstractDatasetReader<E> {
   private void openNextReader() {
     if (Formats.PARQUET.equals(descriptor.getFormat())) {
       this.reader = new ParquetFileSystemDatasetReader(fileSystem,
-          filesIter.next(), accessor.getEntitySchema(), accessor.getType());
+          filesIter.next(), accessor.getReadSchema(), accessor.getType());
     } else if (Formats.JSON.equals(descriptor.getFormat())) {
       this.reader = new JSONFileReader<E>(
           fileSystem, filesIter.next(), accessor);
@@ -101,7 +101,7 @@ class MultiFileDatasetReader<E> extends AbstractDatasetReader<E> {
       this.reader = new InputFormatReader(fileSystem, filesIter.next(), descriptor);
     } else {
       this.reader = new FileSystemDatasetReader<E>(fileSystem, filesIter.next(),
-          accessor.getEntitySchema(), accessor.getType());
+          accessor.getReadSchema(), accessor.getType());
     }
     reader.initialize();
     this.readerIterator = Iterators.filter(reader,

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemDatasetRepository.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemDatasetRepository.java
@@ -295,11 +295,14 @@ public class TestFileSystemDatasetRepository extends TestDatasetRepositories {
           .schema(ReflectData.AllowNull.get().getSchema(ObjectPoJo.class))
           .build(), ObjectPoJo.class);
 
-      TestHelpers.assertThrows("AllowNull primitives should not accept null",
+      // should load the dataset because PrimitivePoJo can be used to write
+      final Dataset<PrimitivePoJo> dataset = repo.load(
+          NAMESPACE, name, PrimitivePoJo.class);
+      TestHelpers.assertThrows("AllowNull primitives cannot read nullable type",
           IncompatibleSchemaException.class, new Runnable() {
             @Override
             public void run() {
-              repo.load(NAMESPACE, name, PrimitivePoJo.class);
+              dataset.newReader();
             }
           });
 

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestProjection.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestProjection.java
@@ -20,19 +20,26 @@ import com.google.common.io.Closeables;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Set;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.hadoop.fs.Path;
 import org.junit.After;
 import org.junit.Test;
 import org.kitesdk.data.Dataset;
 import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.DatasetWriter;
+import org.kitesdk.data.Datasets;
 import org.kitesdk.data.IncompatibleSchemaException;
+import org.kitesdk.data.TestHelpers;
+import org.kitesdk.data.View;
 import org.kitesdk.data.event.IncompatibleEvent;
 import org.kitesdk.data.event.ReflectSmallEvent;
 import org.kitesdk.data.event.ReflectStandardEvent;
 import org.kitesdk.data.event.SmallEvent;
 import org.kitesdk.data.event.StandardEvent;
 import org.kitesdk.data.spi.DatasetRepository;
+import org.kitesdk.data.spi.Schemas;
 import org.kitesdk.data.spi.TestRefinableViews;
 
 public class TestProjection extends TestRefinableViews {
@@ -55,7 +62,74 @@ public class TestProjection extends TestRefinableViews {
   }
 
   @Test
-  public void testSpecificProjection() throws IOException {
+  public void testGenericProjectionAsSchema() throws IOException {
+    Dataset<StandardEvent> original = Datasets.load(
+        unbounded.getUri(), StandardEvent.class);
+    Schema standardEvent = Schemas.fromAvsc(conf,
+        URI.create("resource:standard_event.avsc"));
+    final Schema smallEvent = Schemas.fromAvsc(conf,
+        URI.create("resource:small_event.avsc"));
+
+    DatasetWriter<GenericRecord> writer = null;
+    try {
+      writer = original.asSchema(standardEvent).newWriter();
+      writer.write(toGeneric(sepEvent, standardEvent));
+      writer.write(toGeneric(octEvent, standardEvent));
+      writer.write(toGeneric(novEvent, standardEvent));
+    } finally {
+      Closeables.close(writer, false);
+    }
+
+    final View<GenericRecord> smallEvents = original.asSchema(smallEvent);
+
+    Set<GenericRecord> expected = Sets.newHashSet(
+        toGeneric(toSmallEvent(sepEvent), smallEvent),
+        toGeneric(toSmallEvent(octEvent), smallEvent),
+        toGeneric(toSmallEvent(novEvent), smallEvent));
+
+    assertContentEquals(expected, smallEvents);
+
+    TestHelpers.assertThrows("Should not be able to write small events",
+        IncompatibleSchemaException.class, new Runnable() {
+          @Override
+          public void run() {
+            smallEvents.newWriter();
+          }
+        });
+  }
+
+  @Test
+  public void testSpecificProjectionAsType() throws IOException {
+    Dataset<GenericRecord> original = Datasets.load(unbounded.getUri());
+
+    DatasetWriter<StandardEvent> writer = null;
+    try {
+      writer = original.asType(StandardEvent.class).newWriter();
+      writer.write(sepEvent);
+      writer.write(octEvent);
+      writer.write(novEvent);
+    } finally {
+      Closeables.close(writer, false);
+    }
+
+    final View<SmallEvent> smallEvents = original.asType(SmallEvent.class);
+
+    Set<SmallEvent> expected = Sets.newHashSet(toSmallEvent(sepEvent),
+        toSmallEvent(octEvent), toSmallEvent(novEvent));
+
+    assertContentEquals(expected, smallEvents);
+
+    TestHelpers.assertThrows("Should not be able to write small events",
+        IncompatibleSchemaException.class, new Runnable() {
+          @Override
+          public void run() {
+            smallEvents.newWriter();
+          }
+        });
+  }
+
+  @Test
+  public void testSpecificProjectionLoad() throws IOException {
     DatasetWriter<StandardEvent> writer = null;
     try {
       writer = unbounded.newWriter();
@@ -77,12 +151,49 @@ public class TestProjection extends TestRefinableViews {
   }
 
   @Test
-  public void testReflectProjection() throws IOException {
+  public void testReflectProjectionAsType() throws IOException {
+    Dataset<StandardEvent> original = repo.create(
+        "ns", "reflectProjection",
+        new DatasetDescriptor.Builder()
+            .schema(StandardEvent.class)
+            .build(),
+        StandardEvent.class);
+
+    DatasetWriter<ReflectStandardEvent> writer = null;
+    try {
+      writer = original.asType(ReflectStandardEvent.class).newWriter();
+      writer.write(new ReflectStandardEvent(sepEvent));
+      writer.write(new ReflectStandardEvent(octEvent));
+      writer.write(new ReflectStandardEvent(novEvent));
+    } finally {
+      Closeables.close(writer, false);
+    }
+
+    final View<ReflectSmallEvent> smallEvents = original.asType(ReflectSmallEvent.class);
+
+    Set<ReflectSmallEvent> expected = Sets.newHashSet(
+        new ReflectSmallEvent(sepEvent), new ReflectSmallEvent(octEvent),
+        new ReflectSmallEvent(novEvent));
+
+    assertContentEquals(expected, smallEvents);
+
+    TestHelpers.assertThrows("Should not be able to write small events",
+        IncompatibleSchemaException.class, new Runnable() {
+          @Override
+          public void run() {
+            smallEvents.newWriter();
+          }
+        });
+  }
+
+  @Test
+  public void testReflectProjectionLoad() throws IOException {
     Dataset<ReflectStandardEvent> original = repo.create(
         "ns", "reflectProjection",
         new DatasetDescriptor.Builder()
             .schema(ReflectStandardEvent.class)
-            .build(), ReflectStandardEvent.class);
+            .build(),
+        ReflectStandardEvent.class);
 
     DatasetWriter<ReflectStandardEvent> writer = null;
     try {
@@ -94,7 +205,7 @@ public class TestProjection extends TestRefinableViews {
       Closeables.close(writer, false);
     }
 
-    Dataset<ReflectSmallEvent> dataset = repo.load("ns", original.getName(),
+    View<ReflectSmallEvent> dataset = repo.load("ns", original.getName(),
         ReflectSmallEvent.class);
 
     Set<ReflectSmallEvent> expected = Sets.newHashSet(
@@ -131,7 +242,7 @@ public class TestProjection extends TestRefinableViews {
     assertContentEquals(expected, dataset);
   }
 
-  @Test(expected=IncompatibleSchemaException.class)
+  @Test
   public void testIncompatibleProjection() throws IOException {
     DatasetWriter<StandardEvent> writer = null;
     try {
@@ -143,7 +254,31 @@ public class TestProjection extends TestRefinableViews {
       Closeables.close(writer, false);
     }
 
-    repo.load("ns", unbounded.getDataset().getName(), IncompatibleEvent.class);
+    TestHelpers.assertThrows(
+        "Should not load a dataset with an incompatible class",
+        IncompatibleSchemaException.class, new Runnable() {
+          @Override
+          public void run() {
+            repo.load("ns", unbounded.getDataset().getName(),
+                IncompatibleEvent.class);
+          }
+        });
+
+    TestHelpers.assertThrows("Should reject a schema that can't read or write",
+        IncompatibleSchemaException.class, new Runnable() {
+          @Override
+          public void run() {
+            unbounded.asType(IncompatibleEvent.class);
+          }
+        });
+
+    TestHelpers.assertThrows("Should reject a schema that can't read or write",
+        IncompatibleSchemaException.class, new Runnable() {
+          @Override
+          public void run() {
+            unbounded.getDataset().asType(IncompatibleEvent.class);
+          }
+        });
   }
 
   private static SmallEvent toSmallEvent(StandardEvent event) {
@@ -153,10 +288,11 @@ public class TestProjection extends TestRefinableViews {
         .build();
   }
 
-  private static IncompatibleEvent toIncompatibleEvent(StandardEvent event) {
-    return IncompatibleEvent.newBuilder()
-        .setUserId(String.valueOf(event.getUserId()))
-        .setSessionId(event.getSessionId())
-        .build();
+  private static GenericRecord toGeneric(GenericRecord rec, Schema schema) {
+    GenericRecordBuilder builder = new GenericRecordBuilder(schema);
+    for (Schema.Field field : schema.getFields()) {
+      builder.set(field, rec.get(field.name()));
+    }
+    return builder.build();
   }
 }

--- a/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/DaoView.java
+++ b/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/DaoView.java
@@ -39,9 +39,7 @@ import org.kitesdk.data.spi.Marker;
 import org.kitesdk.data.spi.MarkerRange;
 import java.util.List;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.conf.Configuration;
-import org.kitesdk.data.RefinableView;
 
 class DaoView<E> extends AbstractRefinableView<E> implements InputFormatAccessor<E> {
 
@@ -57,9 +55,9 @@ class DaoView<E> extends AbstractRefinableView<E> implements InputFormatAccessor
     this.dataset = view.dataset;
   }
 
-  private DaoView(DaoView<?> view, Schema schema) {
-    super(view, schema);
-    this.dataset = (DaoDataset<E>) view.dataset;
+  private DaoView(DaoView<?> view, Schema schema, Class<E> type) {
+    super(view, schema, type);
+    this.dataset = (DaoDataset<E>) view.dataset.asType(type);
   }
 
   @Override
@@ -68,8 +66,8 @@ class DaoView<E> extends AbstractRefinableView<E> implements InputFormatAccessor
   }
 
   @Override
-  public <T extends GenericRecord> RefinableView<T> asSchema(Schema schema) {
-    return new DaoView<T>(this, schema);
+  protected <T> AbstractRefinableView<T> project(Schema schema, Class<T> type) {
+    return new DaoView<T>(this, schema, type);
   }
 
   EntityScanner<E> newEntityScanner() {

--- a/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/DaoView.java
+++ b/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/DaoView.java
@@ -38,7 +38,10 @@ import org.kitesdk.data.spi.StorageKey;
 import org.kitesdk.data.spi.Marker;
 import org.kitesdk.data.spi.MarkerRange;
 import java.util.List;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.conf.Configuration;
+import org.kitesdk.data.RefinableView;
 
 class DaoView<E> extends AbstractRefinableView<E> implements InputFormatAccessor<E> {
 
@@ -54,9 +57,19 @@ class DaoView<E> extends AbstractRefinableView<E> implements InputFormatAccessor
     this.dataset = view.dataset;
   }
 
+  private DaoView(DaoView<?> view, Schema schema) {
+    super(view, schema);
+    this.dataset = (DaoDataset<E>) view.dataset;
+  }
+
   @Override
   protected DaoView<E> filter(Constraints constraints) {
     return new DaoView<E>(this, constraints);
+  }
+
+  @Override
+  public <T extends GenericRecord> RefinableView<T> asSchema(Schema schema) {
+    return new DaoView<T>(this, schema);
   }
 
   EntityScanner<E> newEntityScanner() {

--- a/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/avro/AvroEntityComposer.java
+++ b/kite-data/kite-data-hbase/src/main/java/org/kitesdk/data/hbase/avro/AvroEntityComposer.java
@@ -116,8 +116,8 @@ public class AvroEntityComposer<E extends IndexedRecord> implements
   public Object extractField(E entity, String fieldName) {
     // make sure the field is a direct child of the schema
     ValidationException.check(
-        accessor.getEntitySchema().getField(fieldName) != null,
-        "No field named %s in schema %s", fieldName, accessor.getEntitySchema());
+        accessor.getReadSchema().getField(fieldName) != null,
+        "No field named %s in schema %s", fieldName, accessor.getReadSchema());
     return accessor.get(entity, fieldName);
   }
 

--- a/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/DatasetKeyInputFormat.java
+++ b/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/DatasetKeyInputFormat.java
@@ -15,11 +15,14 @@
  */
 package org.kitesdk.data.mapreduce;
 
+import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
+import org.apache.avro.specific.SpecificRecord;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -39,6 +42,7 @@ import org.kitesdk.data.spi.PartitionKey;
 import org.kitesdk.data.spi.PartitionedDataset;
 import org.kitesdk.data.TypeNotFoundException;
 import org.kitesdk.data.View;
+import org.kitesdk.data.spi.DataModelUtil;
 import org.kitesdk.data.spi.InputFormatAccessor;
 import org.kitesdk.data.spi.filesystem.FileSystemDataset;
 import org.slf4j.Logger;
@@ -61,6 +65,7 @@ public class DatasetKeyInputFormat<E> extends InputFormat<E, Void>
   public static final String KITE_INPUT_URI = "kite.inputUri";
   public static final String KITE_PARTITION_DIR = "kite.inputPartitionDir";
   public static final String KITE_TYPE = "kite.inputEntityType";
+  public static final String KITE_READER_SCHEMA = "kite.readerSchema";
 
   private Configuration conf;
   private InputFormat<E, Void> delegate;
@@ -104,7 +109,13 @@ public class DatasetKeyInputFormat<E> extends InputFormat<E, Void>
       for (String property : descriptor.listProperties()) {
         conf.set(property, descriptor.getProperty(property));
       }
-      withType(view.getType());
+
+      if (DataModelUtil.isGeneric(view.getType())) {
+        withSchema(view.getSchema());
+      } else {
+        withType(view.getType());
+      }
+
       conf.set(KITE_INPUT_URI, view.getUri().toString());
       return this;
     }
@@ -135,9 +146,22 @@ public class DatasetKeyInputFormat<E> extends InputFormat<E, Void>
      * @return this for method chaining
      */
     public <E> ConfigBuilder withType(Class<E> type) {
+      String readerSchema = conf.get(KITE_READER_SCHEMA);
+      Preconditions.checkArgument(DataModelUtil.isGeneric(type) || readerSchema == null,
+        "Can't configure a type when a reader schema is already set: {}", readerSchema);
       conf.setClass(KITE_TYPE, type, type);
       return this;
     }
+
+    public ConfigBuilder withSchema(Schema readerSchema) {
+      Class<?> type = conf.getClass(KITE_TYPE, null);
+      Preconditions.checkArgument(type == null,
+        "Can't configure a reader schema when a type is already set: {}", type);
+
+      conf.set(KITE_READER_SCHEMA, readerSchema.toString());
+      return this;
+    }
+
   }
 
   /**
@@ -230,7 +254,7 @@ public class DatasetKeyInputFormat<E> extends InputFormat<E, Void>
 
   @SuppressWarnings({"deprecation", "unchecked"})
   private static <E> View<E> load(Configuration conf) {
-    Class<E> type; 
+    Class<E> type;
     try {
       type = (Class<E>)conf.getClass(KITE_TYPE, GenericData.Record.class);
     } catch (RuntimeException e) {

--- a/kite-data/kite-data-mapreduce/src/test/java/org/kitesdk/data/mapreduce/TestDatasetRecordWriter.java
+++ b/kite-data/kite-data-mapreduce/src/test/java/org/kitesdk/data/mapreduce/TestDatasetRecordWriter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015 Cloudera, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kitesdk.data.mapreduce;
+
+import com.google.common.collect.ImmutableList;
+import junit.framework.Assert;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kitesdk.data.Dataset;
+import org.kitesdk.data.DatasetDescriptor;
+import org.kitesdk.data.Format;
+import org.kitesdk.data.spi.SchemaValidationUtil;
+
+@RunWith(Parameterized.class)
+public class TestDatasetRecordWriter extends FileSystemTestBase {
+
+  private Dataset<GenericData.Record> dataset;
+
+  public TestDatasetRecordWriter(Format format) {
+    super(format);
+  }
+
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    dataset = repo.create("ns", "out",
+        new DatasetDescriptor.Builder()
+            .property("kite.allow.csv", "true")
+            .schema(STATS_SCHEMA)
+            .format(format)
+            .build(), GenericData.Record.class);
+  }
+
+  @Test
+  public void testBasicRecordWriter() {
+    DatasetKeyOutputFormat.DatasetRecordWriter<GenericData.Record> recordWriter;
+    recordWriter =
+      new DatasetKeyOutputFormat.DatasetRecordWriter<GenericData.Record>(dataset);
+
+    ImmutableList<Integer> counts = ImmutableList.of(1, 2, 3, 4, 5, 6, 7, 8, 9,
+      10);
+
+    for (Integer count : counts) {
+      GenericData.Record record = new GenericData.Record(STATS_SCHEMA);
+      record.put("count", count);
+      record.put("name", "name"+count);
+
+      recordWriter.write(record, null);
+    }
+
+    recordWriter.close(null);
+  }
+
+}

--- a/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/BaseDatasetCommand.java
+++ b/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/BaseDatasetCommand.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import org.apache.avro.generic.GenericRecord;
 import org.kitesdk.data.Datasets;
 import org.kitesdk.data.URIBuilder;
 import org.kitesdk.data.View;
@@ -106,6 +107,14 @@ abstract class BaseDatasetCommand extends BaseCommand {
   protected <E> View<E> load(String uriOrName, Class<E> type) {
     if (isDatasetOrViewUri(uriOrName)) {
       return Datasets.<E, View<E>>load(uriOrName, type);
+    } else {
+      return getDatasetRepository().load(namespace, uriOrName, type);
+    }
+  }
+
+  protected View<GenericRecord> load(String uriOrName) {
+    if (isDatasetOrViewUri(uriOrName)) {
+      return Datasets.load(uriOrName);
     } else {
       return getDatasetRepository().load(namespace, uriOrName);
     }

--- a/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/CopyCommand.java
+++ b/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/CopyCommand.java
@@ -67,8 +67,8 @@ public class CopyCommand extends BaseDatasetCommand {
     Preconditions.checkArgument(datasets.size() == 2,
         "Cannot copy multiple datasets");
 
-    View<Record> source = load(datasets.get(0), Record.class);
     View<Record> dest = load(datasets.get(1), Record.class);
+    View<Record> source = load(datasets.get(0), Record.class).asSchema(dest.getSchema());
 
     CopyTask task = new CopyTask<Record>(source, dest);
 

--- a/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/CopyCommand.java
+++ b/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/CopyCommand.java
@@ -22,13 +22,13 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.List;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.crunch.PipelineResult;
 import org.apache.crunch.Target;
 import org.kitesdk.data.View;
 import org.kitesdk.tools.CopyTask;
 import org.slf4j.Logger;
 
-import static org.apache.avro.generic.GenericData.Record;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.thrift.DelegationTokenIdentifier;
@@ -67,10 +67,11 @@ public class CopyCommand extends BaseDatasetCommand {
     Preconditions.checkArgument(datasets.size() == 2,
         "Cannot copy multiple datasets");
 
-    View<Record> dest = load(datasets.get(1), Record.class);
-    View<Record> source = load(datasets.get(0), Record.class).asSchema(dest.getSchema());
+    View<GenericRecord> dest = load(datasets.get(1));
+    View<GenericRecord> source = load(datasets.get(0))
+        .asSchema(dest.getSchema());
 
-    CopyTask task = new CopyTask<Record>(source, dest);
+    CopyTask task = new CopyTask<GenericRecord>(source, dest);
 
     JobConf conf = new JobConf(getConf());
 
@@ -123,7 +124,7 @@ public class CopyCommand extends BaseDatasetCommand {
     );
   }
 
-  private boolean isHiveView(View<Record> view) {
+  private boolean isHiveView(View<?> view) {
     return view.getDataset().getUri().toString().startsWith("dataset:hive:");
   }
 }

--- a/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/CreateDatasetCommand.java
+++ b/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/CreateDatasetCommand.java
@@ -21,6 +21,7 @@ import com.beust.jcommander.Parameters;
 import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.net.URI;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.avro.Schema;
@@ -71,7 +72,7 @@ public class CreateDatasetCommand extends BaseDatasetCommand {
 
   @DynamicParameter(names = {"--set", "--property"},
       description = "Add a property pair: prop.name=value")
-  Map<String, String> properties;
+  Map<String, String> properties = new HashMap<String, String>();
 
   public CreateDatasetCommand(Logger console) {
     super(console);

--- a/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/UpdateDatasetCommand.java
+++ b/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/UpdateDatasetCommand.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
 import org.kitesdk.data.Dataset;
 import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.Datasets;
@@ -61,7 +62,7 @@ public class UpdateDatasetCommand extends BaseDatasetCommand {
     }
 
     String dataset = datasets.remove(0);
-    Dataset<GenericData.Record> currentDataset = load(dataset, GenericData.Record.class).getDataset();
+    Dataset<GenericRecord> currentDataset = load(dataset).getDataset();
 
     DatasetDescriptor.Builder descriptorBuilder = new DatasetDescriptor
         .Builder(currentDataset.getDescriptor());

--- a/kite-tools-parent/kite-tools/src/test/java/org/kitesdk/cli/commands/TestCopyCommandClusterChangedNameWithPartitioning.java
+++ b/kite-tools-parent/kite-tools/src/test/java/org/kitesdk/cli/commands/TestCopyCommandClusterChangedNameWithPartitioning.java
@@ -52,12 +52,14 @@ public class TestCopyCommandClusterChangedNameWithPartitioning extends TestCopyC
     psOut.write(partitionStrategy.toString(true).getBytes());
     psOut.close();
 
-    return ImmutableList.of("-p", partitionStrategyJson);
+    return ImmutableList.of(
+        "-p", partitionStrategyJson,
+        "--set", "kite.writer.cache-size=20");
   }
 
   @Override
   public void testCopyWithoutCompaction() throws Exception {
-    testCopyWithoutCompaction(6);
+    testCopyWithoutCompaction(5);
   }
 
   @Override

--- a/kite-tools-parent/kite-tools/src/test/java/org/kitesdk/cli/commands/TestCopyCommandClusterChangedNameWithPartitioning.java
+++ b/kite-tools-parent/kite-tools/src/test/java/org/kitesdk/cli/commands/TestCopyCommandClusterChangedNameWithPartitioning.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015 Cloudera, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kitesdk.cli.commands;
+
+import com.beust.jcommander.internal.Lists;
+import com.google.common.collect.ImmutableList;
+import java.io.FileOutputStream;
+import java.util.List;
+import org.apache.avro.Schema;
+import org.kitesdk.data.PartitionStrategy;
+
+public class TestCopyCommandClusterChangedNameWithPartitioning extends TestCopyCommandClusterSchemaEvolution {
+
+  private static final String partitionStrategyJson = "target/partition-strategy.json";
+
+  @Override
+  public Schema getEvolvedSchema(Schema original) {
+    List<Schema.Field> fields = Lists.newArrayList();
+    for (Schema.Field field : original.getFields()) {
+      fields.add(new Schema.Field(field.name(), field.schema(), field.doc(),
+        field.defaultValue()));
+    }
+
+    Schema evolved = Schema.createRecord("NewUser", original.getDoc(),
+      original.getNamespace(), false);
+    evolved.addAlias("User");
+    evolved.setFields(fields);
+
+    return evolved;
+  }
+
+  @Override
+  public List<String> getExtraCreateArgs() throws Exception {
+    PartitionStrategy partitionStrategy = new PartitionStrategy.Builder()
+      .hash("id", "part", 5)
+      .build();
+
+    FileOutputStream psOut = new FileOutputStream(partitionStrategyJson);
+    psOut.write(partitionStrategy.toString(true).getBytes());
+    psOut.close();
+
+    return ImmutableList.of("-p", partitionStrategyJson);
+  }
+
+  @Override
+  public void testCopyWithoutCompaction() throws Exception {
+    testCopyWithoutCompaction(6);
+  }
+
+  @Override
+  public void testCopyWithNumWriters() throws Exception {
+    testCopyWithNumWriters(5);
+  }
+  
+}

--- a/kite-tools-parent/kite-tools/src/test/java/org/kitesdk/cli/commands/TestCopyCommandClusterNewField.java
+++ b/kite-tools-parent/kite-tools/src/test/java/org/kitesdk/cli/commands/TestCopyCommandClusterNewField.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 Cloudera, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kitesdk.cli.commands;
+
+import com.beust.jcommander.internal.Lists;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.apache.avro.Schema;
+import org.codehaus.jackson.node.NullNode;
+
+public class TestCopyCommandClusterNewField extends TestCopyCommandClusterSchemaEvolution {
+
+  @Override
+  public Schema getEvolvedSchema(Schema original) {
+    List<Schema.Field> fields = Lists.newArrayList();
+    fields.add(new Schema.Field("new",
+      Schema.createUnion(ImmutableList.of(
+          Schema.create(Schema.Type.NULL),
+          Schema.create(Schema.Type.STRING))),
+      "New field", NullNode.getInstance()));
+
+    for (Schema.Field field : original.getFields()) {
+      fields.add(new Schema.Field(field.name(), field.schema(), field.doc(),
+        field.defaultValue()));
+    }
+
+    Schema evolved = Schema.createRecord(original.getName(), original.getDoc(),
+      original.getNamespace(), false);
+    evolved.setFields(fields);
+
+    return evolved;
+  }
+
+  @Override
+  public List<String> getExtraCreateArgs() {
+    return ImmutableList.of();
+  }
+
+}

--- a/kite-tools-parent/kite-tools/src/test/java/org/kitesdk/cli/commands/TestCopyCommandClusterSchemaEvolution.java
+++ b/kite-tools-parent/kite-tools/src/test/java/org/kitesdk/cli/commands/TestCopyCommandClusterSchemaEvolution.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2015 Cloudera, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kitesdk.cli.commands;
+
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.util.List;
+import org.apache.avro.Schema;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Ignore;
+import org.kitesdk.cli.TestUtil;
+import com.google.common.collect.Lists;
+import static org.mockito.Mockito.mock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class TestCopyCommandClusterSchemaEvolution extends TestCopyCommandCluster {
+
+  private static final String evolvedAvsc = "target/evolved_user.avsc";
+
+  @Override
+  public void createDestination() throws Exception {
+    FileInputStream schemaIn = new FileInputStream(avsc);
+    Schema original = new Schema.Parser().parse(schemaIn);
+    schemaIn.close();
+
+    Schema evolved = getEvolvedSchema(original);
+
+    FileOutputStream schemaOut = new FileOutputStream(evolvedAvsc);
+    schemaOut.write(evolved.toString(true).getBytes());
+    schemaOut.close();
+
+    List<String> createArgs = Lists.newArrayList(
+      "create", dest, "-s", evolvedAvsc, "-r", repoUri, "-d", "target/data");
+    createArgs.addAll(getExtraCreateArgs());
+
+    TestUtil.run(LoggerFactory.getLogger(this.getClass()),
+      "delete", dest, "-r", repoUri, "-d", "target/data");
+    TestUtil.run(LoggerFactory.getLogger(this.getClass()),
+      createArgs.toArray(new String[createArgs.size()]));
+    this.console = mock(Logger.class);
+    this.command = new CopyCommand(console);
+    command.setConf(new Configuration());
+  }
+
+  @Ignore
+  @Override
+  public void testPartitionedCopyWithNumWriters() throws Exception {
+    super.testPartitionedCopyWithNumWriters(); //To change body of generated methods, choose Tools | Templates.
+  }
+
+  
+
+  public abstract Schema getEvolvedSchema(Schema original) throws Exception;
+
+  public abstract List<String> getExtraCreateArgs() throws Exception;
+  
+}


### PR DESCRIPTION
This extends Joey's PR, #346, and fixes the review issues I noted. One of the main issues was that without changing the backing dataset's type class, projection would fail. This adds `asType` projection to take care of that issue.