### PR TITLE
KITE-1118: Optimize writing data to S3

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemProperties.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemProperties.java
@@ -60,4 +60,12 @@ public class FileSystemProperties {
    * be closed and finalized once they reach this age.
    */
   public static final String ROLL_INTERVAL_S_PROP = "kite.writer.roll-interval-seconds";
+
+  /**
+   * Until HADOOP-9565 is available and fully adopted, need to make this configurable so that
+   * we can avoid multiple expensive copy operations when writing output to a file system that
+   * does not support fast file renaming. Default is false unless the FileSystem URI scheme is
+   * s3n or s3a.
+   */
+  public static final String OBJECTSTORE_FILESYSTEM = "kite.writer.object-store";
 }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemProperties.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemProperties.java
@@ -64,8 +64,8 @@ public class FileSystemProperties {
   /**
    * Until HADOOP-9565 is available and fully adopted, need to make this configurable so that
    * we can avoid multiple expensive copy operations when writing output to a file system that
-   * does not support fast file renaming. Default is false unless the FileSystem URI scheme is
-   * s3n or s3a.
+   * does not support efficient file renaming. Default is true unless the FileSystem URI scheme
+   * is s3n or s3a.
    */
-  public static final String OBJECTSTORE_FILESYSTEM = "kite.writer.object-store";
+  public static final String SUPPORTS_RENAME_PROP = "kite.writer.fs-supports-rename";
 }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemUtil.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemUtil.java
@@ -21,6 +21,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import java.io.IOException;
+import java.net.URI;
 import java.util.Collection;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -658,5 +659,24 @@ public class FileSystemUtil {
     } else {
       return SchemaUtil.merge(left, right);
     }
+  }
+
+  /**
+   * Check if an object store FileSystem such as S3 is being used.
+   *
+   * @param fsUri the FileSystem URI
+   * @param conf the FileSystem Configuration
+   * @return {@code true} if the FileSystem URI or {@link FileSystemProperties#OBJECTSTORE_FILESYSTEM
+   *     configuration} indicates that we are using an object store FileSystem implementation,
+   *     {@code false} otherwise.
+   */
+  public static boolean isObjectStoreFileSystem(URI fsUri, Configuration conf) {
+    String fsUriScheme = fsUri.getScheme();
+
+    // Only S3 is an object store by default, but allow configuration override.
+    // This logic is intended as a temporary placeholder solution and should
+    // be revisited once HADOOP-9565 has been completed.
+    return conf.getBoolean(FileSystemProperties.OBJECTSTORE_FILESYSTEM,
+        fsUriScheme.equals("s3n") || fsUriScheme.equals("s3a"));
   }
 }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemUtil.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemUtil.java
@@ -662,21 +662,22 @@ public class FileSystemUtil {
   }
 
   /**
-   * Check if an object store FileSystem such as S3 is being used.
+   * Determine whether a FileSystem that supports efficient file renaming is being used. Two known
+   * FileSystem implementations that currently lack this feature are S3N and S3A.
    *
    * @param fsUri the FileSystem URI
    * @param conf the FileSystem Configuration
-   * @return {@code true} if the FileSystem URI or {@link FileSystemProperties#OBJECTSTORE_FILESYSTEM
-   *     configuration} indicates that we are using an object store FileSystem implementation,
-   *     {@code false} otherwise.
+   * @return {@code true} if the FileSystem URI or {@link FileSystemProperties#SUPPORTS_RENAME_PROP
+   *     configuration override} indicates that the FileSystem implementation supports efficient
+   *     rename operations, {@code false} otherwise.
    */
