### PR TITLE
KITE-1023: Fix PartitionView URI escaping.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetDescriptor.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/DatasetDescriptor.java
@@ -179,6 +179,10 @@ public class DatasetDescriptor {
   /**
    * Get the URL location where the data for this {@link Dataset} is stored
    * (optional).
+   * <p>
+   * Due to a bug in Hadoop's {@link Path}, the URI returned by this method
+   * should not be used to create a path using its {@link URI} constructor.
+   * Instead, use {@code new Path(desc.getLocation().toString())}.
    *
    * @return a location URL or null if one is not set
    *
@@ -563,13 +567,13 @@ public class DatasetDescriptor {
     /**
      * Configure the dataset's location (optional).
      *
-     * @param uri A location Path
+     * @param path A location Path
      * @return An instance of the builder for method chaining.
      *
      * @since 0.8.0
      */
-    public Builder location(Path uri) {
-      return location(uri.toUri());
+    public Builder location(Path path) {
+      return location(path.toString());
     }
 
     /**

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/PartitionView.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/PartitionView.java
@@ -32,11 +32,17 @@ import javax.annotation.concurrent.Immutable;
 public interface PartitionView<E> extends View<E> {
   /**
    * Returns the location of this partition as a {@link URI}.
+   * <p>
+   * Due to a bug in Hadoop's {@link org.apache.hadoop.fs.Path}, the URI
+   * returned by this method should not be used to create a path using its
+   * {@link URI} constructor. Instead, use
+   * {@code new Path(desc.getLocation().toString())}.
+   *
    *
    * @return a {@code URI} for the location of this partition.
    * @since 1.1.0
    */
-  public URI getLocation();
+  URI getLocation();
 
   /**
    * Deletes the entities included in this {@link View}.

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemDataset.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemDataset.java
@@ -399,8 +399,12 @@ public class FileSystemDataset<E> extends AbstractDataset<E> implements
           partitionListener.partitionAdded(namespace, name, relative.toString());
         }
 
+        // use new Path(String) for locations because setting the URI directly
+        // results in the location URI being unescaped. the URI from
+        // #getLocation() is not a Path internal URI from with extra escapes
         List<Pair<Path, Path>> staged = FileSystemUtil.stageMove(fileSystem,
-            new Path(src.getLocation()), new Path(dest.getLocation()),
+            new Path(src.getLocation().toString()),
+            new Path(dest.getLocation().toString()),
             "tmp" /* data should be added to recover from a failure */ );
         FileSystemUtil.finishMove(fileSystem, staged);
 
@@ -451,7 +455,7 @@ public class FileSystemDataset<E> extends AbstractDataset<E> implements
           for (PartitionView<E> partition : existingPartitions) {
             FileSystemPartitionView<E> toReplace =
                 (FileSystemPartitionView<E>) partition;
-            Path path = new Path(toReplace.getLocation());
+            Path path = new Path(toReplace.getLocation().toString());
             removals.add(path);
             notReplaced.remove(toReplace);
             if (partitionListener != null && descriptor.isPartitioned()) {
@@ -462,7 +466,8 @@ public class FileSystemDataset<E> extends AbstractDataset<E> implements
 
           // replace the directory all at once
           FileSystemUtil.replace(fileSystem, directory,
-              new Path(dest.getLocation()), new Path(src.getLocation()),
+              new Path(dest.getLocation().toString()),
+              new Path(src.getLocation().toString()),
               removals);
 
           if (partitionListener != null && descriptor.isPartitioned()) {
@@ -486,7 +491,8 @@ public class FileSystemDataset<E> extends AbstractDataset<E> implements
       PartitionView<E> srcPartition = Iterables.getOnlyElement(
           replacement.getCoveringPartitions());
       List<Pair<Path, Path>> staged = FileSystemUtil.stageMove(fileSystem,
-          new Path(srcPartition.getLocation()), new Path(unbounded.getLocation()),
+          new Path(srcPartition.getLocation().toString()),
+          new Path(unbounded.getLocation().toString()),
           "replace" /* data should replace to recover from a failure */ );
       deleteAll(); // remove all existing files
       FileSystemUtil.finishMove(fileSystem, staged);

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemDataset.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemDataset.java
@@ -681,7 +681,7 @@ public class FileSystemDataset<E> extends AbstractDataset<E> implements
           "Configuration or FileSystem must be set");
       Preconditions.checkState(type != null, "No type specified");
 
-      this.directory = new Path(descriptor.getLocation());
+      this.directory = new Path(descriptor.getLocation().toString());
 
       if (fileSystem == null) {
         try {

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemDatasetRepository.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemDatasetRepository.java
@@ -230,7 +230,7 @@ public class FileSystemDatasetRepository extends AbstractDatasetRepository
     // we still need to delete the data directory
     boolean changed = metadataProvider.delete(namespace, name);
 
-    Path dataLocation = new Path(descriptor.getLocation());
+    Path dataLocation = new Path(descriptor.getLocation().toString());
     FileSystem dataFS = fsForPath(dataLocation, conf);
 
     if (fs.getUri().equals(dataFS.getUri())) {

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemUtil.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemUtil.java
@@ -64,7 +64,7 @@ public class FileSystemUtil {
     Preconditions.checkNotNull(descriptor.getLocation(),
         "Cannot get FileSystem for a descriptor with no location");
 
-    Path dataPath = new Path(descriptor.getLocation());
+    Path dataPath = new Path(descriptor.getLocation().toString());
     FileSystem fs = null;
 
     try {

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemDataset.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemDataset.java
@@ -97,7 +97,7 @@ public class TestFileSystemDataset extends MiniDFSTest {
   @Before
   public void setUp() throws IOException {
     testDirectory = fileSystem.makeQualified(
-        new Path(Files.createTempDir().getAbsolutePath()));
+        new Path(Files.createTempDir().getAbsolutePath() + "/test%2F-0"));
   }
 
   @After

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemUtil.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemUtil.java
@@ -182,7 +182,7 @@ public class TestFileSystemUtil {
     Assert.assertFalse("Should not flag at mixed depth",
         descriptor.hasProperty("kite.filesystem.mixed-depth"));
     Assert.assertEquals("Location should be at the partition directory",
-        partitionPath.toUri(), actual.getLocation());
+        URI.create(partitionPath.toString()), actual.getLocation());
     Assert.assertEquals("Should use user schema",
         USER_SCHEMA, actual.getSchema());
     Assert.assertEquals("Should have Avro format",

--- a/kite-data/kite-data-hive/src/main/java/org/kitesdk/data/spi/hive/HiveExternalMetadataProvider.java
+++ b/kite-data/kite-data-hive/src/main/java/org/kitesdk/data/spi/hive/HiveExternalMetadataProvider.java
@@ -84,7 +84,7 @@ class HiveExternalMetadataProvider extends HiveAbstractMetadataProvider {
           .build();
     }
 
-    Path managerPath = new Path(new Path(newDescriptor.getLocation()),
+    Path managerPath = new Path(new Path(newDescriptor.getLocation().toString()),
         SCHEMA_DIRECTORY);
 
     // Store the schema with the schema manager and use the


### PR DESCRIPTION
This adds test for URIs with escaped characters and fixes handling in
the FS PartitionView implementation. The implementation was accidentally
unescaping URIs by using URI.create, which expects escaped characters,
along with URI#getPath, which will remove escapes.

This also fixes the URI returned by getLocation. This previously used
Path#getUri, but that method returns the Path's internal URI that
is double-escaped. Returning a URI created from Path#toString is the
correct behavior because it matches the Path passed in. Similarly,
the merge and replace methods in the FS dataset implementation that rely
on Paths created from those locations have been updated to correctly
construct a Path from a URI by converting the URI to a String rather
than setting the internal URI directly.