### PR TITLE
KITE-1040: Cache Hive MetaStore connections.

### DIFF
--- a/kite-data/kite-data-crunch/src/test/java/org/kitesdk/data/crunch/TestCrunchDatasetsHive.java
+++ b/kite-data/kite-data-crunch/src/test/java/org/kitesdk/data/crunch/TestCrunchDatasetsHive.java
@@ -41,7 +41,7 @@ public class TestCrunchDatasetsHive extends TestCrunchDatasets {
   @After
   public void cleanHCatalog() {
     // ensures all tables are removed
-    MetaStoreUtil hcat = new MetaStoreUtil(fileSystem.getConf());
+    MetaStoreUtil hcat = MetaStoreUtil.get(fileSystem.getConf());
 
     for (String database: hcat.getAllDatabases()) {
       for (String tableName : hcat.getAllTables(database)) {

--- a/kite-data/kite-data-hive/src/main/java/org/kitesdk/data/spi/hive/HiveAbstractMetadataProvider.java
+++ b/kite-data/kite-data-hive/src/main/java/org/kitesdk/data/spi/hive/HiveAbstractMetadataProvider.java
@@ -60,7 +60,7 @@ abstract class HiveAbstractMetadataProvider extends AbstractMetadataProvider imp
 
   protected MetaStoreUtil getMetaStoreUtil() {
     if (metastore == null) {
-      metastore = new MetaStoreUtil(conf);
+      metastore = MetaStoreUtil.get(conf);
     }
     return metastore;
   }

--- a/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestExternalBackwardCompatibility.java
+++ b/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestExternalBackwardCompatibility.java
@@ -62,7 +62,7 @@ public class TestExternalBackwardCompatibility {
   public void addTableToDefault() {
     // this test uses the local FS because
     this.conf = new Configuration();
-    this.metastore = new MetaStoreUtil(conf);
+    this.metastore = MetaStoreUtil.get(conf);
     cleanHive();
     metastore.dropTable("default", "test");
     this.descriptor = new DatasetDescriptor.Builder()
@@ -77,7 +77,7 @@ public class TestExternalBackwardCompatibility {
   @After
   public void cleanHive() {
     // ensures all tables are removed
-    MetaStoreUtil metastore = new MetaStoreUtil(conf);
+    MetaStoreUtil metastore = MetaStoreUtil.get(conf);
     for (String database : metastore.getAllDatabases()) {
       for (String table : metastore.getAllTables(database)) {
         metastore.dropTable(database, table);

--- a/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestHiveDatasetURIs.java
+++ b/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestHiveDatasetURIs.java
@@ -56,7 +56,7 @@ public class TestHiveDatasetURIs extends MiniDFSTest {
   @After
   public void cleanHive() {
     // ensures all tables are removed
-    MetaStoreUtil metastore = new MetaStoreUtil(getConfiguration());
+    MetaStoreUtil metastore = MetaStoreUtil.get(getConfiguration());
     for (String database : metastore.getAllDatabases()) {
       for (String table : metastore.getAllTables(database)) {
         metastore.dropTable(database, table);

--- a/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestHiveDatasetURIsCompatibility.java
+++ b/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestHiveDatasetURIsCompatibility.java
@@ -36,7 +36,7 @@ public class TestHiveDatasetURIsCompatibility {
       .schemaLiteral("\"string\"")
       .build();
 
-  private static final MetaStoreUtil metastore = new MetaStoreUtil(new Configuration());
+  private static final MetaStoreUtil metastore = MetaStoreUtil.get(new Configuration());
 
   @Before
   @After

--- a/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestHiveDatasetURIsWithDefaultConfiguration.java
+++ b/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestHiveDatasetURIsWithDefaultConfiguration.java
@@ -63,7 +63,7 @@ public class TestHiveDatasetURIsWithDefaultConfiguration extends MiniDFSTest {
   @After
   public void cleanHive() {
     // ensures all tables are removed
-    MetaStoreUtil metastore = new MetaStoreUtil(getConfiguration());
+    MetaStoreUtil metastore = MetaStoreUtil.get(getConfiguration());
     for (String database : metastore.getAllDatabases()) {
       for (String table : metastore.getAllTables(database)) {
         metastore.dropTable(database, table);

--- a/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestHiveExternalDatasetRepository.java
+++ b/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestHiveExternalDatasetRepository.java
@@ -68,7 +68,7 @@ public class TestHiveExternalDatasetRepository extends TestFileSystemDatasetRepo
   @After
   public void cleanHive() {
     // ensures all tables are removed
-    MetaStoreUtil metastore = new MetaStoreUtil(getConfiguration());
+    MetaStoreUtil metastore = MetaStoreUtil.get(getConfiguration());
     for (String database : metastore.getAllDatabases()) {
       for (String table : metastore.getAllTables(database)) {
         metastore.dropTable(database, table);

--- a/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestHiveExternalMetadataProvider.java
+++ b/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestHiveExternalMetadataProvider.java
@@ -48,7 +48,7 @@ public class TestHiveExternalMetadataProvider extends TestMetadataProviders {
   @After
   public void cleanHive() {
     // ensures all tables are removed
-    MetaStoreUtil metastore = new MetaStoreUtil(getConfiguration());
+    MetaStoreUtil metastore = MetaStoreUtil.get(getConfiguration());
     for (String database : metastore.getAllDatabases()) {
       for (String table : metastore.getAllTables(database)) {
         metastore.dropTable(database, table);

--- a/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestHiveManagedDatasetRepository.java
+++ b/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestHiveManagedDatasetRepository.java
@@ -57,7 +57,7 @@ public class TestHiveManagedDatasetRepository extends TestFileSystemDatasetRepos
   @After
   public void cleanHive() {
     // ensures all tables are removed
-    MetaStoreUtil metastore = new MetaStoreUtil(getConfiguration());
+    MetaStoreUtil metastore = MetaStoreUtil.get(getConfiguration());
     for (String database : metastore.getAllDatabases()) {
       for (String table : metastore.getAllTables(database)) {
         metastore.dropTable(database, table);

--- a/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestHiveManagedMetadataProvider.java
+++ b/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestHiveManagedMetadataProvider.java
@@ -38,7 +38,7 @@ public class TestHiveManagedMetadataProvider extends TestMetadataProviders {
   @After
   public void cleanHive() {
     // ensures all tables are removed
-    MetaStoreUtil metastore = new MetaStoreUtil(getConfiguration());
+    MetaStoreUtil metastore = MetaStoreUtil.get(getConfiguration());
     for (String database : metastore.getAllDatabases()) {
       for (String table : metastore.getAllTables(database)) {
         metastore.dropTable(database, table);

--- a/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestHivePartitioning.java
+++ b/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestHivePartitioning.java
@@ -37,7 +37,7 @@ public class TestHivePartitioning {
   @After
   public void cleanHive() {
     // ensures all tables are removed
-    MetaStoreUtil metastore = new MetaStoreUtil(new Configuration());
+    MetaStoreUtil metastore = MetaStoreUtil.get(new Configuration());
     for (String database : metastore.getAllDatabases()) {
       for (String table : metastore.getAllTables(database)) {
         metastore.dropTable(database, table);

--- a/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestHiveRepositoryURIs.java
+++ b/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestHiveRepositoryURIs.java
@@ -49,7 +49,7 @@ public class TestHiveRepositoryURIs extends TestFileSystemRepositoryURIs {
   @After
   public void cleanHive() {
     // ensures all tables are removed
-    MetaStoreUtil metastore = new MetaStoreUtil(getConfiguration());
+    MetaStoreUtil metastore = MetaStoreUtil.get(getConfiguration());
     for (String database : metastore.getAllDatabases()) {
       for (String table : metastore.getAllTables(database)) {
         metastore.dropTable(database, table);

--- a/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestManagedExternalHandling.java
+++ b/kite-data/kite-data-hive/src/test/java/org/kitesdk/data/spi/hive/TestManagedExternalHandling.java
@@ -62,7 +62,7 @@ public class TestManagedExternalHandling {
   @After
   public void cleanHive() {
     // ensures all tables are removed
-    MetaStoreUtil metastore = new MetaStoreUtil(new Configuration());
+    MetaStoreUtil metastore = MetaStoreUtil.get(new Configuration());
     for (String database : metastore.getAllDatabases()) {
       for (String table : metastore.getAllTables(database)) {
         metastore.dropTable(database, table);
@@ -146,7 +146,7 @@ public class TestManagedExternalHandling {
   @Test
   public void testRepositoryList() throws Exception {
     // create unreadable hive tables
-    MetaStoreUtil metastore = new MetaStoreUtil(new Configuration());
+    MetaStoreUtil metastore = MetaStoreUtil.get(new Configuration());
     metastore.dropTable("default", "bad_type");
     metastore.dropTable("bad", "bad_serde");
     metastore.dropTable("bad", "bad_schema");


### PR DESCRIPTION
This adds a MetaStoreUtil.get method that keeps track of util objects
(and the internal MetaStore connection) by connection URIs. These are
safe to share because they are thread-safe.