### PR TITLE
Kite-1046: Add num-records option to json-schema command

### DIFF
--- a/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/JSONSchemaCommand.java
+++ b/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/cli/commands/JSONSchemaCommand.java
@@ -65,6 +65,15 @@ public class JSONSchemaCommand extends BaseCommand {
       description="Minimize schema file size by eliminating white space")
   boolean minimize=false;
 
+  @edu.umd.cs.findbugs.annotations.SuppressWarnings(
+      value="UWF_NULL_FIELD",
+      justification = "Field set by JCommander")
+  @Parameter(names={"-n", "--num-records"},
+             description="Number of records to derive schema from",
+             arity=1)
+  int numRecords = 10;  // By default we look at first 10 records
+
+
   @Override
   public int run() throws IOException {
     Preconditions.checkArgument(samplePaths != null && !samplePaths.isEmpty(),
@@ -74,7 +83,7 @@ public class JSONSchemaCommand extends BaseCommand {
 
     // assume fields are nullable by default, users can easily change this
     Schema sampleSchema = JsonUtil.inferSchema(
-        open(samplePaths.get(0)), recordName, 10);
+        open(samplePaths.get(0)), recordName, numRecords);
 
     if (sampleSchema != null) {
       output(sampleSchema.toString(!minimize), console, outputPath);


### PR DESCRIPTION
This code piggy backs on the existing strategy for parsing new options.

Only difference here is adding the "arity" parameter, to force users to enter exactly 1 value.

Here's how the help text now looks:

```
Usage: ./kite-dataset [general options] json-schema <sample json path> [command options]

  Description:

    Build a schema from a JSON data sample

  Command options:

    -n, --num-records
	Number of records to derive schema from (default: 10)
    -o, --output
	Save schema avsc to path
  * --class, --record-name
	A name or class for the result schema
    --minimize
	Minimize schema file size by eliminating white space

  * = required
```

If you don't enter a value in, you'll see this:

```
Expected a value after parameter --num-records
```

And if you specify something other than a valid integer is gives you this:

```
"-n": couldn't convert "blah" to an integer
```
