### PR TITLE
KITE-1101: Added logic to FileSystemPartitionIterator to exclude dire…

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/Constraints.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/Constraints.java
@@ -727,7 +727,9 @@ public class Constraints {
       }
 
       // this is fail-fast: if the key fails a constraint, then drop it
-      for (int i = 0; i < partitionPredicates.size(); i += 1) {
+      //only check for the number of values in the key in case the key does not
+      //have all fields populated yet
+      for (int i = 0; i < key.size(); i += 1) {
         Object pValue = key.get(i);
         if (!partitionPredicates.get(i).apply(pValue)) {
           return false;

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/Marker.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/Marker.java
@@ -120,6 +120,13 @@ public abstract class Marker {
   }
 
   /**
+   * Returns the number of elements in the marker.
+   * @return the number of elements in the marker.
+   * @since 1.2.0
+   */
+  public abstract int size();
+
+  /**
    * A basic Marker implementation backed by a Map.
    *
    * @since 0.9.0
@@ -162,6 +169,11 @@ public abstract class Marker {
         return false;
       }
       return Objects.equal(this.values, ((ImmutableMarker) obj).values);
+    }
+
+    @Override
+    public int size() {
+      return values.size();
     }
   }
 

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/StorageKey.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/StorageKey.java
@@ -96,12 +96,15 @@ public class StorageKey extends Marker implements Comparable<StorageKey> {
 
   @Override
   public boolean has(String name) {
-    return fields.containsKey(name);
+    //check if id value exists and it is less than the size meaning we have a value.
+    Integer id = fields.get(name);
+    return id != null && id < values.size();
   }
 
   @Override
   public Object get(String name) {
-    return values.get(fields.get(name));
+    int index = fields.get(name);
+    return index < values.size() ? values.get(index) : null;
   }
 
   /**
@@ -132,8 +135,6 @@ public class StorageKey extends Marker implements Comparable<StorageKey> {
    */
   public void replaceValues(List<Object> values) {
     Preconditions.checkArgument(values != null, "Values cannot be null");
-    Preconditions.checkArgument(values.size() == fields.size(),
-        "Not enough values for a complete StorageKey");
     this.values = values;
   }
 
@@ -182,6 +183,7 @@ public class StorageKey extends Marker implements Comparable<StorageKey> {
   public StorageKey reuseFor(Path path, PathConversion conversion) {
     conversion.toKey(path, this);
     this.path = path;
+
     return this;
   }
 
@@ -204,6 +206,10 @@ public class StorageKey extends Marker implements Comparable<StorageKey> {
       }
     }
     return 0;
+  }
+
+  public int size(){
+    return values.size();
   }
 
   @Override

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/StorageKey.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/StorageKey.java
@@ -135,6 +135,7 @@ public class StorageKey extends Marker implements Comparable<StorageKey> {
    */
   public void replaceValues(List<Object> values) {
     Preconditions.checkArgument(values != null, "Values cannot be null");
+    Preconditions.checkArgument(values.size() <= fields.size(), "Values cannot be larger than fields size");
     this.values = values;
   }
 

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/TimeDomain.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/TimeDomain.java
@@ -135,7 +135,8 @@ public class TimeDomain {
       for (CalendarFieldPartitioner fp : partitioners) {
         time.add((Integer) key.get(fp.getName()));
       }
-      return times.apply(time);
+      //if contains null is partial so allow it for now...
+      return time.contains(null) ? true : times.apply(time);
     }
 
     @Override
@@ -222,13 +223,19 @@ public class TimeDomain {
 
     private boolean checkLower(Marker key) {
       for (int i = 0; i < names.length; i += 1) {
-        int value = (Integer) key.get(names[i]);
-        if (value < lower[i]) {
-          // strictly within range, so all other levels must be
-          // example: 2013-4-10 to 2013-10-4 => 4 < month < 10 => accept
-          return false;
-        } else if (value > lower[i]) {
-          // falls out of the range at this level
+        Object markerValue = key.get(names[i]);
+        if(markerValue != null) {
+          int value = (Integer) markerValue;
+          if (value < lower[i]) {
+            // strictly within range, so all other levels must be
+            // example: 2013-4-10 to 2013-10-4 => 4 < month < 10 => accept
+            return false;
+          } else if (value > lower[i]) {
+            // falls out of the range at this level
+            return true;
+          }
+        }else {
+          //returning true because at this point no value is known so nothing to disqualify on
           return true;
         }
         // value was equal to one endpoint, continue checking
@@ -240,10 +247,17 @@ public class TimeDomain {
     private boolean checkUpper(Marker key) {
       // same as checkLower, see comments there
       for (int i = 0; i < names.length; i += 1) {
-        int value = (Integer) key.get(names[i]);
-        if (value > upper[i]) {
-          return false;
-        } else if (value < upper[i]) {
+
+        Object markerValue = key.get(names[i]);
+        if(markerValue != null) {
+          int value = (Integer) markerValue;
+          if (value > upper[i]) {
+            return false;
+          } else if (value < upper[i]) {
+            return true;
+          }
+        }else{
+          //returning true because at this point no value is known so nothing to disqualify on
           return true;
         }
       }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemViewKeyInputFormat.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemViewKeyInputFormat.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -127,10 +128,9 @@ class FileSystemViewKeyInputFormat<E> extends InputFormat<E, Void> {
         return new CSVInputFormat().getSplits(jobContext);
       } else if (Formats.INPUTFORMAT.equals(format)) {
         return InputFormatUtil.newInputFormatInstance(dataset.getDescriptor())
-            .getSplits(jobContext);
+                .getSplits(jobContext);
       } else {
-        throw new UnsupportedOperationException(
-            "Not a supported format: " + format);
+        throw new UnsupportedOperationException("Not a supported format: " + format);
       }
     } else {
       return ImmutableList.of();
@@ -141,7 +141,6 @@ class FileSystemViewKeyInputFormat<E> extends InputFormat<E, Void> {
   private boolean setInputPaths(JobContext jobContext, Job job) throws IOException {
     List<Path> paths = Lists.newArrayList((Iterator)
         (view == null ? dataset.pathIterator() : view.pathIterator()));
-    LOG.debug("Input paths: {}", paths);
     if (paths.isEmpty()) {
       return false;
     }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemViewKeyInputFormat.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemViewKeyInputFormat.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -128,9 +127,10 @@ class FileSystemViewKeyInputFormat<E> extends InputFormat<E, Void> {
         return new CSVInputFormat().getSplits(jobContext);
       } else if (Formats.INPUTFORMAT.equals(format)) {
         return InputFormatUtil.newInputFormatInstance(dataset.getDescriptor())
-                .getSplits(jobContext);
+            .getSplits(jobContext);
       } else {
-        throw new UnsupportedOperationException("Not a supported format: " + format);
+        throw new UnsupportedOperationException(
+            "Not a supported format: " + format);
       }
     } else {
       return ImmutableList.of();
@@ -141,6 +141,7 @@ class FileSystemViewKeyInputFormat<E> extends InputFormat<E, Void> {
   private boolean setInputPaths(JobContext jobContext, Job job) throws IOException {
     List<Path> paths = Lists.newArrayList((Iterator)
         (view == null ? dataset.pathIterator() : view.pathIterator()));
+    LOG.debug("Input paths: {}", paths);
     if (paths.isEmpty()) {
       return false;
     }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/PartialPathConversion.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/PartialPathConversion.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2013 Cloudera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data.spi.filesystem;
+
+import com.google.common.collect.Lists;
+import org.apache.avro.Schema;
+import org.apache.hadoop.fs.Path;
+import org.kitesdk.data.impl.Accessor;
+import org.kitesdk.data.spi.FieldPartitioner;
+import org.kitesdk.data.spi.StorageKey;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * An implementation of {@link PathConversion} that builds a key from the start of the path to the end
+ * instead of started at the end and building backwards.  The benefit of implementation is that the
+ * partial keys can be created without traversing the entire tree.
+ */
+public class PartialPathConversion extends PathConversion{
+
+  private final Path rootPath;
+
+  /**
+   * Creates a conversion for any path prefixed with the {@code rootDirectory} and partitioned
+   * @param rootDirectory the root location from which the path is being evaluated
+   * @param schema The schema for the payload dataset
+     */
+  public PartialPathConversion(Path rootDirectory, Schema schema){
+    super(schema);
+    this.rootPath = rootDirectory;
+  }
+
+  //Supposed to build keys from start to finish vs end to start
+  public StorageKey toKey(Path fromPath, StorageKey storage) {
+    final List<FieldPartitioner> partitioners =
+            Accessor.getDefault().getFieldPartitioners(storage.getPartitionStrategy());
+
+    //Strip off the root directory to get partition segments
+    String truncatedPath = fromPath.toString();
+    if(truncatedPath.startsWith(rootPath.toString())){
+      truncatedPath = truncatedPath.substring(rootPath.toString().length());
+    }
+
+    List<String> pathParts = new LinkedList<String>();
+    //Check that there are segments to parse.
+    if(!truncatedPath.isEmpty()) {
+      Path currentPath = new Path(truncatedPath);
+      while (currentPath != null) {
+        String name = currentPath.getName();
+        if(!name.isEmpty()) {
+          pathParts.add(currentPath.getName());
+        }
+        currentPath = currentPath.getParent();
+      }
+
+      //list is now last -> first so reverse the list to be first -> last
+      Collections.reverse(pathParts);
+    }
+
+
+    final List<Object> values = Lists.newArrayList(
+            new Object[pathParts.size()]);
+    //for each segment we have get the value for the key
+    for(int  i = 0; i < pathParts.size(); i++){
+      values.set(i, valueForDirname(
+              (FieldPartitioner<?, ?>) partitioners.get(i),
+              pathParts.get(i)));
+    }
+
+    storage.replaceValues(values);
+    return storage;
+  }
+}

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/PathConversion.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/PathConversion.java
@@ -42,7 +42,7 @@ import java.util.Map;
 public class PathConversion {
 
   private final Schema schema;
-
+  
   public PathConversion(Schema schema) {
     this.schema = schema;
   }

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestPartialPathConversion.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestPartialPathConversion.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2013 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kitesdk.data.spi.filesystem;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.Lists;
+import junit.framework.Assert;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.hadoop.fs.Path;
+import org.junit.Test;
+import org.kitesdk.data.PartitionStrategy;
+import org.kitesdk.data.spi.StorageKey;
+
+import java.util.Collections;
+import java.util.List;
+
+public class TestPartialPathConversion {
+
+    private static final Schema schema = SchemaBuilder.record("Event").fields()
+            .requiredLong("id")
+            .requiredLong("timestamp")
+            .endRecord();
+
+    private static final Path ROOT_PATH = new Path("/some/root/path");
+    private static final PathConversion convert = new PartialPathConversion(ROOT_PATH, schema);
+    private static final Splitter EQ = Splitter.on('=');
+
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testToKey() {
+        PartitionStrategy strategy = new PartitionStrategy.Builder()
+                .identity("id")
+                .year("timestamp")
+                .month("timestamp")
+                .day("timestamp")
+                .build();
+
+        StorageKey expected = new StorageKey(strategy);
+        expected.replaceValues((List) Lists.newArrayList(1L, 2013, 11));
+
+        Assert.assertEquals(expected, convert.toKey(
+                new Path(ROOT_PATH, "id=1/year=2013/month=11"), new StorageKey(strategy)));
+
+        expected.replaceValues((List) Lists.newArrayList(1L, 2013));
+
+        Assert.assertEquals(expected, convert.toKey(
+                new Path(ROOT_PATH, "id=1/year=2013"), new StorageKey(strategy)));
+
+        expected.replaceValues((List) Lists.newArrayList(1L));
+
+        Assert.assertEquals(expected, convert.toKey(
+                new Path(ROOT_PATH, "id=1"), new StorageKey(strategy)));
+
+        expected.replaceValues(Collections.emptyList());
+
+        Assert.assertEquals(expected, convert.toKey(
+                ROOT_PATH, new StorageKey(strategy)));
+    }
+}


### PR DESCRIPTION
…ctories with data that does not qualify. Extended predicates and StorageKey code to support partial values.

Note this might violate some of the initial designs for StorageKey and the Predicates so I'm open to alternate ways of doing this logic.  @rdblue and @rbrush if you have some insight or critique that would be helpful.  It is not necessarily the cleanest changes so if you have suggestions on how to clean this up with original design intent that would be helpful.

In some smaller tests I've seen significant improvements in job startup time (1s vs 100s) and a lot less memory pressure on the driver program when kicking off the job.