-  public static boolean isObjectStoreFileSystem(URI fsUri, Configuration conf) {
+  public static boolean supportsRename(URI fsUri, Configuration conf) {
     String fsUriScheme = fsUri.getScheme();
 
-    // Only S3 is an object store by default, but allow configuration override.
+    // Only S3 is known to not support renaming, but allow configuration override.
     // This logic is intended as a temporary placeholder solution and should
     // be revisited once HADOOP-9565 has been completed.
-    return conf.getBoolean(FileSystemProperties.OBJECTSTORE_FILESYSTEM,
-        fsUriScheme.equals("s3n") || fsUriScheme.equals("s3a"));
+    return conf.getBoolean(FileSystemProperties.SUPPORTS_RENAME_PROP,
+        !(fsUriScheme.equalsIgnoreCase("s3n") || fsUriScheme.equalsIgnoreCase("s3a")));
   }
 }

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemWriter.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemWriter.java
@@ -121,9 +121,9 @@ class FileSystemWriter<E> extends AbstractDatasetWriter<E> implements RollingWri
       conf.set(prop, descriptor.getProperty(prop));
     }
 
-    // For performance reasons we will likely wish to skip temp file creation if the file system is an
-    // object store such as S3, and write the file directly.
-    this.useTempPath = !FileSystemUtil.isObjectStoreFileSystem(fs.getUri(), conf);
+    // For performance reasons we will skip temp file creation if the file system does not support
+    // efficient renaming, and write the file directly.
+    this.useTempPath = FileSystemUtil.supportsRename(fs.getUri(), conf);
   }
 
   @Override

--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemWriter.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/FileSystemWriter.java
@@ -98,6 +98,9 @@ class FileSystemWriter<E> extends AbstractDatasetWriter<E> implements RollingWri
   @VisibleForTesting
   final Configuration conf;
 
+  @VisibleForTesting
+  final boolean useTempPath;
+
   private FileSystemWriter(FileSystem fs, Path path, long rollIntervalMillis,
                            long targetFileSize, DatasetDescriptor descriptor, Schema writerSchema) {
     Preconditions.checkNotNull(fs, "File system is not defined");
@@ -117,6 +120,10 @@ class FileSystemWriter<E> extends AbstractDatasetWriter<E> implements RollingWri
     for (String prop : descriptor.listProperties()) {
       conf.set(prop, descriptor.getProperty(prop));
     }
+
+    // For performance reasons we will likely wish to skip temp file creation if the file system is an
+    // object store such as S3, and write the file directly.
+    this.useTempPath = !FileSystemUtil.isObjectStoreFileSystem(fs.getUri(), conf);
   }
 
   @Override
