### PR TITLE
CDK-976: Fix task configuration in MR

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/DefaultConfiguration.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/DefaultConfiguration.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.fs.Path;
 public class DefaultConfiguration {
 
   // initialize the default configuration from the environment
+  private static boolean initDone = false;
   private static Configuration conf;
 
   static{
@@ -57,14 +58,25 @@ public class DefaultConfiguration {
    * @return A {@code Configuration} based on the environment or set by
    *          {@link #set(Configuration)}
    */
-  public static Configuration get() {
+  public static synchronized Configuration get() {
     return new Configuration(conf);
   }
 
   /**
    * Set the default Hadoop {@link Configuration}.
    */
-  public static void set(Configuration conf) {
+  public static synchronized void set(Configuration conf) {
     DefaultConfiguration.conf = conf;
+    DefaultConfiguration.initDone = true;
+  }
+
+  /**
+   * Initialize the default Hadoop {@link Configuration} if it has not been set.
+   */
+  public static synchronized void init(Configuration conf) {
+    if (!initDone) {
+      DefaultConfiguration.conf = conf;
+      DefaultConfiguration.initDone = true;
+    }
   }
 }

--- a/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/DatasetKeyInputFormat.java
+++ b/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/DatasetKeyInputFormat.java
@@ -34,6 +34,7 @@ import org.kitesdk.data.Dataset;
 import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.DatasetException;
 import org.kitesdk.data.Datasets;
+import org.kitesdk.data.spi.DefaultConfiguration;
 import org.kitesdk.data.spi.PartitionKey;
 import org.kitesdk.data.spi.PartitionedDataset;
 import org.kitesdk.data.TypeNotFoundException;
@@ -258,6 +259,8 @@ public class DatasetKeyInputFormat<E> extends InputFormat<E, Void>
   @edu.umd.cs.findbugs.annotations.SuppressWarnings(value="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR",
       justification="Delegate set by setConf")
   public RecordReader<E, Void> createRecordReader(InputSplit inputSplit, TaskAttemptContext taskAttemptContext) throws IOException, InterruptedException {
+    Configuration conf = Hadoop.TaskAttemptContext.getConfiguration.invoke(taskAttemptContext);
+    DefaultConfiguration.set(conf);
     return delegate.createRecordReader(inputSplit, taskAttemptContext);
   }
 

--- a/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/DatasetKeyInputFormat.java
+++ b/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/DatasetKeyInputFormat.java
@@ -260,7 +260,7 @@ public class DatasetKeyInputFormat<E> extends InputFormat<E, Void>
       justification="Delegate set by setConf")
   public RecordReader<E, Void> createRecordReader(InputSplit inputSplit, TaskAttemptContext taskAttemptContext) throws IOException, InterruptedException {
     Configuration conf = Hadoop.TaskAttemptContext.getConfiguration.invoke(taskAttemptContext);
-    DefaultConfiguration.set(conf);
+    DefaultConfiguration.init(conf);
     return delegate.createRecordReader(inputSplit, taskAttemptContext);
   }
 

--- a/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/DatasetKeyOutputFormat.java
+++ b/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/DatasetKeyOutputFormat.java
@@ -501,7 +501,7 @@ public class DatasetKeyOutputFormat<E> extends OutputFormat<E, Void> {
   @Override
   public OutputCommitter getOutputCommitter(TaskAttemptContext taskAttemptContext) {
     Configuration conf = Hadoop.TaskAttemptContext.getConfiguration.invoke(taskAttemptContext);
-    DefaultConfiguration.set(conf);
+    DefaultConfiguration.init(conf);
     View<E> view = load(taskAttemptContext);
     return usePerTaskAttemptDatasets(view) ?
         new MergeOutputCommitter<E>() : new NullOutputCommitter();

--- a/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/DatasetKeyOutputFormat.java
+++ b/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/DatasetKeyOutputFormat.java
@@ -47,6 +47,7 @@ import org.kitesdk.data.spi.Constraints;
 import org.kitesdk.data.spi.DataModelUtil;
 import org.kitesdk.data.spi.DatasetRepositories;
 import org.kitesdk.data.spi.DatasetRepository;
+import org.kitesdk.data.spi.DefaultConfiguration;
 import org.kitesdk.data.spi.Mergeable;
 import org.kitesdk.data.spi.PartitionKey;
 import org.kitesdk.data.spi.Registration;
@@ -499,6 +500,8 @@ public class DatasetKeyOutputFormat<E> extends OutputFormat<E, Void> {
 
   @Override
   public OutputCommitter getOutputCommitter(TaskAttemptContext taskAttemptContext) {
+    Configuration conf = Hadoop.TaskAttemptContext.getConfiguration.invoke(taskAttemptContext);
+    DefaultConfiguration.set(conf);
     View<E> view = load(taskAttemptContext);
     return usePerTaskAttemptDatasets(view) ?
         new MergeOutputCommitter<E>() : new NullOutputCommitter();

--- a/kite-data/kite-data-mapreduce/src/test/java/org/kitesdk/data/mapreduce/FileSystemTestBase.java
+++ b/kite-data/kite-data-mapreduce/src/test/java/org/kitesdk/data/mapreduce/FileSystemTestBase.java
@@ -25,14 +25,29 @@ import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.runners.Parameterized;
 import org.kitesdk.data.Format;
 import org.kitesdk.data.Formats;
 import org.kitesdk.data.spi.DatasetRepository;
+import org.kitesdk.data.spi.DefaultConfiguration;
 import org.kitesdk.data.spi.filesystem.FileSystemDatasetRepository;
 
 public class FileSystemTestBase {
+
+  private static Configuration original = null;
+
+  @BeforeClass
+  public static void saveDefaultConfiguration() {
+    original = DefaultConfiguration.get();
+  }
+
+  @AfterClass
+  public static void restoreDefaultConfiguration() {
+    DefaultConfiguration.set(original);
+  }
 
   public FileSystemTestBase(Format format) {
     this.format = format;


### PR DESCRIPTION
This sets the default configuration using the one passed to the InputFormat or OutputFormat when running in a MR task. To avoid this setting leaking into tests, this adds `DefaultConfiguration.init(Configuration)`, which will set the default conf only if it has not already been set via `set` or `init`. (Otherwise, test fail.)

This replaces #368.