### PR TITLE
KITE-1053: Fix int overflow bug in FS writer.

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemWriter.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemWriter.java
@@ -72,7 +72,7 @@ class FileSystemWriter<E> extends AbstractDatasetWriter<E> {
   private final DatasetDescriptor descriptor;
   private Path tempPath;
   private Path finalPath;
-  private int count = 0;
+  private long count = 0;
 
   protected final FileSystem fs;
   protected FileAppender<E> appender;


### PR DESCRIPTION
Keeping the number of records written in an int caused a bug where
writing more than Integer.MAX_VALUE records (~2B) would overflow the
counter and the check to see whether any records had been written would
fail because count is less than 0. The fix is to use a long.