### PR TITLE
KITE-1137 javaTargetVersion=1.7 and javaVersion prop to be used by maven compiler plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ For Hadoop 1:
 mvn install -Dhadoop.profile=1
 ```
 
-By default Java 7 is used. If you want to use Java 6, then add `-DjavaVersion=1.6`, e.g.
+By default Java 7 is used. If you want to use Java 6, then add `-DjavaVersion=1.6`, `-DjavaTargetVersion=1.6` e.g.
 
 ```
-mvn install -DjavaVersion=1.6
+mvn install -DjavaVersion=1.6 -DjavaTargetVersion=1.6
 ```

--- a/kite-data/kite-data-hive/src/main/java/org/kitesdk/data/spi/hive/HiveUtils.java
+++ b/kite-data/kite-data-hive/src/main/java/org/kitesdk/data/spi/hive/HiveUtils.java
@@ -35,7 +35,6 @@ import org.apache.avro.Schema;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Order;
@@ -45,7 +44,6 @@ import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
-import org.kitesdk.compat.DynMethods;
 import org.kitesdk.compat.Hadoop;
 import org.kitesdk.data.DatasetDescriptor;
 import org.kitesdk.data.DatasetException;
@@ -60,7 +58,7 @@ import org.kitesdk.data.spi.FieldPartitioner;
 import org.kitesdk.data.spi.SchemaUtil;
 
 class HiveUtils {
-  static final String HDFS_SCHEME = "hdfs";
+  private static final String HDFS_SCHEME = "hdfs";
 
   private static final String CUSTOM_PROPERTIES_PROPERTY_NAME = "kite.custom.property.names";
   private static final String PARTITION_EXPRESSION_PROPERTY_NAME = "kite.partition.expression";
@@ -181,7 +179,7 @@ class HiveUtils {
   private static List<FieldSchema> getPartCols(Table table) {
     List<FieldSchema> partKeys = table.getPartitionKeys();
     if (partKeys == null) {
-      partKeys = new ArrayList<FieldSchema>();
+      partKeys = new ArrayList<>();
       table.setPartitionKeys(partKeys);
     }
     return partKeys;
@@ -191,6 +189,7 @@ class HiveUtils {
    * Returns the first non-null value from the sequence or null if there is no
    * non-null value.
    */
+  @SafeVarargs
   private static <T> T coalesce(T... values) {
     for (T value : values) {
       if (value != null) {
@@ -218,6 +217,8 @@ class HiveUtils {
       table.setTableType(TableType.EXTERNAL_TABLE.toString());
       // but it doesn't work without some additional magic:
       table.getParameters().put("EXTERNAL", "TRUE");
+
+      Preconditions.checkNotNull(descriptor.getLocation(), "Descriptor.location cannot be null");
       table.getSd().setLocation(descriptor.getLocation().toString());
     } else {
       table.setTableType(TableType.MANAGED_TABLE.toString());
@@ -238,10 +239,11 @@ class HiveUtils {
 
     if (includeSchema) {
       URL schemaURL = descriptor.getSchemaUrl();
-      if (useSchemaURL(schemaURL)) {
+      
+      if (schemaURL != null && useSchemaURL(schemaURL)) {
         table.getParameters().put(
             AVRO_SCHEMA_URL_PROPERTY_NAME,
-            descriptor.getSchemaUrl().toExternalForm());
+                schemaURL.toExternalForm());
       } else {
         table.getParameters().put(
             AVRO_SCHEMA_LITERAL_PROPERTY_NAME,
@@ -268,8 +270,7 @@ class HiveUtils {
 
   private static boolean useSchemaURL(@Nullable URL schemaURL) {
     try {
-      return ((schemaURL != null) &&
-          HDFS_SCHEME.equals(schemaURL.toURI().getScheme()));
+      return schemaURL != null && HDFS_SCHEME.equals(schemaURL.toURI().getScheme());
     } catch (URISyntaxException ex) {
       return false;
     }
@@ -300,11 +301,11 @@ class HiveUtils {
     return table;
   }
 
-  public static void updateTableSchema(Table table, DatasetDescriptor descriptor) {
+  static void updateTableSchema(Table table, DatasetDescriptor descriptor) {
     URL schemaURL = descriptor.getSchemaUrl();
 
     if (table.getParameters().get(AVRO_SCHEMA_LITERAL_PROPERTY_NAME) != null) {
-      if (useSchemaURL(schemaURL)) {
+      if (schemaURL != null && useSchemaURL(schemaURL)) {
         table.getParameters().remove(AVRO_SCHEMA_LITERAL_PROPERTY_NAME);
         table.getParameters().put(AVRO_SCHEMA_URL_PROPERTY_NAME,
             schemaURL.toExternalForm());
@@ -327,7 +328,7 @@ class HiveUtils {
     } else {
       // neither the literal or the URL are set, so add the URL if specified
       // and the schema literal if not.
-      if (useSchemaURL(schemaURL)) {
+      if (schemaURL != null && useSchemaURL(schemaURL)) {
         table.getParameters().put(
                 AVRO_SCHEMA_URL_PROPERTY_NAME,
                 schemaURL.toExternalForm());
@@ -358,7 +359,7 @@ class HiveUtils {
         HiveSchemaConverter.convertSchema(descriptor.getSchema()));
   }
 
-  static FileSystem fsForPath(Configuration conf, Path path) {
+  private static FileSystem fsForPath(Configuration conf, Path path) {
     try {
       return path.getFileSystem(conf);
     } catch (IOException ex) {
@@ -478,7 +479,7 @@ class HiveUtils {
     }
   }
 
-  public static void addResource(Configuration hiveConf, Configuration conf) {
+  static void addResource(Configuration hiveConf, Configuration conf) {
     if (Hadoop.Configuration.addResource.isNoop()) {
       for (Map.Entry<String, String> entry : conf) {
         hiveConf.set(entry.getKey(), entry.getValue());

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
 
     <!-- Java versions -->
     <javaVersion>1.7</javaVersion>
-    <targetJavaVersion>1.6</targetJavaVersion>
+    <targetJavaVersion>1.7</targetJavaVersion>
     <Xdoclint /> <!-- set by the java8 profile to turn off doclint -->
 
     <!-- used by jdiff, semver rule -->
@@ -428,7 +428,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${vers.maven-compiler-plugin}</version>
           <configuration>
-            <source>1.6</source>
+            <source>${javaVersion}</source>
             <target>${targetJavaVersion}</target>
             <compilerArgs>
               <arg>-Xlint:unchecked</arg>


### PR DESCRIPTION
 * according to the readme default should be java 7 so might as well update the target version property
 * In top level pom.xml the maven compiler plugin to use the javaVersion property instead of the hard coded 1.6 value
 * Some warnings had to be fixed in HiveUtils, because of the -Werror (error on warnings) maven flag