### PR TITLE
CDK-991: Add size-based and time-based file rolling.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/ClockReady.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/ClockReady.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data.spi;
+
+/**
+ * Classes that can perform time-based operations implement this interface to
+ * accept clock ticks. Classes that are ClockReady do not perform clock-aware
+ * operations unless {@link #tick()} is called to provide a clock signal.
+ * <p>
+ * Implementing classes should document thread-safety guarantees, though none
+ * are required.
+ */
+public interface ClockReady {
+  /**
+   * Called to provide a clock signal to the implementing class.
+   */
+  void tick();
+}

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/DescriptorUtil.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/DescriptorUtil.java
@@ -49,4 +49,49 @@ public class DescriptorUtil {
     }
     return false;
   }
+
+  /**
+   * Returns the value of the property parsed as a long, or the default value.
+   * <p>
+   * If the value cannot be parsed as a long, this will return the default
+   * value.
+   *
+   * @param prop a String property name
+   * @param descriptor a {@link DatasetDescriptor}
+   * @param defaultValue default value if prop is not present or is invalid
+   * @return the value of prop parsed as a long or the default value
+   */
+  public static long getLong(String prop, DatasetDescriptor descriptor,
+                             long defaultValue) {
+    if (descriptor.hasProperty(prop)) {
+      String asString = descriptor.getProperty(prop);
+      try {
+        return Long.parseLong(asString);
+      } catch (NumberFormatException e) {
+        // return the default value
+      }
+    }
+    return defaultValue;
+  }
+
+  /**
+   * Returns the value of the property parsed as an int, or the default value.
+   * <p>
+   * If the value cannot be parsed as an int or if the value is larger than the
+   * maximum value of an int, this will return the default value.
+   *
+   * @param prop a String property name
+   * @param descriptor a {@link DatasetDescriptor}
+   * @param defaultValue default value if prop is not present or is invalid
+   * @return the value of prop parsed as an int or the default value
+   */
+  public static int getInt(String prop, DatasetDescriptor descriptor,
+                            int defaultValue) {
+    long asLong = getLong(prop, descriptor, defaultValue);
+    if (asLong > Integer.MAX_VALUE) {
+      return defaultValue;
+    } else {
+      return (int) asLong;
+    }
+  }
 }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/RollingWriter.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/RollingWriter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data.spi;
+
+/**
+ * Datasets writers that can perform time-based and size-based rolling should
+ * implement this interface to allow callers to configure the current roll
+ * settings and to provide a clock signal for time-based rolling.
+ */
+public interface RollingWriter extends ClockReady {
+  void setRollIntervalMillis(long rollIntervalMillis);
+  void setTargetFileSize(long targetSizeBytes);
+}

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/AvroAppender.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/AvroAppender.java
@@ -76,6 +76,11 @@ class AvroAppender<E> implements FileSystemWriter.FileAppender<E> {
   }
 
   @Override
