### PR TITLE
KITE-1076: Fix flaky Crunch-Hive test.

### DIFF
--- a/kite-data/kite-data-crunch/pom.xml
+++ b/kite-data/kite-data-crunch/pom.xml
@@ -64,6 +64,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <reuseForks>false</reuseForks>
           <systemProperties>
             <property>
               <!-- Make sure derby.log goes to target/ subdir


### PR DESCRIPTION
The test fails in job setup using the local job runner when the HBase
test has been run first. It appears to be a bug in the test runner code
that can be avoided by not reusing test VMs for the Crunch module.