### PR TITLE
KITE-1126: Update morphlines to use Solr6.3.0 instead of Solr4

### DIFF
--- a/kite-morphlines/kite-morphlines-solr-core/pom.xml
+++ b/kite-morphlines/kite-morphlines-solr-core/pom.xml
@@ -96,6 +96,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>${vers.maven-surefire-plugin}</version>
         <configuration>
           <argLine>-Xmx2048m -Dtests.locale=en-US</argLine>
           <!--<forkMode>always</forkMode>-->

--- a/kite-morphlines/kite-morphlines-solr-core/pom.xml
+++ b/kite-morphlines/kite-morphlines-solr-core/pom.xml
@@ -73,6 +73,12 @@
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <dependencyManagement>

--- a/kite-morphlines/kite-morphlines-solr-core/pom.xml
+++ b/kite-morphlines/kite-morphlines-solr-core/pom.xml
@@ -97,7 +97,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>-Dtests.locale=en-US</argLine>
+          <argLine>-Xmx2048m -Dtests.locale=en-US</argLine>
           <!--<forkMode>always</forkMode>-->
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
           <systemPropertyVariables>

--- a/pom.xml
+++ b/pom.xml
@@ -171,9 +171,9 @@
     <vers.slf4j>1.6.1</vers.slf4j>
     <vers.codahale.metrics>3.0.2</vers.codahale.metrics>
     <vers.typesafe.config>1.0.2</vers.typesafe.config>
-    <vers.solr>6.2.1</vers.solr>
-    <solr.expected.version>6.2.1</solr.expected.version> <!-- sanity check to verify we actually run against the expected version rather than some outdated version -->
-    <vers.solr-cdh5>6.2.1</vers.solr-cdh5>
+    <vers.solr>6.3.0</vers.solr>
+    <solr.expected.version>6.3.0</solr.expected.version> <!-- sanity check to verify we actually run against the expected version rather than some outdated version -->
+    <vers.solr-cdh5>6.3.0</vers.solr-cdh5>
     <vers.tika>1.13</vers.tika>
     <vers.jackson>2.3.1</vers.jackson>
     <vers.opencsv>2.3</vers.opencsv>

--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
     <vers.maven-shade-plugin>2.3</vers.maven-shade-plugin>
     <vers.maven-site-plugin>3.3</vers.maven-site-plugin>
     <vers.maven-source-plugin>2.2.1</vers.maven-source-plugin>
-    <vers.maven-surefire-plugin>2.14.1</vers.maven-surefire-plugin>
+    <vers.maven-surefire-plugin>2.19.1</vers.maven-surefire-plugin>
     <vers.maven-antrun-plugin>1.7</vers.maven-antrun-plugin>
     <vers.maven-jar-plugin>2.4</vers.maven-jar-plugin>
     <vers.maven-exec-plugin>1.2.1</vers.maven-exec-plugin>


### PR DESCRIPTION
Corresponding JIRA is here: https://issues.cloudera.org/browse/KITE-1126