### PR TITLE
CDK-1016: Fix OutputFormat writing directly to datasets.

### DIFF
--- a/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/DatasetKeyOutputFormat.java
+++ b/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/DatasetKeyOutputFormat.java
@@ -461,7 +461,7 @@ public class DatasetKeyOutputFormat<E> extends OutputFormat<E, Void> {
       }
       FileSystemDataset fsDataset = (FileSystemDataset) target;
       PartitionKey key = fsDataset.keyFromDirectory(new Path(partitionDir));
-      if (key != null) {
+      if (key != null && !key.getValues().isEmpty()) {
         working = fsDataset.getPartition(key, true);
       }
       return new DatasetRecordWriter<E>(working);


### PR DESCRIPTION
This happens only when a dataset instance is passed to the configuration
methods. The fix is to verify that the target dataset is not the root by
inspecting whether the partition key has any values.