### PR TITLE
KITE-1035 added kite configuration service for oozie to supplement the KiteURIHandler

### DIFF
--- a/kite-data/kite-data-oozie/src/main/java/org/kitesdk/data/oozie/KiteConfigurationService.java
+++ b/kite-data/kite-data-oozie/src/main/java/org/kitesdk/data/oozie/KiteConfigurationService.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright 2015 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kitesdk.data.oozie;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.oozie.ErrorCode;
+import org.apache.oozie.service.HadoopAccessorException;
+import org.apache.oozie.service.HadoopAccessorService;
+import org.apache.oozie.service.Service;
+import org.apache.oozie.service.ServiceException;
+import org.apache.oozie.service.Services;
+import org.apache.oozie.util.XConfiguration;
+import org.apache.oozie.util.XLog;
+
+public class KiteConfigurationService implements Service {
+
+  public static final String CONF_PREFIX = Service.CONF_PREFIX + "KiteConfigurationService.";
+  public static final String KITE_CONFIGURATION = CONF_PREFIX + "kite.configuration";
+
+  private static XLog LOG = XLog.getLog(KiteConfigurationService.class);
+  private Configuration conf;
+  private Configuration kiteConf;
+
+  @Override
+  public void init(Services services) throws ServiceException {
+    conf = services.getConf();
+    try {
+      loadKiteConf(services);
+    } catch(IOException ioe) {
+        throw new ServiceException(ErrorCode.E0100, KiteConfigurationService.class.getName(), "An exception occured while attempting"
+                + "to load the Kite Configuration", ioe);
+    }
+  }
+
+  public Configuration getKiteConf() {
+    return kiteConf;
+  }
+
+  // largely borrowed with from the HCatAccessorService
+  // configuration methodology. Modification includes the
+  // ability to specify multiple paths to configurations
+  private void loadKiteConf(Services services) throws IOException {
+    String[] paths = conf.getStrings(KITE_CONFIGURATION);
+    if (paths != null && paths.length != 0) {
+      kiteConf = new Configuration();
+      for(String path : paths) {
+        if (path.startsWith("hdfs")) {
+            Path p = new Path(path);
+            HadoopAccessorService has = services.get(HadoopAccessorService.class);
+            
+            try {
+                FileSystem fs = has.createFileSystem(
+                        System.getProperty("user.name"), p.toUri(), has.createJobConf(p.toUri().getAuthority()));
+                if (fs.exists(p)) {
+                    FSDataInputStream is = null;
+                    try {
+                        is = fs.open(p);
+                        Configuration partialConf = new XConfiguration(is);
+                        kiteConf = merge(kiteConf, partialConf);
+                    } finally {
+                        if (is != null) {
+                            is.close();
+                        }
+                    }
+                    LOG.info("Loaded Kite Configuration: " + path);
+                } else {
+                    LOG.warn("Kite Configuration could not be found at [" + path + "]");
+                }
+            } catch (HadoopAccessorException hae) {
+                throw new IOException(hae);
+            }
+        } else {
+            File f = new File(path);
+            if (f.exists()) {
+                InputStream is = null;
+                try {
+                    is = new FileInputStream(f);
+                    Configuration partialConf = new XConfiguration(is);
+                    kiteConf = merge(kiteConf, partialConf);
+                } finally {
+                    if (is != null) {
+                        is.close();
+                    }
+                }
+                LOG.info("Loaded Kite Configuration: " + path);
+            } else {
+                LOG.warn("Kite Configuration could not be found at [" + path + "]");
+            }
+        }
+      }
+    } else {
+      LOG.info("Kite Configuration not specified");
+    }
+  }
+
+  @Override
+  public void destroy() {
+    //no-op
+  }
+
+  @Override
+  public Class<? extends Service> getInterface() {
+    return KiteConfigurationService.class;
+  }
+
+  //borrowed from spring-hadoop ConfigurationUtils. Alternative for CDH5 compatibility
+  //where Configuration.addResource(configuration) is not available
+  private static Configuration merge(Configuration one, Configuration two) {
+    if (one == null) {
+      if (two == null) {
+        return new Configuration();
+      }
+      return new Configuration(two);
+    }
+
+    Configuration c = new Configuration(one);
+
+    if (two == null) {
+      return c;
+    }
+
+    for (Map.Entry<String, String> entry : two) {
+      c.set(entry.getKey(), entry.getValue());
+    }
+
+    return c;
+  }
+
+}

