### PR TITLE
Root temp directory path is now configurable in HiveAbstractDatasetRe…

### DIFF
--- a/kite-data/kite-data-hive/src/main/java/org/kitesdk/data/spi/hive/HiveAbstractDatasetRepository.java
+++ b/kite-data/kite-data-hive/src/main/java/org/kitesdk/data/spi/hive/HiveAbstractDatasetRepository.java
@@ -24,13 +24,24 @@ import org.apache.hadoop.fs.Path;
 import org.kitesdk.data.DatasetNotFoundException;
 import org.kitesdk.data.spi.filesystem.FileSystemDatasetRepository;
 import org.kitesdk.data.spi.MetadataProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class HiveAbstractDatasetRepository extends FileSystemDatasetRepository {
+
+  private static final Logger LOG = LoggerFactory
+      .getLogger(HiveAbstractDatasetRepository.class);
 
   private static final String HIVE_METASTORE_URIS_SEPARATOR = ",";
 
   private final MetadataProvider provider;
   private final URI repoUri;
+
+  private static Path getRootDirectory(Configuration conf) {
+    String pathString = conf.get("kite.hive.tmp.root", "/tmp");
+    LOG.info("Using root directory: " + pathString);
+    return new Path(pathString);
+  }
 
   /**
    * Create an HCatalog dataset repository with external tables.
@@ -48,7 +59,7 @@ class HiveAbstractDatasetRepository extends FileSystemDatasetRepository {
   HiveAbstractDatasetRepository(Configuration conf, MetadataProvider provider) {
     // Because the managed provider overrides dataset locations, the only time
     // the storage path is used is to create temporary dataset repositories
-    super(conf, new Path("/tmp"), provider);
+    super(conf, getRootDirectory(conf), provider);
     this.provider = provider;
     this.repoUri = getRepositoryUri(conf, null);
   }

--- a/kite-data/kite-data-hive/src/main/java/org/kitesdk/data/spi/hive/HiveAbstractDatasetRepository.java
+++ b/kite-data/kite-data-hive/src/main/java/org/kitesdk/data/spi/hive/HiveAbstractDatasetRepository.java
@@ -39,7 +39,7 @@ class HiveAbstractDatasetRepository extends FileSystemDatasetRepository {
 
   private static Path getRootDirectory(Configuration conf) {
     String pathString = conf.get("kite.hive.tmp.root", "/tmp");
-    LOG.info("Using root directory: " + pathString);
+    LOG.debug("Using root directory: " + pathString);
     return new Path(pathString);
   }
 


### PR DESCRIPTION
…pository

When importing data into Hive Kite creates a temporary directory in /tmp and if the import is successful it moves the data into the Hive warehouse.
However on a secure cluster if a /tmp and the Hive warehouse directories are in separate encryption zones this move fails because the 2 directories are encrypted with different keyes and the move operation is not supported.
This change introduces a configuration key which enables the users to set the path of the temporary directory.
