### PR TITLE
KITE-1137 update javaVersion to 1.7 and fix warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ For Hadoop 1:
 mvn install -Dhadoop.profile=1
 ```
 
-By default Java 7 is used. If you want to use Java 6, then add `-DjavaVersion=1.6`, e.g.
+By default Java 7 is used. If you want to use Java 6, then add `-DjavaVersion=1.6`, `-DjavaTargetVersion=1.6` e.g.
 
 ```
-mvn install -DjavaVersion=1.6
+mvn install -DjavaVersion=1.6 -DjavaTargetVersion=1.6
 ```

--- a/kite-data/kite-data-hive/src/main/java/org/kitesdk/data/spi/hive/HiveUtils.java
+++ b/kite-data/kite-data-hive/src/main/java/org/kitesdk/data/spi/hive/HiveUtils.java
@@ -191,6 +191,7 @@ class HiveUtils {
    * Returns the first non-null value from the sequence or null if there is no
    * non-null value.
    */
+  @SafeVarargs
   private static <T> T coalesce(T... values) {
     for (T value : values) {
       if (value != null) {

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
 
     <!-- Java versions -->
     <javaVersion>1.7</javaVersion>
-    <targetJavaVersion>1.6</targetJavaVersion>
+    <targetJavaVersion>1.7</targetJavaVersion>
     <Xdoclint /> <!-- set by the java8 profile to turn off doclint -->
 
     <!-- used by jdiff, semver rule -->
@@ -428,7 +428,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${vers.maven-compiler-plugin}</version>
           <configuration>
-            <source>1.6</source>
+            <source>${javaVersion}</source>
             <target>${targetJavaVersion}</target>
             <compilerArgs>
               <arg>-Xlint:unchecked</arg>


### PR DESCRIPTION
 * according to the readme default should be java 7 so might as well update the target version property
 * In top level pom.xml the maven compiler plugin to use the javaVersion property instead of the hard coded 1.6 value
 * Some warnings had to be fixed in HiveUtils, because of the -Werror (error on warnings) maven flag