### PR TITLE
KITE-1073: Remove work-around setting default FS in CLI.

### DIFF
--- a/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/tools/TransformTask.java
+++ b/kite-tools-parent/kite-tools/src/main/java/org/kitesdk/tools/TransformTask.java
@@ -148,10 +148,6 @@ public class TransformTask<S, T> extends Configured {
       // copy to avoid making changes to the caller's configuration
       Configuration conf = new Configuration(getConf());
       conf.set("mapreduce.framework.name", "local");
-      // replace the default FS for Crunch to avoid distributed cache errors.
-      // this doesn't affect the source or target, they are fully-qualified.
-      conf.set("fs.defaultFS", "file:/");
-      conf.set("fs.default.name", "file:/");
       setConf(conf);
     }
 


### PR DESCRIPTION
This removes the work-around added for KITE-898, where job submission
was failing when importing local-to-HDFS unless the default FS was
local. This is no longer needed and is causing a different failure.