### PR TITLE
CDK-1019: Move Hive token setup into TransformTask.

### DIFF
--- a/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/CopyCommand.java
+++ b/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/CopyCommand.java
@@ -29,14 +29,6 @@ import org.kitesdk.data.View;
 import org.kitesdk.tools.CopyTask;
 import org.slf4j.Logger;
 
-import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
-import org.apache.hadoop.hive.thrift.DelegationTokenIdentifier;
-import org.apache.hadoop.io.Text;
-import org.apache.hadoop.mapred.JobConf;
-import org.apache.hadoop.security.token.Token;
-import org.apache.thrift.TException;
-
 @Parameters(commandDescription="Copy records from one Dataset to another")
 public class CopyCommand extends BaseDatasetCommand {
 
@@ -77,23 +69,7 @@ public class CopyCommand extends BaseDatasetCommand {
 
     CopyTask task = new CopyTask<GenericRecord>(source, dest);
 
-    JobConf conf = new JobConf(getConf());
-
-    try {
-      if ((isHiveView(source) || isHiveView(dest))
-          && conf.getBoolean(HiveConf.ConfVars.METASTORE_USE_THRIFT_SASL.varname, false)) {
-        // Need to set up delegation token auth
-        HiveMetaStoreClient metaStoreClient = new HiveMetaStoreClient(new HiveConf());
-        String hiveTokenStr = metaStoreClient.getDelegationToken("yarn");
-        Token<DelegationTokenIdentifier> hiveToken = new Token<DelegationTokenIdentifier>();
-        hiveToken.decodeFromUrlString(hiveTokenStr);
-        conf.getCredentials().addToken(new Text("HIVE_METASTORE_TOKEN"), hiveToken);
-    }
-    } catch (TException ex) {
-      throw new RuntimeException("Unable to obtain Hive delegation token");
-    }
-
-    task.setConf(conf);
+    task.setConf(getConf());
 
     if (noCompaction) {
       task.noCompaction();
@@ -130,9 +106,5 @@ public class CopyCommand extends BaseDatasetCommand {
         "# Copy the movies dataset into HBase in a map-only job",
         "movies dataset:hbase:zk-host/movies --no-compaction"
     );
-  }
-
-  private boolean isHiveView(View<?> view) {
-    return view.getDataset().getUri().toString().startsWith("dataset:hive:");
   }
 }

--- a/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/tools/TransformTask.java
+++ b/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/tools/TransformTask.java
@@ -35,6 +35,12 @@ import org.apache.crunch.types.avro.Avros;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.thrift.DelegationTokenIdentifier;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.security.token.Token;
+import org.apache.thrift.TException;
 import org.kitesdk.compat.DynMethods;
 import org.kitesdk.data.Dataset;
 import org.kitesdk.data.DatasetException;
@@ -122,6 +128,10 @@ public class TransformTask<S, T> extends Configured {
       setConf(conf);
     }
 
+    if (isHive(from) || isHive(to)) {
+      setConf(addHiveDelegationToken(getConf()));
+    }
+
     PType<T> toPType = ptype(to);
     MapFn<T, T> validate = new CheckEntityClass<T>(to.getType());
 
@@ -185,6 +195,37 @@ public class TransformTask<S, T> extends Configured {
             "Object does not match expected type " + entityClass +
             ": " + String.valueOf(input));
       }
+    }
+  }
+
+  private static boolean isHive(View<?> view) {
+    return "hive".equals(
+        URI.create(view.getUri().getSchemeSpecificPart()).getScheme());
+  }
+
+  private static final Text HIVE_MS_TOKEN_ALIAS = new Text("HIVE_METASTORE_TOKEN");
+
+  private static Configuration addHiveDelegationToken(Configuration conf) {
+    // this uses a JobConf because we don't have access to the MR Job
+    JobConf jobConf = new JobConf(conf);
+
+    try {
+      if (conf.getBoolean(
+          HiveConf.ConfVars.METASTORE_USE_THRIFT_SASL.varname, false)) {
+        // Need to set up delegation token auth
+        HiveMetaStoreClient metaStoreClient = new HiveMetaStoreClient(new HiveConf());
+        String hiveTokenStr = metaStoreClient.getDelegationToken("yarn");
+        Token<DelegationTokenIdentifier> hiveToken = new Token<DelegationTokenIdentifier>();
+        hiveToken.decodeFromUrlString(hiveTokenStr);
+        jobConf.getCredentials().addToken(HIVE_MS_TOKEN_ALIAS, hiveToken);
+      }
+
+      return jobConf;
+
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to obtain Hive delegation token", e);
+    } catch (TException e) {
+      throw new RuntimeException("Unable to obtain Hive delegation token", e);
     }
   }
 }


### PR DESCRIPTION
This takes the delegation token code from the CopyCommand and moves it
into TransformTask so that all of the transform-based commands will work
with Hive.