### PR TITLE
KITE-452 javaVersion prop to use by maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -428,7 +428,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${vers.maven-compiler-plugin}</version>
           <configuration>
-            <source>1.6</source>
+            <source>${javaVersion}</source>
             <target>${targetJavaVersion}</target>
             <compilerArgs>
               <arg>-Xlint:unchecked</arg>


### PR DESCRIPTION
 In top level pom.xml the maven compiler plugin to use the javaVersion property instead of the hard coded 1.6 value