+  public long pos() throws IOException {
+    return out.getPos();
+  }
+
+  @Override
   public void flush() throws IOException {
     // Avro sync forces the end of the current block so the data is recoverable
     dataFileWriter.flush();

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVAppender.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/CSVAppender.java
@@ -62,6 +62,11 @@ class CSVAppender<E> implements FileSystemWriter.FileAppender<E> {
   }
 
   @Override
+  public long pos() throws IOException {
+    return outgoing.getPos();
+  }
+
+  @Override
   public void close() throws IOException {
     writer.close();
     outgoing.close();

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/DurableParquetAppender.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/DurableParquetAppender.java
@@ -64,6 +64,12 @@ class DurableParquetAppender<E extends IndexedRecord> implements FileSystemWrite
   }
 
   @Override
+  public long pos() throws IOException {
+    // based on final Parquet file size, not temporary Avro size
+    return parquetAppender.pos();
+  }
+
+  @Override
   public void flush() throws IOException {
     avroAppender.flush();
   }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemProperties.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemProperties.java
@@ -48,4 +48,16 @@ public class FileSystemProperties {
    * Used to enable record reuse, if supported by the implementation.
    */
   public static final String REUSE_RECORDS = "kite.reader.reuse-records";
+
+  /**
+   * Used to set the target size, in bytes, for data files. Data files will be
+   * closed and finalized once they reach this size.
+   */
+  public static final String TARGET_FILE_SIZE_PROP = "kite.writer.target-file-size";
+
+  /**
+   * Used to set the roll interval, in seconds, for data files. Data files will
+   * be closed and finalized once they reach this age.
+   */
+  public static final String ROLL_INTERVAL_S_PROP = "kite.writer.roll-interval-seconds";
 }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemView.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemView.java
@@ -117,7 +117,8 @@ class FileSystemView<E> extends AbstractRefinableView<E> implements InputFormatA
     if (dataset.getDescriptor().isPartitioned()) {
       writer = PartitionedDatasetWriter.newWriter(this);
     } else {
-      writer = FileSystemWriter.newWriter(fs, root, dataset.getDescriptor());
+      writer = FileSystemWriter.newWriter(
+          fs, root, -1, -1 /* get from descriptor */, dataset.getDescriptor());
     }
     writer.initialize();
     return writer;

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/PartitionedDatasetWriter.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/PartitionedDatasetWriter.java
@@ -27,8 +27,8 @@ import org.kitesdk.data.ValidationException;
 import org.kitesdk.data.spi.AbstractDatasetWriter;
 import org.kitesdk.data.spi.DescriptorUtil;
 import org.kitesdk.data.spi.EntityAccessor;
-import org.kitesdk.data.spi.FieldPartitioner;
 import org.kitesdk.data.spi.PartitionListener;
+import org.kitesdk.data.spi.RollingWriter;
 import org.kitesdk.data.spi.StorageKey;
 import org.kitesdk.data.spi.ReaderWriterState;
 import com.google.common.base.Objects;
@@ -44,10 +44,12 @@ import org.kitesdk.data.spi.ClockReady;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.kitesdk.data.spi.filesystem.FileSystemProperties.ROLL_INTERVAL_S_PROP;
+import static org.kitesdk.data.spi.filesystem.FileSystemProperties.TARGET_FILE_SIZE_PROP;
 import static org.kitesdk.data.spi.filesystem.FileSystemProperties.WRITER_CACHE_SIZE_PROP;
 
 abstract class PartitionedDatasetWriter<E, W extends FileSystemWriter<E>>
-    extends AbstractDatasetWriter<E> implements ClockReady {
+    extends AbstractDatasetWriter<E> implements RollingWriter {
 
   private static final Logger LOG = LoggerFactory
     .getLogger(PartitionedDatasetWriter.class);
@@ -65,6 +67,17 @@ abstract class PartitionedDatasetWriter<E, W extends FileSystemWriter<E>>
   private final Map<String, Object> provided;
 
   protected ReaderWriterState state;
+  protected long targetFileSize;
+  protected long rollIntervalMillis;
+
+  /**
+   * Accessor for the cache loaders to use the current roll config values.
+   */
+  public interface ConfAccessor {
+    long getTargetFileSize();
+
+    long getRollIntervalMillis();
+  }
 
   static <E> PartitionedDatasetWriter<E, ?> newWriter(FileSystemView<E> view) {
     DatasetDescriptor descriptor = view.getDataset().getDescriptor();
@@ -92,13 +105,27 @@ abstract class PartitionedDatasetWriter<E, W extends FileSystemWriter<E>>
     this.view = view;
     this.partitionStrategy = descriptor.getPartitionStrategy();
 
+    int defaultMaxWriters = partitionStrategy.getCardinality();
+    if (defaultMaxWriters < 0 || defaultMaxWriters > DEFAULT_WRITER_CACHE_SIZE) {
+      defaultMaxWriters = DEFAULT_WRITER_CACHE_SIZE;
+    }
     this.maxWriters = DescriptorUtil.getInt(WRITER_CACHE_SIZE_PROP, descriptor,
-        Math.min(DEFAULT_WRITER_CACHE_SIZE, partitionStrategy.getCardinality()));
+        defaultMaxWriters);
 
     this.state = ReaderWriterState.NEW;
     this.reusedKey = new StorageKey(partitionStrategy);
     this.accessor = view.getAccessor();
     this.provided = view.getProvidedValues();
+
+    // get file rolling properties
+    if (!Formats.PARQUET.equals(descriptor.getFormat())) {
+      this.targetFileSize = DescriptorUtil.getLong(
+          TARGET_FILE_SIZE_PROP, descriptor, -1);
+    } else {
+      targetFileSize = -1;
+    }
+    this.rollIntervalMillis = 1000 * DescriptorUtil.getLong(
+        ROLL_INTERVAL_S_PROP, descriptor, -1);
   }
 
   @Override
@@ -165,6 +192,30 @@ abstract class PartitionedDatasetWriter<E, W extends FileSystemWriter<E>>
   }
 
   @Override
+  public void setRollIntervalMillis(long rollIntervalMillis) {
+    this.rollIntervalMillis = rollIntervalMillis;
+    if (ReaderWriterState.OPEN == state) {
+      for (DatasetWriter<E> writer : cachedWriters.asMap().values()) {
+        if (writer instanceof RollingWriter) {
+          ((RollingWriter) writer).setRollIntervalMillis(rollIntervalMillis);
+        }
+      }
+    }
+  }
+
+  @Override
+  public void setTargetFileSize(long targetSizeBytes) {
+    this.targetFileSize = targetSizeBytes;
+    if (ReaderWriterState.OPEN == state) {
+      for (DatasetWriter<E> writer : cachedWriters.asMap().values()) {
+        if (writer instanceof RollingWriter) {
+          ((RollingWriter) writer).setTargetFileSize(targetSizeBytes);
+        }
+      }
+    }
+  }
+
+  @Override
   public void tick() {
     if (ReaderWriterState.OPEN == state) {
       for (DatasetWriter<E> writer : cachedWriters.asMap().values()) {
@@ -196,11 +247,13 @@ abstract class PartitionedDatasetWriter<E, W extends FileSystemWriter<E>>
 
     private final FileSystemView<E> view;
     private final PathConversion convert;
+    private final ConfAccessor conf;
 
-    public DatasetWriterCacheLoader(FileSystemView<E> view) {
+    public DatasetWriterCacheLoader(FileSystemView<E> view, ConfAccessor conf) {
       this.view = view;
       this.convert = new PathConversion(
           view.getDataset().getDescriptor().getSchema());
+      this.conf = conf;
     }
 
     @Override
@@ -213,6 +266,7 @@ abstract class PartitionedDatasetWriter<E, W extends FileSystemWriter<E>>
       FileSystemWriter<E> writer = FileSystemWriter.newWriter(
           dataset.getFileSystem(),
           new Path(dataset.getDirectory(), partition),
+          conf.getRollIntervalMillis(), conf.getTargetFileSize(),
           dataset.getDescriptor());
 
       PartitionListener listener = dataset.getPartitionListener();
@@ -237,11 +291,14 @@ abstract class PartitionedDatasetWriter<E, W extends FileSystemWriter<E>>
 
     private final FileSystemView<E> view;
     private final PathConversion convert;
+    private final ConfAccessor conf;
 
-    public IncrementalDatasetWriterCacheLoader(FileSystemView<E> view) {
+    public IncrementalDatasetWriterCacheLoader(FileSystemView<E> view,
+                                               ConfAccessor conf) {
       this.view = view;
       this.convert = new PathConversion(
           view.getDataset().getDescriptor().getSchema());
+      this.conf = conf;
     }
 
     @Override
@@ -257,6 +314,7 @@ abstract class PartitionedDatasetWriter<E, W extends FileSystemWriter<E>>
       FileSystemWriter<E> writer = FileSystemWriter.newWriter(
           dataset.getFileSystem(),
           new Path(dataset.getDirectory(), partition),
+          conf.getRollIntervalMillis(), conf.getTargetFileSize(),
           dataset.getDescriptor());
 
       PartitionListener listener = dataset.getPartitionListener();
@@ -301,7 +359,17 @@ abstract class PartitionedDatasetWriter<E, W extends FileSystemWriter<E>>
 
     @Override
     protected CacheLoader<StorageKey, FileSystemWriter<E>> createCacheLoader() {
-      return new DatasetWriterCacheLoader<E>(view);
+      return new DatasetWriterCacheLoader<E>(view, new ConfAccessor() {
+        @Override
+        public long getTargetFileSize() {
+          return NonDurablePartitionedDatasetWriter.this.targetFileSize;
+        }
+
+        @Override
+        public long getRollIntervalMillis() {
+          return NonDurablePartitionedDatasetWriter.this.rollIntervalMillis;
+        }
+      });
     }
   }
 
@@ -316,7 +384,18 @@ abstract class PartitionedDatasetWriter<E, W extends FileSystemWriter<E>>
     @Override
     protected CacheLoader<StorageKey, FileSystemWriter.IncrementalWriter<E>>
         createCacheLoader() {
-      return new IncrementalDatasetWriterCacheLoader<E>(view);
+      return new IncrementalDatasetWriterCacheLoader<E>(
+          view, new ConfAccessor() {
+        @Override
+        public long getTargetFileSize() {
+          return IncrementalPartitionedDatasetWriter.this.targetFileSize;
+        }
+
+        @Override
+        public long getRollIntervalMillis() {
+          return IncrementalPartitionedDatasetWriter.this.rollIntervalMillis;
+        }
+      });
     }
 
     @Override

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestAvroWriter.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestAvroWriter.java
@@ -39,6 +39,11 @@ public class TestAvroWriter extends TestFileSystemWriters {
   public FileSystemWriter<Record> newWriter(Path directory, Schema schema) {
     return FileSystemWriter.newWriter(fs, directory,
         new DatasetDescriptor.Builder()
+            .property(
+                "kite.writer.roll-interval-seconds", String.valueOf(1))
+            .property(
+                "kite.writer.target-file-size",
+                String.valueOf(2 * 1024 * 1024)) // 2 MB
             .schema(schema)
             .format("avro")
             .build());

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestAvroWriter.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestAvroWriter.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
@@ -29,7 +28,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.DatasetReader;
-import org.kitesdk.data.DatasetWriter;
 import org.kitesdk.data.Flushable;
 import org.kitesdk.data.Syncable;
 import org.kitesdk.data.spi.ReaderWriterState;
@@ -37,13 +35,13 @@ import org.kitesdk.data.spi.ReaderWriterState;
 public class TestAvroWriter extends TestFileSystemWriters {
   @Override
   public FileSystemWriter<Record> newWriter(Path directory, Schema schema) {
-    return FileSystemWriter.newWriter(fs, directory,
+    return FileSystemWriter.newWriter(fs, directory, 100, 2 * 1024 * 1024,
         new DatasetDescriptor.Builder()
             .property(
-                "kite.writer.roll-interval-seconds", String.valueOf(1))
+                "kite.writer.roll-interval-seconds", String.valueOf(10))
             .property(
                 "kite.writer.target-file-size",
-                String.valueOf(2 * 1024 * 1024)) // 2 MB
+                String.valueOf(32 * 1024 * 1024)) // 32 MB
             .schema(schema)
             .format("avro")
             .build());

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestDatasetWriterCacheLoader.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestDatasetWriterCacheLoader.java
@@ -15,6 +15,7 @@
  */
 package org.kitesdk.data.spi.filesystem;
 
+import com.google.common.cache.CacheLoader;
 import com.google.common.io.Files;
 import java.io.IOException;
 import junit.framework.Assert;
@@ -66,7 +67,18 @@ public class TestDatasetWriterCacheLoader {
   @Test
   public void testInitializeAfterParitionAddedCallback() throws Exception {
     PartitionedDatasetWriter.DatasetWriterCacheLoader<Object> loader
-      = new PartitionedDatasetWriter.DatasetWriterCacheLoader<Object>(view);
+      = new PartitionedDatasetWriter.DatasetWriterCacheLoader<Object>(
+        view, new PartitionedDatasetWriter.ConfAccessor() {
+      @Override
+      public long getTargetFileSize() {
+        return -1;
+      }
+
+      @Override
+      public long getRollIntervalMillis() {
+        return -1;
+      }
+    });
 
     StorageKey key = new StorageKey.Builder(partitionStrategy)
       .add("username", "test1")
@@ -77,7 +89,18 @@ public class TestDatasetWriterCacheLoader {
   @Test
   public void testIncrementatlInitializeAfterParitionAddedCallback() throws Exception {
     PartitionedDatasetWriter.IncrementalDatasetWriterCacheLoader<Object> loader
-      = new PartitionedDatasetWriter.IncrementalDatasetWriterCacheLoader<Object>(view);
+      = new PartitionedDatasetWriter.IncrementalDatasetWriterCacheLoader<Object>(
+        view, new PartitionedDatasetWriter.ConfAccessor() {
+      @Override
+      public long getTargetFileSize() {
+        return -1;
+      }
+
+      @Override
+      public long getRollIntervalMillis() {
+        return -1;
+      }
+    });
 
     StorageKey key = new StorageKey.Builder(partitionStrategy)
       .add("username", "test1")

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestParquetWriter.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestParquetWriter.java
@@ -19,7 +19,6 @@ package org.kitesdk.data.spi.filesystem;
 import java.io.IOException;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
-import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -28,7 +27,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.DatasetReader;
-import org.kitesdk.data.DatasetWriter;
 import org.kitesdk.data.Flushable;
 import org.kitesdk.data.LocalFileSystem;
 import org.kitesdk.data.Syncable;
@@ -36,7 +34,7 @@ import org.kitesdk.data.Syncable;
 public class TestParquetWriter extends TestFileSystemWriters {
   @Override
   public FileSystemWriter<Record> newWriter(Path directory, Schema schema) {
-    return FileSystemWriter.newWriter(fs, directory,
+    return FileSystemWriter.newWriter(fs, directory, 1, -1,
         new DatasetDescriptor.Builder()
             .property(
                 "kite.writer.roll-interval-seconds", String.valueOf(1))
@@ -65,7 +63,7 @@ public class TestParquetWriter extends TestFileSystemWriters {
   public void testParquetConfiguration() throws IOException {
     FileSystem fs = LocalFileSystem.getInstance();
     FileSystemWriter<Object> writer = FileSystemWriter.newWriter(
-        fs, new Path("/tmp"),
+        fs, new Path("/tmp"), -1, -1,
         new DatasetDescriptor.Builder()
             .property("parquet.block.size", "34343434")
             .schema(SchemaBuilder.record("test").fields()
@@ -87,7 +85,7 @@ public class TestParquetWriter extends TestFileSystemWriters {
   public void testConfigureDurableParquetAppender() throws IOException {
     FileSystem fs = LocalFileSystem.getInstance();
     FileSystemWriter<Object> writer = FileSystemWriter.newWriter(
-        fs, new Path("/tmp"),
+        fs, new Path("/tmp"), -1, -1,
         new DatasetDescriptor.Builder()
             .property(FileSystemProperties.NON_DURABLE_PARQUET_PROP, "false")
             .schema(SchemaBuilder.record("test").fields()
@@ -103,7 +101,7 @@ public class TestParquetWriter extends TestFileSystemWriters {
   public void testConfigureNonDurableParquetAppender() throws IOException {
     FileSystem fs = LocalFileSystem.getInstance();
     FileSystemWriter<Object> writer = FileSystemWriter.newWriter(
-        fs, new Path("/tmp"),
+        fs, new Path("/tmp"), -1, -1,
         new DatasetDescriptor.Builder()
             .property(FileSystemProperties.NON_DURABLE_PARQUET_PROP, "true")
             .schema(SchemaBuilder.record("test").fields()
@@ -118,6 +116,5 @@ public class TestParquetWriter extends TestFileSystemWriters {
   @Override
   @Ignore // Needs PARQUET-308 to estimate current file size
   public void testTargetFileSize() throws IOException {
-    super.testTargetFileSize();
   }
 }

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestParquetWriter.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestParquetWriter.java
@@ -38,6 +38,8 @@ public class TestParquetWriter extends TestFileSystemWriters {
   public FileSystemWriter<Record> newWriter(Path directory, Schema schema) {
     return FileSystemWriter.newWriter(fs, directory,
         new DatasetDescriptor.Builder()
+            .property(
+                "kite.writer.roll-interval-seconds", String.valueOf(1))
             .schema(schema)
             .format("parquet")
             .build());
@@ -111,5 +113,11 @@ public class TestParquetWriter extends TestFileSystemWriters {
             .build());
     Assert.assertEquals("Enabling the non-durable parquet appender should get us a non-durable appender",
         ParquetAppender.class, writer.newAppender(testDirectory).getClass());
+  }
+
+  @Override
+  @Ignore // Needs PARQUET-308 to estimate current file size
+  public void testTargetFileSize() throws IOException {
+    super.testTargetFileSize();
   }
 }


### PR DESCRIPTION
File size-based rolling works and is passing a new test for Avro, but is
disabled for Parquet because the appender has no reliable size estimate
for Parquet.

Time-based rolling uses a new SPI interface, ClockReady, which exposes a
method for passing time signals to implementing classes. This removes
the need for Kite to provide a thread-based check.