### PR TITLE
Add viewfs dataset

### DIFF
--- a/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/Loader.java
+++ b/kite-data/kite-data-core/src/main/java/org/kitesdk/data/spi/filesystem/Loader.java
@@ -110,6 +110,15 @@ public class Loader implements Loadable {
         builder);
 
     Registration.register(
+        new URIPattern("viewfs:/*path?absolute=true"),
+        new URIPattern("viewfs:/*path/:namespace/:dataset?absolute=true"),
+        builder);
+    Registration.register(
+        new URIPattern("viewfs:*path"),
+        new URIPattern("viewfs:*path/:namespace/:dataset"),
+        builder);
+
+    Registration.register(
         new URIPattern("webhdfs:/*path?absolute=true"),
         new URIPattern("webhdfs:/*path/:namespace/:dataset?absolute=true"),
         builder);


### PR DESCRIPTION
We are using sqoop which rely on kite and were facing issue after migrating to viewfs default scheme in our hadoop preprod cluster:
`17/09/07 13:13:25 ERROR sqoop.Sqoop: Got exception running Sqoop: org.kitesdk.data.DatasetNotFoundException: Unknown dataset URI pattern: dataset:viewfs://root/user/toto/metrics_backups/20170905/monitoring/io_usage
Check that JARs for viewfs datasets are on the classpath
org.kitesdk.data.DatasetNotFoundException: Unknown dataset URI pattern: dataset:viewfs://root/user/toto/metrics_backups/20170905/monitoring/io_usage
Check that JARs for viewfs datasets are on the classpath`

This patch solve this issue by just defining viewfs dataset URI pattern