### PR TITLE
KITE-1083: Add single jars to DistCache for Hive.

### DIFF
--- a/kite-tools-parent/pom.xml
+++ b/kite-tools-parent/pom.xml
@@ -207,6 +207,11 @@
          in the dependency modules
          -->
 
+    <!-- When changing Hive dependencies, be careful that the required jars are
+         pulled in by the TransformTask. New dependencies should be added to
+         the distributed cache by class.
+         -->
+
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-exec</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,10 @@
     <vers.hbase2>0.98.3-hadoop2</vers.hbase2>
     <vers.hbase-cdh4>0.94.6-cdh${cdh4.version}</vers.hbase-cdh4>
     <vers.hbase-cdh5>1.0.0-cdh${cdh5.version}</vers.hbase-cdh5>
+    <!-- When changing Hive versions, be careful that the required jars are
+         pulled in by the TransformTask in kite-tools. New dependencies
+         should be added to the distributed cache by class.
+         -->
     <vers.hive>1.1.0</vers.hive>
     <vers.hive-cdh5>1.1.0-cdh${cdh5.version}</vers.hive-cdh5>
     <vers.jetty>8.1.14.v20131031</vers.jetty>
@@ -792,6 +796,12 @@
       </dependency>
 
       <!-- Hive dependencies -->
+
+      <!-- When changing Hive dependencies, be careful that the required jars are
+           pulled in by the TransformTask in kite-tools. New dependencies
+           should be added to the distributed cache by class.
+           -->
+
       <dependency>
         <groupId>org.apache.hive</groupId>
         <artifactId>hive-exec</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
     <vers.hbase2>0.98.3-hadoop2</vers.hbase2>
     <vers.hbase-cdh4>0.94.6-cdh${cdh4.version}</vers.hbase-cdh4>
     <vers.hbase-cdh5>1.0.0-cdh${cdh5.version}</vers.hbase-cdh5>
-    <vers.hive>0.13.0</vers.hive>
+    <vers.hive>1.1.0</vers.hive>
     <vers.hive-cdh5>1.1.0-cdh${cdh5.version}</vers.hive-cdh5>
     <vers.jetty>8.1.14.v20131031</vers.jetty>
     <vers.jexl>2.1.1</vers.jexl>


### PR DESCRIPTION
This changes the way jobs submitted by the CLI are configured.
Previously, the entire lib directory for Hive was added to the
distributed cache. This caused long job and task startup times and
exposed some conflicting jar problems. This commit updates the setup so
that individual jars are added for classes needed for interacting with
the Hive MetaStore. In cases where the job is local or the job isn't
interacting with Hive, this doesn't add Hive dependencies to the
distributed cache at all.