@@ -142,7 +149,7 @@ class FileSystemWriter<E> extends AbstractDatasetWriter<E> implements RollingWri
     // initialize paths
     try {
       this.finalPath = new Path(directory, uniqueFilename(descriptor.getFormat()));
-      this.tempPath = tempFilename(finalPath);
+      this.tempPath = useTempPath ? tempFilename(finalPath) : finalPath;
     } catch (RuntimeException e) {
       this.state = ReaderWriterState.ERROR;
       throw new DatasetOperationException(e,
@@ -218,17 +225,20 @@ class FileSystemWriter<E> extends AbstractDatasetWriter<E> implements RollingWri
       // been flushed or the writer is not in an error state. Only instances of
       // IncrementalWriter set flushed to true.
       if (count > 0 && (flushed || ReaderWriterState.OPEN.equals(state))) {
-        // commit the temp file
-        try {
-          if (!fs.rename(tempPath, finalPath)) {
-            throw new DatasetOperationException(
-                "Failed to move %s to %s", tempPath, finalPath);
+        // commit the temp file if using one (otherwise temp=final so no action
+        // is necessary)
+        if (useTempPath) {
+          try {
+            if (!fs.rename(tempPath, finalPath)) {
+              throw new DatasetOperationException(
+                  "Failed to move %s to %s", tempPath, finalPath);
+            }
+          } catch (RuntimeException e) {
+            throw new DatasetOperationException(e,
+                "Failed to commit %s", finalPath);
+          } catch (IOException e) {
+            throw new DatasetIOException("Failed to commit " + finalPath, e);
           }
-        } catch (RuntimeException e) {
-          throw new DatasetOperationException(e,
-              "Failed to commit %s", finalPath);
-        } catch (IOException e) {
-          throw new DatasetIOException("Failed to commit " + finalPath, e);
         }
 
         LOG.debug("Committed {} for appender {} ({} entities)",

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestAvroObjectStoreWriter.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestAvroObjectStoreWriter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013 Cloudera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kitesdk.data.spi.filesystem;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData.Record;
+import org.apache.hadoop.fs.Path;
+import org.kitesdk.data.DatasetDescriptor;
+
+public class TestAvroObjectStoreWriter extends TestAvroWriter {
+  @Override
+  public FileSystemWriter<Record> newWriter(Path directory, Schema datasetSchema, Schema writerSchema) {
+    return FileSystemWriter.newWriter(fs, directory, 100, 2 * 1024 * 1024,
+        new DatasetDescriptor.Builder()
+            .property(
+                "kite.writer.roll-interval-seconds", String.valueOf(10))
+            .property(
+                "kite.writer.target-file-size",
+                String.valueOf(32 * 1024 * 1024)) // 32 MB
+            .property(
+                "kite.writer.object-store", String.valueOf(true))
+            .schema(datasetSchema)
+            .format("avro")
+            .build(), writerSchema);
+  }
+}

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestAvroWriterWithoutRename.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestAvroWriterWithoutRename.java
@@ -21,7 +21,7 @@ import org.apache.avro.generic.GenericData.Record;
 import org.apache.hadoop.fs.Path;
 import org.kitesdk.data.DatasetDescriptor;
 
-public class TestAvroObjectStoreWriter extends TestAvroWriter {
+public class TestAvroWriterWithoutRename extends TestAvroWriter {
   @Override
   public FileSystemWriter<Record> newWriter(Path directory, Schema datasetSchema, Schema writerSchema) {
     return FileSystemWriter.newWriter(fs, directory, 100, 2 * 1024 * 1024,
@@ -32,7 +32,7 @@ public class TestAvroObjectStoreWriter extends TestAvroWriter {
                 "kite.writer.target-file-size",
                 String.valueOf(32 * 1024 * 1024)) // 32 MB
             .property(
-                "kite.writer.object-store", String.valueOf(true))
+                "kite.writer.fs-supports-rename", String.valueOf(false))
             .schema(datasetSchema)
             .format("avro")
             .build(), writerSchema);

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemUtil.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemUtil.java
@@ -698,37 +698,37 @@ public class TestFileSystemUtil {
   }
 
   @Test
-  public void testObjectStoreConfigNotSet() {
-    Assert.assertTrue("Should default to object store for S3A",
-        FileSystemUtil.isObjectStoreFileSystem(URI.create("s3a://bucket/path"), new Configuration()));
-    Assert.assertTrue("Should default to object store for S3N",
-        FileSystemUtil.isObjectStoreFileSystem(URI.create("s3n://bucket/path"), new Configuration()));
-    Assert.assertFalse("Should default to not object store for HDFS",
-        FileSystemUtil.isObjectStoreFileSystem(URI.create("hdfs://cluster/path"), new Configuration()));
-    Assert.assertFalse("Should default to not object store for FILE",
-        FileSystemUtil.isObjectStoreFileSystem(URI.create("file:///path"), new Configuration()));
+  public void testSupportsRenameConfigNotSet() {
+    Assert.assertFalse("Should default to false for S3A",
+        FileSystemUtil.supportsRename(URI.create("s3a://bucket/path"), new Configuration()));
+    Assert.assertFalse("Should default to false for S3N",
+        FileSystemUtil.supportsRename(URI.create("s3n://bucket/path"), new Configuration()));
+    Assert.assertTrue("Should default to true for HDFS",
+        FileSystemUtil.supportsRename(URI.create("hdfs://cluster/path"), new Configuration()));
+    Assert.assertTrue("Should default to true for FILE",
+        FileSystemUtil.supportsRename(URI.create("file:///path"), new Configuration()));
   }
 
   @Test
-  public void testObjectStoreConfigFalse() {
+  public void testSupportsRenameConfigFalse() {
     Configuration conf = new Configuration();
-    conf.setBoolean(FileSystemProperties.OBJECTSTORE_FILESYSTEM, false);
+    conf.setBoolean(FileSystemProperties.SUPPORTS_RENAME_PROP, false);
 
-    Assert.assertFalse("Should override via config to not object store for S3A",
-        FileSystemUtil.isObjectStoreFileSystem(URI.create("s3a://bucket/path"), conf));
-    Assert.assertFalse("Should override via config to not object store for S3N",
-        FileSystemUtil.isObjectStoreFileSystem(URI.create("s3n://bucket/path"), conf));
+    Assert.assertFalse("Should override via config to false for HDFS",
+        FileSystemUtil.supportsRename(URI.create("hdfs://cluster/path"), conf));
+    Assert.assertFalse("Should override via config to false for FILE",
+        FileSystemUtil.supportsRename(URI.create("file:///path"), conf));
   }
 
   @Test
-  public void testObjectStoreConfigTrue() {
+  public void testSupportsRenameConfigTrue() {
     Configuration conf = new Configuration();
-    conf.setBoolean(FileSystemProperties.OBJECTSTORE_FILESYSTEM, true);
+    conf.setBoolean(FileSystemProperties.SUPPORTS_RENAME_PROP, true);
 
-    Assert.assertTrue("Should override via config to object store for HDFS",
-        FileSystemUtil.isObjectStoreFileSystem(URI.create("hdfs://cluster/path"), conf));
-    Assert.assertTrue("Should override via config to object store for FILE",
-        FileSystemUtil.isObjectStoreFileSystem(URI.create("file:///path"), conf));
+    Assert.assertTrue("Should override via config to true for S3A",
+        FileSystemUtil.supportsRename(URI.create("s3a://bucket/path"), conf));
+    Assert.assertTrue("Should override via config true for S3N",
+        FileSystemUtil.supportsRename(URI.create("s3n://bucket/path"), conf));
   }
 
   private URI parent(URI file) {

--- a/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemUtil.java
+++ b/kite-data/kite-data-core/src/test/java/org/kitesdk/data/spi/filesystem/TestFileSystemUtil.java
@@ -697,6 +697,40 @@ public class TestFileSystemUtil {
         });
   }
 
+  @Test
+  public void testObjectStoreConfigNotSet() {
+    Assert.assertTrue("Should default to object store for S3A",
+        FileSystemUtil.isObjectStoreFileSystem(URI.create("s3a://bucket/path"), new Configuration()));
+    Assert.assertTrue("Should default to object store for S3N",
+        FileSystemUtil.isObjectStoreFileSystem(URI.create("s3n://bucket/path"), new Configuration()));
+    Assert.assertFalse("Should default to not object store for HDFS",
+        FileSystemUtil.isObjectStoreFileSystem(URI.create("hdfs://cluster/path"), new Configuration()));
+    Assert.assertFalse("Should default to not object store for FILE",
+        FileSystemUtil.isObjectStoreFileSystem(URI.create("file:///path"), new Configuration()));
+  }
+
+  @Test
+  public void testObjectStoreConfigFalse() {
+    Configuration conf = new Configuration();
+    conf.setBoolean(FileSystemProperties.OBJECTSTORE_FILESYSTEM, false);
+
+    Assert.assertFalse("Should override via config to not object store for S3A",
+        FileSystemUtil.isObjectStoreFileSystem(URI.create("s3a://bucket/path"), conf));
+    Assert.assertFalse("Should override via config to not object store for S3N",
+        FileSystemUtil.isObjectStoreFileSystem(URI.create("s3n://bucket/path"), conf));
+  }
+
+  @Test
+  public void testObjectStoreConfigTrue() {
+    Configuration conf = new Configuration();
+    conf.setBoolean(FileSystemProperties.OBJECTSTORE_FILESYSTEM, true);
+
+    Assert.assertTrue("Should override via config to object store for HDFS",
+        FileSystemUtil.isObjectStoreFileSystem(URI.create("hdfs://cluster/path"), conf));
+    Assert.assertTrue("Should override via config to object store for FILE",
+        FileSystemUtil.isObjectStoreFileSystem(URI.create("file:///path"), conf));
+  }
+
   private URI parent(URI file) {
     return new Path(file).getParent().toUri();
   }

--- a/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/DatasetKeyOutputFormat.java
+++ b/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/DatasetKeyOutputFormat.java
@@ -55,6 +55,7 @@ import org.kitesdk.data.spi.TemporaryDatasetRepository;
 import org.kitesdk.data.spi.TemporaryDatasetRepositoryAccessor;
 import org.kitesdk.data.spi.filesystem.FileSystemDataset;
 import org.kitesdk.data.spi.filesystem.FileSystemProperties;
+import org.kitesdk.data.spi.filesystem.FileSystemUtil;
 
 /**
  * A MapReduce {@code OutputFormat} for writing to a {@link Dataset}.
@@ -444,7 +445,7 @@ public class DatasetKeyOutputFormat<E> extends OutputFormat<E, Void> {
     View<E> target = load(taskAttemptContext);
     View<E> working;
 
-    if (usePerTaskAttemptDatasets(target)) {
+    if (usePerTaskAttemptDatasets(target, conf)) {
       working = loadOrCreateTaskAttemptView(taskAttemptContext);
     } else {
       working = target;
@@ -503,11 +504,17 @@ public class DatasetKeyOutputFormat<E> extends OutputFormat<E, Void> {
     Configuration conf = Hadoop.TaskAttemptContext.getConfiguration.invoke(taskAttemptContext);
     DefaultConfiguration.init(conf);
     View<E> view = load(taskAttemptContext);
-    return usePerTaskAttemptDatasets(view) ?
+    return usePerTaskAttemptDatasets(view, conf) ?
         new MergeOutputCommitter<E>() : new NullOutputCommitter();
   }
 
-  private static <E> boolean usePerTaskAttemptDatasets(View<E> target) {
+  private static <E> boolean usePerTaskAttemptDatasets(View<E> target, Configuration conf) {
+    // For performance reasons we should skip the intermediate task attempt and job output datasets if the
+    // file system is an object store such as S3, and write to the target dataset directly.
+    if (FileSystemUtil.isObjectStoreFileSystem(URI.create(target.getUri().getSchemeSpecificPart()), conf)) {
+      return false;
+    }
+
     // new API output committers are not called properly in Hadoop 1
     return !Hadoop.isHadoop1() && target.getDataset() instanceof Mergeable;
   }

--- a/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/DatasetKeyOutputFormat.java
+++ b/kite-data/kite-data-mapreduce/src/main/java/org/kitesdk/data/mapreduce/DatasetKeyOutputFormat.java
@@ -510,8 +510,8 @@ public class DatasetKeyOutputFormat<E> extends OutputFormat<E, Void> {
 
   private static <E> boolean usePerTaskAttemptDatasets(View<E> target, Configuration conf) {
     // For performance reasons we should skip the intermediate task attempt and job output datasets if the
-    // file system is an object store such as S3, and write to the target dataset directly.
-    if (FileSystemUtil.isObjectStoreFileSystem(URI.create(target.getUri().getSchemeSpecificPart()), conf)) {
+    // file system does not support efficient renaming (such as S3), and write to the target dataset directly.
+    if (!FileSystemUtil.supportsRename(URI.create(target.getUri().getSchemeSpecificPart()), conf)) {
       return false;
     }
 


### PR DESCRIPTION
Pull request for https://issues.cloudera.org/browse/KITE-1118

For importing about 20 GB of data into S3, this provided approximately an 8x job speedup, from 40 min to 5 min.