--- a/kite-data/kite-data-oozie/src/main/java/org/kitesdk/data/oozie/KiteConfigurationService.java
+++ b/kite-data/kite-data-oozie/src/main/java/org/kitesdk/data/oozie/KiteConfigurationService.java
@@ -39,12 +39,10 @@ public class KiteConfigurationService implements Service {
   public static final String KITE_CONFIGURATION = CONF_PREFIX + "kite.configuration";
 
   private static XLog LOG = XLog.getLog(KiteConfigurationService.class);
-  private Configuration conf;
   private Configuration kiteConf;
 
   @Override
   public void init(Services services) throws ServiceException {
-    conf = services.getConf();
     try {
       loadKiteConf(services);
     } catch(IOException ioe) {
@@ -61,9 +59,9 @@ public class KiteConfigurationService implements Service {
   // configuration methodology. Modification includes the
   // ability to specify multiple paths to configurations
   private void loadKiteConf(Services services) throws IOException {
-    String[] paths = conf.getStrings(KITE_CONFIGURATION);
+    String[] paths = services.getConf().getStrings(KITE_CONFIGURATION);
     if (paths != null && paths.length != 0) {
-      kiteConf = new Configuration();
+      kiteConf = new Configuration(false);
       for(String path : paths) {
         if (path.startsWith("hdfs")) {
             Path p = new Path(path);

--- a/kite-data/kite-data-oozie/src/main/java/org/kitesdk/data/oozie/KiteURIHandler.java
+++ b/kite-data/kite-data-oozie/src/main/java/org/kitesdk/data/oozie/KiteURIHandler.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.oozie.ErrorCode;
@@ -28,6 +29,7 @@ import org.apache.oozie.action.hadoop.LauncherURIHandler;
 import org.apache.oozie.dependency.URIHandler;
 import org.apache.oozie.dependency.URIHandlerException;
 import org.apache.oozie.service.HadoopAccessorException;
+import org.apache.oozie.service.Services;
 import org.apache.oozie.service.URIHandlerService;
 import org.apache.oozie.util.XLog;
 import org.kitesdk.data.DatasetException;
@@ -36,6 +38,7 @@ import org.kitesdk.data.Datasets;
 import org.kitesdk.data.Signalable;
 import org.kitesdk.data.URIBuilder;
 import org.kitesdk.data.View;
+import org.kitesdk.data.spi.DefaultConfiguration;
 
 /**
  * A Kite URI handler that works with {@link Signalable} views.
@@ -49,6 +52,8 @@ public class KiteURIHandler implements URIHandler {
 
   private Set<String> supportedSchemes;
   private List<Class<?>> classesToShip;
+
+  private AtomicBoolean confLoaded = new AtomicBoolean(false);
 
   @Override
   public void init(final Configuration conf) {
@@ -101,9 +106,35 @@ public class KiteURIHandler implements URIHandler {
     return null;
   }
 
+  private synchronized void loadConfiguration() {
+    if(Services.get() != null) {
+      KiteConfigurationService kiteService = Services.get().get(KiteConfigurationService.class);
+      if(kiteService != null) {
+        Configuration kiteConf = kiteService.getKiteConf();
+        if(kiteConf != null) {
+          DefaultConfiguration.set(kiteConf);
+        } else {
+          // kite conf was null
+          LOG.warn("Configuration for Kite not loaded, Kite configuration service config was null.");
+        }
+      } else {
+        // service was null
+        LOG.warn("Configuration for Kite not loaded, Kite configuration service was not available.");
+      }
+    } else {
+        // services were null
+        LOG.warn("Configuration for Kite not loaded, oozie services were not available.");
+    }
+  }
+
   @SuppressWarnings("rawtypes")
   @Override
   public boolean exists(final URI uri, final Context context) throws URIHandlerException {
+    // load the configuration if it hasn't been yet
+    if(confLoaded.compareAndSet(false, true)) {
+      loadConfiguration();
+    }
+
     try {
       View<GenericRecord> view = Datasets.load(uri);
       if(view instanceof Signalable) {

--- a/kite-data/kite-data-oozie/src/test/java/org/kitesdk/data/oozie/MiniDFSTest.java
+++ b/kite-data/kite-data-oozie/src/test/java/org/kitesdk/data/oozie/MiniDFSTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2015 Cloudera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kitesdk.data.oozie;
+
+import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.kitesdk.compat.DynMethods;
+
+/**
+ * Provides setup/teardown of a MiniDFSCluster for tests that need one.
+ *
+ * Similar to the primary MiniDFSTest found in kite-data-core but with additional configuration
+ * for hadoop.proxyuser settings.
+ */
+public class MiniDFSTest {
+  private static Configuration conf = null;
+  private static MiniDFSCluster cluster = null;
+  private static FileSystem dfs = null;
+  private static FileSystem lfs = null;
+
+  private static DynMethods.UnboundMethod getFS = new DynMethods
+      .Builder("getFileSystem")
+      .impl(MiniDFSCluster.class)
+      .build();
+
+  protected static Configuration getConfiguration() {
+    return conf;
+  }
+
+  protected static FileSystem getDFS() {
+    return dfs;
+  }
+
+  protected static FileSystem getFS() {
+    return lfs;
+  }
+
+  @BeforeClass
+  @SuppressWarnings("deprecation")
+  public static void setupFS() throws IOException {
+    if (cluster == null) {
+      Configuration c = new Configuration();
+      c.setBoolean("dfs.webhdfs.enabled", true);
+
+      String user = System.getProperty("user.name");
+      c.set("hadoop.proxyuser." + user + ".hosts", "*");
+      c.set("hadoop.proxyuser." + user + ".groups", "*");
+
+      // if this fails with "The directory is already locked" set umask to 0022
+      cluster = new MiniDFSCluster(c, 1, true, null);
+      //cluster = new MiniDFSCluster.Builder(new Configuration()).build();
+      dfs = getFS.invoke(cluster);
+      conf = new Configuration(dfs.getConf());
+      lfs = FileSystem.getLocal(conf);
+    }
+  }
+
+  @AfterClass
+  public static void teardownFS() throws IOException {
+    dfs = null;
+    lfs = null;
+    conf = null;
+    if (cluster != null) {
+      cluster.shutdown();
+      cluster = null;
+    }
+  }
+}

--- a/kite-data/kite-data-oozie/src/test/java/org/kitesdk/data/oozie/TestKiteConfigurationService.java
+++ b/kite-data/kite-data-oozie/src/test/java/org/kitesdk/data/oozie/TestKiteConfigurationService.java
@@ -1,0 +1,243 @@
+/**
+ * Copyright 2015 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kitesdk.data.oozie;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.oozie.service.ServiceException;
+import org.apache.oozie.service.Services;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kitesdk.data.DatasetDescriptor;
+import org.kitesdk.data.spi.DefaultConfiguration;
+import com.google.common.base.Joiner;
+import com.google.common.io.Files;
+
+@RunWith(Parameterized.class)
+public class TestKiteConfigurationService  extends MiniDFSTest {
+
+  protected static final String NAMESPACE = "ns1";
+  protected static final String NAME = "provider_test1";
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> data() {
+    Object[][] data = new Object[][] {
+        { false },  // default to local FS
+        { true } }; // default to distributed FS
+    return Arrays.asList(data);
+  }
+
+  // whether this should use the DFS provided by MiniDFSTest
+  protected boolean distributed;
+
+  protected Configuration conf;
+  protected DatasetDescriptor testDescriptor;
+  protected FileSystem fs;
+  private Configuration startingConf;
+  private String startingOozieHome;
+
+  private File serviceTempDir;
+  Path kiteConfigPath = null;
+
+  public TestKiteConfigurationService(boolean distributed) {
+    this.distributed = distributed;
+  }
+
+  private static Configuration originalKiteConf;
+
+  @BeforeClass
+  public static void defaultConfiguration() {
+    originalKiteConf = DefaultConfiguration.get();
+  }
+
+  @AfterClass
+  public static void restoreConfiguration() {
+    DefaultConfiguration.set(originalKiteConf);
+  }
+
+  @After
+  public void removeDataPath() throws IOException {
+    // restore configuration
+    DefaultConfiguration.set(startingConf);
+
+    if(serviceTempDir != null) {
+      FileUtils.deleteDirectory(serviceTempDir);
+      serviceTempDir = null;
+    }
+    
+    if(kiteConfigPath != null) {
+      fs.delete(kiteConfigPath, true);
+      kiteConfigPath = null;
+    }
+
+    if(Services.get() != null) {
+      Services.get().destroy();
+    }
+
+    if(startingOozieHome == null) {
+      System.clearProperty("oozie.home.dir");
+    } else {
+      System.setProperty("oozie.home.dir", startingOozieHome);
+      startingOozieHome = null;
+    }
+  }
+
+  @Before
+  public void setUp() throws IOException, URISyntaxException {
+    this.conf = (distributed ?
+        MiniDFSTest.getConfiguration() :
+        new Configuration());
+
+    this.fs = FileSystem.get(conf);
+
+    startingOozieHome = System.getProperty("oozie.home.dir");
+    serviceTempDir = Files.createTempDir();
+  }
+
+  @Test
+  public void noKiteConfiguration() throws ServiceException, FileNotFoundException, IOException {
+    Assume.assumeTrue(!distributed);
+
+    kiteConfigPath = new Path("target/kite-conf-serv");
+    setupKiteConfigurationService(kiteConfigPath, true, false, false);
+    Assert.assertNull(Services.get().get(KiteConfigurationService.class).getKiteConf());
+  }
+
+  @Test
+  public void singleKiteConfiguration() throws ServiceException, IOException {
+    Assume.assumeTrue(!distributed);
+
+    kiteConfigPath = new Path("target/kite-conf-serv");
+    setupKiteConfigurationService(kiteConfigPath, true, true, false);
+    Configuration serviceKiteConf = Services.get().get(KiteConfigurationService.class).getKiteConf();
+    Assert.assertNotNull(serviceKiteConf);
+    Assert.assertEquals("test.value",serviceKiteConf.get("test.property"));
+  }
+
+  @Test
+  public void multipleKiteConfigurations() throws ServiceException, IOException {
+    Assume.assumeTrue(!distributed);
+
+    kiteConfigPath = new Path("target/kite-conf-serv");
+    setupKiteConfigurationService(kiteConfigPath, true, true, true);
+    Configuration serviceKiteConf = Services.get().get(KiteConfigurationService.class).getKiteConf();
+    Assert.assertNotNull(serviceKiteConf);
+    Assert.assertEquals("test.value",serviceKiteConf.get("test.property"));
+    Assert.assertEquals("second.value",serviceKiteConf.get("second.property"));
+  }
+
+  @Test
+  public void hdfsKiteConfigurations() throws ServiceException, IOException {
+    Assume.assumeTrue(distributed);
+
+    kiteConfigPath = new Path("hdfs:///testing/kite-conf-serv");
+    setupKiteConfigurationService(kiteConfigPath, true, true, true);
+    Configuration serviceKiteConf = Services.get().get(KiteConfigurationService.class).getKiteConf();
+    Assert.assertNotNull(serviceKiteConf);
+    Assert.assertEquals("test.value",serviceKiteConf.get("test.property"));
+    Assert.assertEquals("second.value",serviceKiteConf.get("second.property"));
+  }
+
+  private void setupKiteConfigurationService(Path kiteConfigLocation, boolean loadKiteService, 
+      boolean loadPrimaryConfig, boolean loadSecondaryConfig) throws IOException, ServiceException  {
+    File confDir = new File(serviceTempDir, "conf");
+    File hadoopConfDir = new File(confDir, "hadoop-conf");
+    File actionConfDir = new File(confDir, "action-conf");
+    confDir.mkdirs();
+    hadoopConfDir.mkdirs();
+    actionConfDir.mkdirs();
+
+    Path kiteConfDir = new Path(kiteConfigLocation, "kite-conf");
+    fs.mkdirs(kiteConfDir);
+
+    // these may need to be forced to local FS
+    File oozieSiteTarget = new File(confDir, "oozie-site.xml");
+    File hadoopConfTarget = new File(hadoopConfDir, "hadoop-site.xml");
+
+    // we'll want tests for this with both local and hdfs files
+    Path primaryConfTarget = new Path(kiteConfDir, "primary-site.xml");
+    Path secondaryConfTarget = new Path(kiteConfDir, "secondary-site.xml");
+
+    Configuration oozieSiteConf = new Configuration(false);
+
+    List<String> configs = new ArrayList<String>();
+    if(loadPrimaryConfig) {
+      configs.add(primaryConfTarget.toString());
+    }
+
+    if(loadSecondaryConfig) {
+      configs.add(secondaryConfTarget.toString());
+    }
+
+    if(!configs.isEmpty()) {
+      oozieSiteConf.set("oozie.service.KiteConfigurationService.kite.configuration", Joiner.on(",").join(configs));
+    }
+
+    oozieSiteConf.set("oozie.services", "org.apache.oozie.service.HadoopAccessorService");
+    FileOutputStream oozieStream = new FileOutputStream(oozieSiteTarget);
+    oozieSiteConf.writeXml(oozieStream);
+    oozieStream.close();
+    FileOutputStream hadoopStream = new FileOutputStream(hadoopConfTarget);
+    conf.writeXml(hadoopStream);
+    hadoopStream.close();
+
+    if(loadPrimaryConfig) {
+      Configuration primaryConf = new Configuration(false);
+      primaryConf.set("test.property", "test.value");
+
+      FSDataOutputStream primaryStream = fs.create(primaryConfTarget);
+      primaryConf.writeXml(primaryStream);
+      primaryStream.close();
+    }
+
+    if(loadSecondaryConfig) {
+      Configuration secondaryConf = new Configuration(false);
+      secondaryConf.set("second.property", "second.value");
+
+      FSDataOutputStream secondaryStream = fs.create(secondaryConfTarget);
+      secondaryConf.writeXml(secondaryStream);
+      secondaryStream.close();
+    }
+
+    // set to the temp directory
+    System.setProperty("oozie.home.dir", serviceTempDir.getAbsolutePath());
+
+    Services services = new Services();
+    services.init();
+    if(loadKiteService) {
+      services.setService(KiteConfigurationService.class);
+    }
+  }
+}

--- a/kite-data/kite-data-oozie/src/test/java/org/kitesdk/data/oozie/TestKiteURIHandler.java
+++ b/kite-data/kite-data-oozie/src/test/java/org/kitesdk/data/oozie/TestKiteURIHandler.java
@@ -16,6 +16,9 @@
 package org.kitesdk.data.oozie;
 
 import org.kitesdk.data.PartitionView;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -27,12 +30,15 @@ import java.util.Set;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.oozie.ErrorCode;
 import org.apache.oozie.XException;
 import org.apache.oozie.dependency.URIHandlerException;
+import org.apache.oozie.service.ServiceException;
+import org.apache.oozie.service.Services;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -51,10 +57,12 @@ import org.kitesdk.data.RefinableView;
 import org.kitesdk.data.View;
 import org.kitesdk.data.oozie.KiteURIHandler;
 import org.kitesdk.data.spi.DatasetRepository;
+import org.kitesdk.data.spi.DefaultConfiguration;
 import org.kitesdk.data.spi.OptionBuilder;
 import org.kitesdk.data.spi.Registration;
 import org.kitesdk.data.spi.URIPattern;
 import org.kitesdk.data.spi.filesystem.FileSystemDatasetRepository;
+import com.google.common.io.Files;
 
 @RunWith(Parameterized.class)
 public class TestKiteURIHandler extends MiniDFSTest {
@@ -76,6 +84,10 @@ public class TestKiteURIHandler extends MiniDFSTest {
   protected Configuration conf;
   protected DatasetDescriptor testDescriptor;
   protected FileSystem fs;
+  private Configuration startingConf;
+  private String startingOozieHome;
+
+  private File serviceTempDir;
 
   public TestKiteURIHandler(boolean distributed) {
     this.distributed = distributed;
@@ -91,6 +103,23 @@ public class TestKiteURIHandler extends MiniDFSTest {
   @After
   public void removeDataPath() throws IOException {
     fs.delete(new Path("target/data"), true);
+    // restore configuration
+    DefaultConfiguration.set(startingConf);
+
+    if(serviceTempDir != null) {
+      FileUtils.deleteDirectory(serviceTempDir);
+      serviceTempDir = null;
+    }
+    if(Services.get() != null) {
+      Services.get().destroy();
+    }
+
+    if(startingOozieHome == null) {
+      System.clearProperty("oozie.home.dir");
+    } else {
+      System.setProperty("oozie.home.dir", startingOozieHome);
+      startingOozieHome = null;
+    }
   }
 
   @Before
@@ -116,6 +145,9 @@ public class TestKiteURIHandler extends MiniDFSTest {
 
     uriHandler = new KiteURIHandler();
 
+    startingConf = DefaultConfiguration.get();
+
+    startingOozieHome = System.getProperty("oozie.home.dir");
   }
 
   private KiteURIHandler uriHandler;
@@ -213,6 +245,89 @@ public class TestKiteURIHandler extends MiniDFSTest {
     URI uri = new URI("view:unreadiable:default/person?version=201404240000");
 
     Assert.assertFalse(uriHandler.exists(uri, null));
+  }
+
+  @Test
+  public void loadConfigFromHCatAccessor() throws URIHandlerException, URISyntaxException, ServiceException, IOException {
+    setupKiteConfigurationService(true, true);
+    URI uri = new URI("view:file:target/data/data/nomailbox?message=hello");
+    uriHandler.exists(uri, null);
+
+    Configuration defaultConf = DefaultConfiguration.get();
+    Assert.assertEquals("test.value", defaultConf.get("test.property"));
+
+    Services.get().get(KiteConfigurationService.class).getKiteConf().set("test.value", "something.else");
+    // doesn't modify default config on further exist calls
+    uriHandler.exists(uri, null);
+
+    defaultConf = DefaultConfiguration.get();
+    Assert.assertEquals("test.value", defaultConf.get("test.property"));
+    Assert.assertEquals("something.else", Services.get().get(KiteConfigurationService.class).getKiteConf().get("test.value"));
+  }
+
+  @Test
+  public void noConfigLoadedWhenNoServices() throws URIHandlerException, URISyntaxException {
+    URI uri = new URI("view:file:target/data/data/nomailbox?message=hello");
+    uriHandler.exists(uri, null);
+    Assert.assertNull(Services.get());
+  }
+
+  @Test
+  public void noConfigLoadedWhenNoKiteService() throws URIHandlerException, URISyntaxException, ServiceException, FileNotFoundException, IOException {
+    setupKiteConfigurationService(false, false);
+
+    URI uri = new URI("view:file:target/data/data/nomailbox?message=hello");
+    uriHandler.exists(uri, null);
+    Assert.assertNotNull(Services.get());
+    Assert.assertNull(Services.get().get(KiteConfigurationService.class));
+  }
+
+  @Test
+  public void noConfigLoadedIfNoKiteServiceConfig() throws URIHandlerException, URISyntaxException, ServiceException, FileNotFoundException, IOException {
+    setupKiteConfigurationService(true, false);
+    URI uri = new URI("view:file:target/data/data/nomailbox?message=hello");
+    uriHandler.exists(uri, null);
+    Assert.assertNotNull(Services.get());
+    Assert.assertNotNull(Services.get().get(KiteConfigurationService.class));
+    Assert.assertNull(Services.get().get(KiteConfigurationService.class).getKiteConf());
+  }
+
+  private void setupKiteConfigurationService(boolean loadKiteService, boolean loadKiteConfig) throws ServiceException, FileNotFoundException, IOException {
+    serviceTempDir = Files.createTempDir();
+    File confDir = new File(serviceTempDir, "conf");
+    File hadoopConfDir = new File(confDir, "hadoop-conf");
+    File hadoopConfTarget = new File(hadoopConfDir, "hadoop-site.xml");
+    File actionConfDir = new File(confDir, "action-conf");
+    File hiveConfDir = new File(confDir, "hive-conf");
+    File hiveConfTarget = new File(hiveConfDir, "hive-site.xml");
+    File oozieSiteTarget = new File(confDir, "oozie-site.xml");
+    confDir.mkdir();
+    hadoopConfDir.mkdir();
+    actionConfDir.mkdir();
+    hiveConfDir.mkdir();
+
+    Configuration oozieSiteConf = new Configuration(false);
+
+    if(loadKiteConfig) {
+      oozieSiteConf.set("oozie.service.KiteConfigurationService.kite.configuration", hiveConfTarget.getAbsolutePath());
+    }
+
+    oozieSiteConf.set("oozie.services", "org.apache.oozie.service.HadoopAccessorService");
+    oozieSiteConf.writeXml(new FileOutputStream(oozieSiteTarget));
+    conf.writeXml(new FileOutputStream(hadoopConfTarget));
+
+    Configuration hiveConf = new Configuration(false);
+    hiveConf.set("test.property", "test.value");
+    hiveConf.writeXml(new FileOutputStream(hiveConfTarget));
+
+    // set to the temp directory
+    System.setProperty("oozie.home.dir", serviceTempDir.getAbsolutePath());
+
+    Services services = new Services();
+    services.init();
+    if(loadKiteService) {
+      services.setService(KiteConfigurationService.class);
+    }
   }
 
   //minimal implementation of the dataset stack to get an non-readiable view to load in the handler


### PR DESCRIPTION
https://issues.cloudera.org/browse/KITE-1035

Alternative implementation of the concept introduced first in pull #399

Sets the default configuration for kite to a list of configuration sources set at the property "oozie.service.KiteConfigurationService.kite.configuration"

(A consumer would also need to add the configuration service to the list of configurations specified for oozie under "oozie.services")