### PR TITLE
CDK-1011: Support a configurable number of writers per partition when…

### DIFF
--- a/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/CompactCommand.java
+++ b/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/CompactCommand.java
@@ -43,6 +43,10 @@ public class CompactCommand extends BaseDatasetCommand {
       description="The number of writer processes to use")
   int numWriters = -1;
 
+  @Parameter(names={"--files-per-partition"},
+      description="The number of files per partition to create")
+  int numPartitionWriters = -1;
+
   @Override
   public int run() throws IOException {
     Preconditions.checkArgument(datasets.size() == 1,
@@ -62,6 +66,10 @@ public class CompactCommand extends BaseDatasetCommand {
 
     if (numWriters >= 0) {
       task.setNumWriters(numWriters);
+    }
+
+    if (numPartitionWriters >= 0) {
+      task.setNumPartitionWriters(numPartitionWriters);
     }
 
     PipelineResult result = task.run();

--- a/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/CopyCommand.java
+++ b/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/CopyCommand.java
@@ -48,6 +48,10 @@ public class CopyCommand extends BaseDatasetCommand {
       description="The number of writer processes to use")
   int numWriters = -1;
 
+  @Parameter(names={"--files-per-partition"},
+      description="The number of files per partition to create")
+  int numPartitionWriters = -1;
+
   @Parameter(
       names={"--overwrite"},
       description="Remove any data already in the target view or dataset")
@@ -73,6 +77,10 @@ public class CopyCommand extends BaseDatasetCommand {
 
     if (numWriters >= 0) {
       task.setNumWriters(numWriters);
+    }
+
+    if (numPartitionWriters >= 0) {
+      task.setNumWriters(numPartitionWriters);
     }
 
     if (overwrite) {

--- a/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/tools/CompactionTask.java
+++ b/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/tools/CompactionTask.java
@@ -62,6 +62,10 @@ public class CompactionTask<T> implements Configurable {
     return task.getConf();
   }
 
+  public void setNumPartitionWriters(int numPartitionWriters) {
+    task.setNumPartitionWriters(numPartitionWriters);
+  }
+
   @SuppressWarnings("unchecked")
   private void checkCompactable(View<T> view) {
     Dataset<T> dataset = view.getDataset();

--- a/kite-tools-parent/kite-tools/src/test/java/org/kitesdk/cli/commands/TestCompactCommandCluster.java
+++ b/kite-tools-parent/kite-tools/src/test/java/org/kitesdk/cli/commands/TestCompactCommandCluster.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2013 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.cli.commands;
+
+import com.beust.jcommander.internal.Lists;
+import com.google.common.collect.Iterators;
+import com.google.common.io.Files;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.LocalJobRunner;
+import org.apache.hadoop.mapreduce.Job;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.kitesdk.cli.TestUtil;
+import org.kitesdk.compat.DynMethods;
+import org.kitesdk.compat.Hadoop;
+import org.kitesdk.data.Dataset;
+import org.kitesdk.data.DatasetDescriptor;
+import org.kitesdk.data.Datasets;
+import org.kitesdk.data.MiniDFSTest;
+import org.kitesdk.data.PartitionStrategy;
+import org.kitesdk.data.URIBuilder;
+import org.kitesdk.data.spi.DatasetRepositories;
+import org.kitesdk.data.spi.DatasetRepository;
+import org.kitesdk.data.spi.filesystem.DatasetTestUtilities;
+import org.kitesdk.data.spi.filesystem.FileSystemDataset;
+import org.slf4j.Logger;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.net.URI;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class TestCompactCommandCluster extends MiniDFSTest {
+
+  private static final String source = "users_source";
+  private static final String source_partitioned = "users_source_partitioned";
+  private static final String avsc = "target/user.avsc";
+  private static String repoUri;
+  private int numRecords;
+
+  @Before
+  public void createDatasets() throws Exception {
+    repoUri = "hdfs://" + getDFS().getUri().getAuthority() + "/tmp/data";
+    TestUtil.run("delete", source, "-r", repoUri, "-d", "target/data");
+
+    String csv = "target/users.csv";
+    BufferedWriter writer = Files.newWriter(
+        new File(csv), CSVSchemaCommand.SCHEMA_CHARSET);
+
+    writer.append("id,username,email\n");
+    numRecords = 10;
+    for(int i = 0; i < numRecords; i++) {
+      writer.append(i+",test"+i+",test"+i+"@example.com\n");
+    }
+    writer.close();
+
+    TestUtil.run("-v", "csv-schema", csv, "-o", avsc, "--class", "User");
+    TestUtil.run("create", source, "-s", avsc,
+        "-r", repoUri, "-d", "target/data");
+
+    URI dsUri = URIBuilder.build("repo:" + repoUri, "default", source_partitioned);
+    Datasets.<Object, Dataset<Object>>create(dsUri, new DatasetDescriptor.Builder()
+        .partitionStrategy(new PartitionStrategy.Builder()
+            .hash("id", 2)
+            .build())
+        .schema(SchemaBuilder.record("User").fields()
+            .requiredLong("id")
+            .optionalString("username")
+            .optionalString("email")
+            .endRecord())
+        .build(), Object.class);
+
+
+    TestUtil.run("csv-import", csv, source, "-r", repoUri, "-d", "target/data");
+    TestUtil.run("csv-import", csv, source_partitioned, "-r", repoUri, "-d", "target/data");
+  }
+
+  @Before
+  public void createCommand(){
+    this.console = mock(Logger.class);
+    this.command = new CompactCommand(console);
+    command.setConf(new Configuration());
+  }
+
+  @After
+  public void deleteSourceDatasets() throws Exception {
+    TestUtil.run("delete", source, "-r", repoUri, "-d", "target/data");
+    TestUtil.run("delete", source_partitioned, "-r", repoUri, "-d", "target/data");
+  }
+
+  private Logger console;
+  private CompactCommand command;
+
+  @Test
+  public void testBasicCompact() throws Exception {
+    command.repoURI = repoUri;
+    command.datasets = Lists.newArrayList(source);
+
+    int rc = command.run();
+    Assert.assertEquals("Should return success", 0, rc);
+
+    DatasetRepository repo = DatasetRepositories.repositoryFor("repo:" + repoUri);
+    int size = DatasetTestUtilities.datasetSize(repo.load("default", source));
+    Assert.assertEquals("Should contain copied records", numRecords, size);
+
+    verify(console).info("Compacted {} records in \"{}\"", (long)numRecords, source);
+    verifyNoMoreInteractions(console);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testCompactWithNumWriters() throws Exception {
+    Assume.assumeTrue(setLocalReducerMax(getConfiguration(), 3));
+
+    command.repoURI = repoUri;
+    command.numWriters = 3;
+    command.datasets = Lists.newArrayList(source);
+
+    int rc = command.run();
+    Assert.assertEquals("Should return success", 0, rc);
+
+    DatasetRepository repo = DatasetRepositories.repositoryFor("repo:" + repoUri);
+    FileSystemDataset<GenericData.Record> ds =
+        (FileSystemDataset<GenericData.Record>) repo.<GenericData.Record>
+            load("default", source);
+    int size = DatasetTestUtilities.datasetSize(ds);
+    Assert.assertEquals("Should contain copied records", numRecords, size);
+
+    Assert.assertEquals("Should produce 3 files",
+        3, Iterators.size(ds.pathIterator()));
+
+    verify(console).info("Compacted {} records in \"{}\"",(long) numRecords, source);
+    verifyNoMoreInteractions(console);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testCompactWithNumPartitionWriters() throws Exception {
+    Assume.assumeTrue(setLocalReducerMax(getConfiguration(), 3));
+
+    command.repoURI = repoUri;
+    command.numWriters = 3;
+    command.numPartitionWriters = 4;
+    command.datasets = Lists.newArrayList(source);
+
+    int rc = command.run();
+    Assert.assertEquals("Should return success", 0, rc);
+
+    DatasetRepository repo = DatasetRepositories.repositoryFor("repo:" + repoUri);
+    FileSystemDataset<GenericData.Record> ds =
+        (FileSystemDataset<GenericData.Record>) repo.<GenericData.Record>
+            load("default", source);
+    int size = DatasetTestUtilities.datasetSize(ds);
+    Assert.assertEquals("Should contain copied records", numRecords, size);
+
+    //ignore the numPartitionWriters
+    Assert.assertEquals("Should produce 3 files",
+        3, Iterators.size(ds.pathIterator()));
+
+    verify(console).info("Compacted {} records in \"{}\"", (long)numRecords, source);
+    verifyNoMoreInteractions(console);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testPartitionedCompactWithNumWriters() throws Exception {
+    Assume.assumeTrue(setLocalReducerMax(getConfiguration(), 2));
+    command.repoURI = repoUri;
+    command.numWriters = 2;
+    command.numPartitionWriters = 1;
+    command.datasets = Lists.newArrayList(source_partitioned);
+
+    int rc = command.run();
+    Assert.assertEquals("Should return success", 0, rc);
+
+    DatasetRepository repo = DatasetRepositories.repositoryFor("repo:" + repoUri);
+    FileSystemDataset<GenericData.Record> ds =
+        (FileSystemDataset<GenericData.Record>) repo.<GenericData.Record>
+            load("default", source_partitioned);
+    int size = DatasetTestUtilities.datasetSize(ds);
+    Assert.assertEquals("Should contain copied records", numRecords, size);
+
+    Assert.assertEquals("Should produce 2 partitions", 2, Iterators.size(ds.getCoveringPartitions().iterator()));
+
+    verify(console).info("Compacted {} records in \"{}\"", (long) numRecords, source_partitioned);
+    verifyNoMoreInteractions(console);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testPartitionedCompactWithNumWritersNumFilesPerPartition() throws Exception {
+    Assume.assumeTrue(setLocalReducerMax(getConfiguration(), 5));
+    command.repoURI = repoUri;
+    command.numWriters = 1;
+    command.numPartitionWriters = 5;
+    command.datasets = Lists.newArrayList(source_partitioned);
+
+    int rc = command.run();
+    Assert.assertEquals("Should return success", 0, rc);
+
+    DatasetRepository repo = DatasetRepositories.repositoryFor("repo:" + repoUri);
+    FileSystemDataset<GenericData.Record> ds =
+        (FileSystemDataset<GenericData.Record>) repo.<GenericData.Record>
+            load("default", source_partitioned);
+    int size = DatasetTestUtilities.datasetSize(ds);
+    Assert.assertEquals("Should contain copied records", numRecords, size);
+
+    Assert.assertEquals("Should produce 2 partitions", 2, Iterators.size(ds.getCoveringPartitions().iterator()));
+
+    verify(console).info("Compacted {} records in \"{}\"", (long)numRecords, source_partitioned);
+    verifyNoMoreInteractions(console);
+  }
+
+  private boolean setLocalReducerMax(Configuration conf, int max) {
+    try {
+      Job job = Hadoop.Job.newInstance.invoke(new Configuration(false));
+      DynMethods.StaticMethod setReducerMax = new DynMethods
+          .Builder("setLocalMaxRunningReduces")
+          .impl(LocalJobRunner.class,
+              org.apache.hadoop.mapreduce.JobContext.class, Integer.TYPE)
+          .buildStaticChecked();
+      setReducerMax.invoke(job, max);
+      // copy the setting into the passed configuration
+      Configuration jobConf = Hadoop.JobContext.getConfiguration.invoke(job);
+      for (Map.Entry<String, String> entry : jobConf) {
+        conf.set(entry.getKey(), entry.getValue());
+      }
+      return true;
+    } catch (NoSuchMethodException e) {
+      return false;
+    }
+  }
+}

--- a/kite-tools-parent/kite-tools/src/test/java/org/kitesdk/cli/commands/TestCopyCommandCluster.java
+++ b/kite-tools-parent/kite-tools/src/test/java/org/kitesdk/cli/commands/TestCopyCommandCluster.java
@@ -61,6 +61,7 @@ public class TestCopyCommandCluster extends MiniDFSTest {
 
   private static final String source = "users_source";
   private static final String dest = "users_dest";
+  private static final String dest_partitioned = "users_dest_partitioned";
   private static final String avsc = "target/user.avsc";
   private static final Pattern UPPER_CASE = Pattern.compile("^[A-Z]+\\d*$");
   private static String repoUri;
@@ -108,6 +109,7 @@ public class TestCopyCommandCluster extends MiniDFSTest {
   @After
   public void deleteDestination() throws Exception {
     TestUtil.run("delete", dest, "-r", repoUri, "-d", "target/data");
+    TestUtil.run("delete", dest_partitioned, "-r", repoUri, "-d", "target/data");
   }
 
   @Test
@@ -175,6 +177,33 @@ public class TestCopyCommandCluster extends MiniDFSTest {
     verifyNoMoreInteractions(console);
   }
 
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testCopyWithNumPartitionWriters() throws Exception {
+    Assume.assumeTrue(setLocalReducerMax(getConfiguration(), 3));
+
+    command.repoURI = repoUri;
+    command.numWriters = 3;
+    command.numPartitionWriters = 4;
+    command.datasets = Lists.newArrayList(source, dest);
+
+    int rc = command.run();
+    Assert.assertEquals("Should return success", 0, rc);
+
+    DatasetRepository repo = DatasetRepositories.repositoryFor("repo:" + repoUri);
+    FileSystemDataset<GenericData.Record> ds =
+        (FileSystemDataset<GenericData.Record>) repo.<GenericData.Record>
+            load("default", dest);
+    int size = DatasetTestUtilities.datasetSize(ds);
+    Assert.assertEquals("Should contain copied records", 6, size);
+
+    Assert.assertEquals("Should produce 4 files",
+        4, Iterators.size(ds.pathIterator()));
+
+    verify(console).info("Added {} records to \"{}\"", 6l, dest);
+    verifyNoMoreInteractions(console);
+  }
+
   private boolean setLocalReducerMax(Configuration conf, int max) {
     try {
       Job job = Hadoop.Job.newInstance.invoke(new Configuration(false));
@@ -200,8 +229,8 @@ public class TestCopyCommandCluster extends MiniDFSTest {
   public void testPartitionedCopyWithNumWriters() throws Exception {
     command.repoURI = repoUri;
     command.numWriters = 3;
-    command.datasets = Lists.newArrayList(source, "dest_partitioned");
-    URI dsUri = URIBuilder.build("repo:" + repoUri, "default", "dest_partitioned");
+    command.datasets = Lists.newArrayList(source, dest_partitioned);
+    URI dsUri = URIBuilder.build("repo:" + repoUri, "default", dest_partitioned);
     Datasets.<Object, Dataset<Object>>create(dsUri, new DatasetDescriptor.Builder()
         .partitionStrategy(new PartitionStrategy.Builder()
             .hash("id", 2)
@@ -219,14 +248,50 @@ public class TestCopyCommandCluster extends MiniDFSTest {
     DatasetRepository repo = DatasetRepositories.repositoryFor("repo:" + repoUri);
     FileSystemDataset<GenericData.Record> ds =
         (FileSystemDataset<GenericData.Record>) repo.<GenericData.Record>
-            load("default", "dest_partitioned");
+            load("default", dest_partitioned);
     int size = DatasetTestUtilities.datasetSize(ds);
     Assert.assertEquals("Should contain copied records", 6, size);
 
     Assert.assertEquals("Should produce 2 partitions",
         2, Iterators.size(ds.pathIterator()));
 
-    verify(console).info("Added {} records to \"{}\"", 6l, "dest_partitioned");
+    verify(console).info("Added {} records to \"{}\"", 6l, dest_partitioned);
+    verifyNoMoreInteractions(console);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testPartitionedCopyWithNumWritersNumFilesPerPartition() throws Exception {
+    command.repoURI = repoUri;
+    command.numWriters = 1;
+    command.numPartitionWriters = 5;
+    command.datasets = Lists.newArrayList(source, dest_partitioned);
+    URI dsUri = URIBuilder.build("repo:" + repoUri, "default", dest_partitioned);
+    Datasets.<Object, Dataset<Object>>create(dsUri, new DatasetDescriptor.Builder()
+        .partitionStrategy(new PartitionStrategy.Builder()
+            .hash("id", 2)
+            .build())
+        .schema(SchemaBuilder.record("User").fields()
+            .requiredLong("id")
+            .optionalString("username")
+            .optionalString("email")
+            .endRecord())
+        .build(), Object.class);
+
+    int rc = command.run();
+    Assert.assertEquals("Should return success", 0, rc);
+
+    DatasetRepository repo = DatasetRepositories.repositoryFor("repo:" + repoUri);
+    FileSystemDataset<GenericData.Record> ds =
+        (FileSystemDataset<GenericData.Record>) repo.<GenericData.Record>
+            load("default", dest_partitioned);
+    int size = DatasetTestUtilities.datasetSize(ds);
+    Assert.assertEquals("Should contain copied records", 6, size);
+
+    Assert.assertEquals("Should produce 2 partitions",
+        2, Iterators.size(ds.pathIterator()));
+
+    verify(console).info("Added {} records to \"{}\"", 6l, dest_partitioned);
     verifyNoMoreInteractions(console);
   }
 


### PR DESCRIPTION
… writing to a dataset, along with copying and compaction.

I didn't see any current tests for the CrunchDatasets.partition(...) method or CompactionCommand/Task.  I can add some if necessary.