### PR TITLE
CDK-983: Fix in predicate ordering.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/CharSequences.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/CharSequences.java
@@ -18,6 +18,7 @@ package org.kitesdk.data.spi;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.LinkedHashMultimap;
 import java.util.AbstractSet;
 import java.util.Iterator;
 import java.util.Set;
@@ -50,8 +51,23 @@ public class CharSequences {
 
   @Immutable
   public static class ImmutableCharSequenceSet extends AbstractSet<CharSequence> {
-    private final HashMultimap<Integer, CharSequence> storage = HashMultimap.create();
+    private final LinkedHashMultimap<Integer, CharSequence> storage =
+        LinkedHashMultimap.create();
     private final int size;
+
+    public ImmutableCharSequenceSet(Object... strings) {
+      int count = 0;
+      for (Object obj : strings) {
+        CharSequence seq = (CharSequence) obj;
+        // like guava collections, do not allow null
+        Preconditions.checkNotNull(seq, "Null values are not allowed");
+        if (!contains(seq)) { // don't add duplicates
+          storage.put(CharSequences.hashCode(seq), seq);
+          count += 1;
+        }
+      }
+      this.size = count;
+    }
 
     public ImmutableCharSequenceSet(Iterable<? extends CharSequence> strings) {
       int count = 0;

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/predicates/In.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/predicates/In.java
@@ -42,7 +42,7 @@ public class In<T> extends RegisteredPredicate<T> {
   }
 
   public static <T> In<T> fromString(String set, Schema schema) {
-    Set<T> values = Sets.newHashSet();
+    Set<T> values = Sets.newLinkedHashSet();
     for (String value : Splitter.on(',').split(set)) {
       values.add(SchemaUtil.<T>fromString(value, schema));
     }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/predicates/Predicates.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/predicates/Predicates.java
@@ -44,8 +44,7 @@ public abstract class Predicates {
   public static <T> In<T> in(T... set) {
     T item = set[0];
     if (item != null && item instanceof CharSequence) {
-      return (In<T>) new In(new CharSequences.ImmutableCharSequenceSet(
-          (Set<CharSequence>) Sets.newHashSet(set)));
+      return (In<T>) new In(new CharSequences.ImmutableCharSequenceSet(set));
     }
     return new In<T>(set);
   }

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/TestViewUris.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/TestViewUris.java
@@ -17,6 +17,7 @@
 package org.kitesdk.data.spi;
 
 import java.net.URI;
+import java.util.UUID;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericRecord;
@@ -119,6 +120,23 @@ public class TestViewUris {
     assertViewUriEquivalent("encoded multi-value constraints",
         "view:file:/tmp/test_name?color=a%2Cb,c",
         test.with("color", "a,b", "c"));
+  }
+
+  @Test
+  public void testURIStringEquality() {
+    for(int i = 0; i < 10; i++) {
+      String a = UUID.randomUUID().toString();
+      String b = UUID.randomUUID().toString();
+      String originalUri = "view:file:/tmp/test_name?color="+ a + "," + b;
+      View<GenericRecord> view = Datasets.load(originalUri);
+      String afterUri = view.getUri().toString();
+      if(!originalUri.equals(afterUri)) {
+        System.out.println("Iteration: " + i);
+        System.out.println("Start: " + originalUri);
+        System.out.println("End  : " + afterUri);
+      }
+      Assert.assertEquals(originalUri, afterUri);
+    }
   }
 
   public void assertViewUriEquivalent(String desc, String uri,


### PR DESCRIPTION
Tracked down more hash sets in use and replaced with linked hash sets.