### PR TITLE
KITE-991: Fix Parquet file size estimate.

### DIFF
--- a/kite-app-parent/cdh5/pom.xml
+++ b/kite-app-parent/cdh5/pom.xml
@@ -435,12 +435,12 @@
       </dependency>
       <!-- manage parquet dependency versions !-->
       <dependency>
-        <groupId>com.twitter</groupId>
+        <groupId>org.apache.parquet</groupId>
         <artifactId>parquet-avro</artifactId>
         <version>${kite.parquet.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.twitter</groupId>
+        <groupId>org.apache.parquet</groupId>
         <artifactId>parquet-hadoop-bundle</artifactId>
         <version>${kite.parquet.version}</version>
       </dependency>

--- a/kite-data/kite-data-core/pom.xml
+++ b/kite-data/kite-data-core/pom.xml
@@ -137,7 +137,7 @@
       <artifactId>avro</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.twitter</groupId>
+      <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-avro</artifactId>
       <exclusions>
         <exclusion>

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/MarkerRange.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/MarkerRange.java
@@ -201,9 +201,9 @@ public class MarkerRange {
     }
 
     public Boundary(MarkerComparator comparator, Marker bound, boolean isInclusive) {
-      parquet.Preconditions.checkArgument(comparator != null,
+      Preconditions.checkArgument(comparator != null,
           "Comparator cannot be null");
-      parquet.Preconditions.checkArgument(bound != null,
+      Preconditions.checkArgument(bound != null,
           "Bound cannot be null");
 
       this.comparator = comparator;

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/Schemas.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/Schemas.java
@@ -29,9 +29,9 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import parquet.avro.AvroSchemaConverter;
-import parquet.hadoop.ParquetFileReader;
-import parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.avro.AvroSchemaConverter;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 
 public class Schemas {
   // used to match resource:schema.avsc URIs

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemViewKeyInputFormat.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemViewKeyInputFormat.java
@@ -35,8 +35,6 @@ import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
-import org.apache.hadoop.mapreduce.lib.input.CombineFileInputFormat;
-import org.apache.hadoop.mapreduce.lib.input.CombineFileRecordReader;
 import org.apache.hadoop.mapreduce.lib.input.CombineFileSplit;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.kitesdk.compat.DynMethods;
@@ -49,8 +47,8 @@ import org.kitesdk.data.spi.DataModelUtil;
 import org.kitesdk.data.spi.FilteredRecordReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import parquet.avro.AvroParquetInputFormat;
-import parquet.avro.AvroReadSupport;
+import org.apache.parquet.avro.AvroParquetInputFormat;
+import org.apache.parquet.avro.AvroReadSupport;
 
 class FileSystemViewKeyInputFormat<E> extends InputFormat<E, Void> {
 

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/ParquetAppender.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/ParquetAppender.java
@@ -76,9 +76,7 @@ class ParquetAppender<E extends IndexedRecord> implements FileSystemWriter.FileA
 
   @Override
   public long pos() throws IOException {
-    // TODO: add a callback to set the position when Parquet decides to flush
-    // this is not a good way to find out the current position
-    return fileSystem.getFileStatus(path).getLen();
+    return avroParquetWriter.getDataSize();
   }
 
   @Override

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/ParquetAppender.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/ParquetAppender.java
@@ -28,10 +28,9 @@ import org.kitesdk.data.CompressionType;
 import org.kitesdk.data.Formats;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import parquet.avro.AvroParquetWriter;
-import parquet.hadoop.ParquetFileWriter;
-import parquet.hadoop.ParquetWriter;
-import parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.avro.AvroParquetWriter;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
 class ParquetAppender<E extends IndexedRecord> implements FileSystemWriter.FileAppender<E> {
 

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/ParquetFileSystemDatasetReader.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/ParquetFileSystemDatasetReader.java
@@ -27,14 +27,13 @@ import com.google.common.base.Preconditions;
 import java.io.EOFException;
 import java.io.IOException;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import parquet.avro.AvroParquetReader;
-import parquet.avro.AvroReadSupport;
+import org.apache.parquet.avro.AvroParquetReader;
+import org.apache.parquet.avro.AvroReadSupport;
 
 class ParquetFileSystemDatasetReader<E extends IndexedRecord> extends AbstractDatasetReader<E> {
 

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestAvroWriter.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestAvroWriter.java
@@ -35,7 +35,7 @@ import org.kitesdk.data.spi.ReaderWriterState;
 public class TestAvroWriter extends TestFileSystemWriters {
   @Override
   public FileSystemWriter<Record> newWriter(Path directory, Schema schema) {
-    return FileSystemWriter.newWriter(fs, directory, 100, 2 * 1024 * 1024,
+    return FileSystemWriter.newWriter(fs, directory, 100, getTargetFileSize(),
         new DatasetDescriptor.Builder()
             .property(
                 "kite.writer.roll-interval-seconds", String.valueOf(10))
@@ -50,6 +50,11 @@ public class TestAvroWriter extends TestFileSystemWriters {
   @Override
   public DatasetReader<Record> newReader(Path path, Schema schema) {
     return new FileSystemDatasetReader<Record>(fs, path, schema, Record.class);
+  }
+
+  @Override
+  public long getTargetFileSize() {
+    return 2 * 1024 * 1024;
   }
 
   @Test

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemWriters.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemWriters.java
@@ -96,6 +96,8 @@ public abstract class TestFileSystemWriters extends MiniDFSTest {
         written, Lists.newArrayList((Iterator) init(reader)));
   }
 
+  public abstract long getTargetFileSize();
+
   @Test
   public void testTargetFileSize() throws IOException {
     init(fsWriter);
@@ -139,7 +141,7 @@ public abstract class TestFileSystemWriters extends MiniDFSTest {
     Assert.assertTrue("Should match written records",
         Sets.newHashSet(written).equals(Sets.newHashSet(actualContent)));
 
-    double ratioToTarget = (((double) rolledFile.getLen()) / 2 / 1024 / 1024);
+    double ratioToTarget = (((double) rolledFile.getLen()) / getTargetFileSize());
     Assert.assertTrue(
         "Should be within 10% of target size: " + ratioToTarget * 100,
         ratioToTarget > 0.90 && ratioToTarget < 1.10);

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestParquetWriter.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestParquetWriter.java
@@ -34,7 +34,7 @@ import org.kitesdk.data.Syncable;
 public class TestParquetWriter extends TestFileSystemWriters {
   @Override
   public FileSystemWriter<Record> newWriter(Path directory, Schema schema) {
-    return FileSystemWriter.newWriter(fs, directory, 1, -1,
+    return FileSystemWriter.newWriter(fs, directory, 1, getTargetFileSize(),
         new DatasetDescriptor.Builder()
             .property(
                 "kite.writer.roll-interval-seconds", String.valueOf(1))
@@ -47,6 +47,11 @@ public class TestParquetWriter extends TestFileSystemWriters {
   public DatasetReader<Record> newReader(Path path, Schema schema) {
     return new ParquetFileSystemDatasetReader<Record>(
         fs, path, schema, Record.class);
+  }
+
+  @Override
+  public long getTargetFileSize() {
+    return 5 * 1024 * 1024 / 2; // ~2.5MB
   }
 
   @Test
@@ -111,10 +116,5 @@ public class TestParquetWriter extends TestFileSystemWriters {
             .build());
     Assert.assertEquals("Enabling the non-durable parquet appender should get us a non-durable appender",
         ParquetAppender.class, writer.newAppender(testDirectory).getClass());
-  }
-
-  @Override
-  @Ignore // Needs PARQUET-308 to estimate current file size
-  public void testTargetFileSize() throws IOException {
   }
 }

--- a/kite-data/kite-data-hive/pom.xml
+++ b/kite-data/kite-data-hive/pom.xml
@@ -131,7 +131,7 @@
       <artifactId>avro</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.twitter</groupId>
+      <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-hive-bundle</artifactId>
       <exclusions>
         <exclusion>

--- a/kite-morphlines/kite-morphlines-hadoop-parquet-avro/pom.xml
+++ b/kite-morphlines/kite-morphlines-hadoop-parquet-avro/pom.xml
@@ -39,7 +39,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.twitter</groupId>
+      <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-avro</artifactId>
         <exclusions>
           <exclusion>

--- a/kite-morphlines/kite-morphlines-hadoop-parquet-avro/src/main/java/org/kitesdk/morphline/hadoop/parquet/avro/ReadAvroParquetFileBuilder.java
+++ b/kite-morphlines/kite-morphlines-hadoop-parquet-avro/src/main/java/org/kitesdk/morphline/hadoop/parquet/avro/ReadAvroParquetFileBuilder.java
@@ -40,8 +40,8 @@ import org.kitesdk.morphline.base.Fields;
 import org.kitesdk.morphline.base.Metrics;
 import org.kitesdk.morphline.stdio.AbstractParser;
 
-import parquet.avro.AvroParquetReader;
-import parquet.avro.AvroReadSupport;
+import org.apache.parquet.avro.AvroParquetReader;
+import org.apache.parquet.avro.AvroReadSupport;
 
 import com.codahale.metrics.Meter;
 import org.kitesdk.morphline.shaded.com.google.common.io.Closeables;

--- a/kite-morphlines/kite-morphlines-hadoop-parquet-avro/src/test/java/org/kitesdk/morphline/hadoop/parquet/avro/AvroParquetMorphlineTest.java
+++ b/kite-morphlines/kite-morphlines-hadoop-parquet-avro/src/test/java/org/kitesdk/morphline/hadoop/parquet/avro/AvroParquetMorphlineTest.java
@@ -34,7 +34,7 @@ import org.kitesdk.morphline.api.Record;
 import org.kitesdk.morphline.base.Fields;
 import org.kitesdk.morphline.hadoop.parquet.avro.ReadAvroParquetFileBuilder;
 
-import parquet.avro.AvroParquetWriter;
+import org.apache.parquet.avro.AvroParquetWriter;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
     <vers.mockito>1.9.5</vers.mockito>
     <vers.mojo-executor>1.5</vers.mojo-executor>
     <vers.oozie>3.3.2-cdh${cdh.version}</vers.oozie> <!-- OOZIE-1790 -->
-    <vers.parquet>1.6.0</vers.parquet>
+    <vers.parquet>1.8.1</vers.parquet>
     <vers.plexus-utils>3.0</vers.plexus-utils>
     <vers.rat>0.9</vers.rat>
     <vers.slf4j>1.6.1</vers.slf4j>
@@ -915,7 +915,7 @@
         <version>${vers.avro}</version>
       </dependency>
       <dependency>
-        <groupId>com.twitter</groupId>
+        <groupId>org.apache.parquet</groupId>
         <artifactId>parquet-hive-bundle</artifactId>
         <version>${vers.parquet}</version>
         <exclusions>
@@ -926,7 +926,7 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>com.twitter</groupId>
+        <groupId>org.apache.parquet</groupId>
         <artifactId>parquet-avro</artifactId>
         <version>${vers.parquet}</version>
         <exclusions>


### PR DESCRIPTION
This fixes size-based rolling for Parquet files and enables the test.
Size-based rolling was previously not working because it wasn't possible
to get the buffered size of a Parquet file. PARQUET-308 exposes an
accessor, which is now available after the update to 1.8.1.

This is based on KITE-1080 that updates Parquet to 1.8.1.
