### PR TITLE
KITE-1102: Correct URI pattern registrations for s3a protocol

### DIFF
--- a/kite-data/kite-data-s3/src/main/java/org/kitesdk/data/spi/s3/Loader.java
+++ b/kite-data/kite-data-s3/src/main/java/org/kitesdk/data/spi/s3/Loader.java
@@ -90,8 +90,8 @@ public class Loader implements Loadable {
         new URIPattern("s3n:/*path/:namespace/:dataset"),
         builder);
     Registration.register(
-        new URIPattern("s3a:/"),
-        new URIPattern("s3a:/:namespace/:dataset"),
+        new URIPattern("s3a:/*path"),
+        new URIPattern("s3a:/*path/:namespace/:dataset"),
         builder);
   }
 


### PR DESCRIPTION
Minor change to fix https://issues.cloudera.org/browse/KITE-1102