### PR TITLE
CDK-1018: Avoid unnecessary copy in MR output format.

### DIFF
--- a/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/DatasetKeyOutputFormat.java
+++ b/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/DatasetKeyOutputFormat.java
@@ -21,7 +21,6 @@ import java.net.URI;
 import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
-import org.apache.avro.reflect.ReflectData;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.Job;
@@ -72,6 +71,7 @@ public class DatasetKeyOutputFormat<E> extends OutputFormat<E, Void> {
   public static final String KITE_PARTITION_DIR = "kite.outputPartitionDir";
   public static final String KITE_TYPE = "kite.outputEntityType";
   public static final String KITE_WRITE_MODE = "kite.outputMode";
+  public static final String KITE_COPY_RECORDS = "kite.copyOutputRecords";
 
   public enum WriteMode {
     DEFAULT, APPEND, OVERWRITE
@@ -306,23 +306,21 @@ public class DatasetKeyOutputFormat<E> extends OutputFormat<E, Void> {
 
     private DatasetWriter<E> datasetWriter;
     private GenericData dataModel;
-    private boolean copyEntities;
+    private boolean copyRecords;
     private Schema schema;
 
-    public DatasetRecordWriter(View<E> view) {
+    public DatasetRecordWriter(View<E> view, boolean copyRecords) {
       this.datasetWriter = view.newWriter();
 
       this.schema = view.getDataset().getDescriptor().getSchema();
       this.dataModel = DataModelUtil.getDataModelForType(
           view.getType());
-      if (dataModel.getClass() != ReflectData.class) {
-        copyEntities = true;
-      }
+      this.copyRecords = copyRecords;
     }
 
     @Override
     public void write(E key, Void v) {
-      if (copyEntities) {
+      if (copyRecords) {
         key = copy(key);
       }
       datasetWriter.write(key);
@@ -453,6 +451,8 @@ public class DatasetKeyOutputFormat<E> extends OutputFormat<E, Void> {
       working = target;
     }
 
+    boolean copyRecords = conf.getBoolean(KITE_COPY_RECORDS, false);
+
     String partitionDir = conf.get(KITE_PARTITION_DIR);
     if (working.getDataset().getDescriptor().isPartitioned() &&
         partitionDir != null) {
@@ -465,9 +465,9 @@ public class DatasetKeyOutputFormat<E> extends OutputFormat<E, Void> {
       if (key != null && !key.getValues().isEmpty()) {
         working = fsDataset.getPartition(key, true);
       }
-      return new DatasetRecordWriter<E>(working);
+      return new DatasetRecordWriter<E>(working, copyRecords);
     } else {
-      return new DatasetRecordWriter<E>(working);
+      return new DatasetRecordWriter<E>(working, copyRecords);
     }
   }
 

--- a/kite-data/kite-data-mapreduce/src/test/java/org/kitesdk/data/mapreduce/TestDatasetRecordWriter.java
+++ b/kite-data/kite-data-mapreduce/src/test/java/org/kitesdk/data/mapreduce/TestDatasetRecordWriter.java
@@ -26,6 +26,7 @@ import org.junit.runners.Parameterized;
 import org.kitesdk.data.Dataset;
 import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.Format;
+import org.kitesdk.data.mapreduce.DatasetKeyOutputFormat.DatasetRecordWriter;
 import org.kitesdk.data.spi.SchemaValidationUtil;
 
 @RunWith(Parameterized.class)
@@ -51,9 +52,8 @@ public class TestDatasetRecordWriter extends FileSystemTestBase {
 
   @Test
   public void testBasicRecordWriter() {
-    DatasetKeyOutputFormat.DatasetRecordWriter<GenericData.Record> recordWriter;
-    recordWriter =
-      new DatasetKeyOutputFormat.DatasetRecordWriter<GenericData.Record>(dataset);
+    DatasetRecordWriter<GenericData.Record> recordWriter;
+    recordWriter = new DatasetRecordWriter<GenericData.Record>(dataset, false);
 
     ImmutableList<Integer> counts = ImmutableList.of(1, 2, 3, 4, 5, 6, 7, 8, 9,
       10);

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
     <vers.mockito>1.9.5</vers.mockito>
     <vers.mojo-executor>1.5</vers.mojo-executor>
     <vers.oozie>3.3.2-cdh${cdh.version}</vers.oozie> <!-- OOZIE-1790 -->
-    <vers.parquet>1.4.1</vers.parquet>
+    <vers.parquet>1.6.0</vers.parquet>
     <vers.plexus-utils>3.0</vers.plexus-utils>
     <vers.rat>0.9</vers.rat>
     <vers.slf4j>1.6.1</vers.slf4j>


### PR DESCRIPTION
It appears that this was working around PARQUET-62, which fixed
dictionary support when incoming records are reused. Updating to 1.6.0
brings in the Parquet fix.

This also adds a property, kite.copyOutputRecords, that allows users to
control whether records should be copied. This defaults to false, but is
a good safety valve in case of other bugs like PARQUET-62.