### PR TITLE
KITE-1068: SolrCellMorphlineTests fails on Locales with non-Arabic di…

### DIFF
--- a/kite-morphlines/kite-morphlines-solr-core/src/test/java/org/kitesdk/morphline/solr/AbstractSolrMorphlineTest.java
+++ b/kite-morphlines/kite-morphlines-solr-core/src/test/java/org/kitesdk/morphline/solr/AbstractSolrMorphlineTest.java
@@ -18,6 +18,7 @@ package org.kitesdk.morphline.solr;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.text.NumberFormat;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
@@ -133,6 +134,8 @@ public class AbstractSolrMorphlineTest extends SolrTestCaseJ4 {
     
     assumeTrue("This test has issues with this locale: https://issues.apache.org/jira/browse/SOLR-5778", 
         "GregorianCalendar".equals(Calendar.getInstance(TimeZone.getDefault(), Locale.getDefault()).getClass().getSimpleName()));
+    assumeTrue("This test has issues with locales with non-Arabic digits",
+        "1".equals(NumberFormat.getInstance().format(1)));
     deleteAllDocuments();
     int numDocs = 0;    
     for (int i = 0; i < 1; i++) {


### PR DESCRIPTION
SolrCellMorphlineTest (and I assume other tests that derive from AbstractSolrMorphlineTest, though I didn't explicitly test them) fail on Locales that use non-Arabic numbers.